### PR TITLE
Allow on_close callbacks to interact with the network

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,21 +119,6 @@ sonarcloud_dependencies()
 load("@vaticle_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
-####################################
-# Load @com_google_protobuf #
-####################################
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "com_google_protobuf",
-    remote = "https://github.com/protocolbuffers/protobuf",
-    commit = "ab840345966d0fa8e7100d771c92a73bfbadd25c",
-)
-
-# Load protoc binary dependencies
-load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
-protobuf_deps()
-
 ######################################
 # Load @vaticle_bazel_distribution #
 ######################################
@@ -169,9 +154,9 @@ pip_parse(
 load("@vaticle_typedb_driver_pip//:requirements.bzl", "install_deps")
 install_deps()
 
-################################
+##############################
 # Load @vaticle dependencies #
-################################
+##############################
 
 # Load repositories
 load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common", "vaticle_typeql", "vaticle_typedb_behaviour", "vaticle_typedb_protocol")
@@ -258,9 +243,9 @@ maven(
     vaticle_typedb_driver_java_maven_overrides
 )
 
-############################################
+################################################
 # Create @vaticle_typedb_driver_workspace_refs #
-############################################
+################################################
 load("@vaticle_bazel_distribution//common:rules.bzl", "workspace_refs")
 workspace_refs(
     name = "vaticle_typedb_driver_workspace_refs"

--- a/c/src/concept/concept.rs
+++ b/c/src/concept/concept.rs
@@ -263,6 +263,7 @@ pub(super) fn borrow_as_thing_type(concept: *const Concept) -> &'static dyn Thin
         Concept::EntityType(entity_type) => entity_type,
         Concept::RelationType(relation_type) => relation_type,
         Concept::AttributeType(attribute_type) => attribute_type,
+        Concept::RootThingType(root_thing_type) => root_thing_type,
         _ => unreachable!(),
     }
 }
@@ -272,6 +273,7 @@ pub(super) fn borrow_as_thing_type_mut(concept: *mut Concept) -> &'static mut dy
         Concept::EntityType(entity_type) => entity_type,
         Concept::RelationType(relation_type) => relation_type,
         Concept::AttributeType(attribute_type) => attribute_type,
+        Concept::RootThingType(root_thing_type) => root_thing_type,
         _ => unreachable!(),
     }
 }

--- a/c/src/concept/type_.rs
+++ b/c/src/concept/type_.rs
@@ -218,7 +218,10 @@ pub extern "C" fn entity_type_get_supertype(
     transaction: *mut Transaction<'static>,
     entity_type: *const Concept,
 ) -> *mut Concept {
-    try_release(borrow_as_entity_type(entity_type).get_supertype(borrow(transaction)).map(Concept::EntityType))
+    try_release_map_optional(
+        borrow_as_entity_type(entity_type).get_supertype(borrow(transaction)).transpose(),
+        Concept::EntityType,
+    )
 }
 
 #[no_mangle]
@@ -282,7 +285,10 @@ pub extern "C" fn relation_type_get_supertype(
     transaction: *mut Transaction<'static>,
     relation_type: *const Concept,
 ) -> *mut Concept {
-    try_release(borrow_as_relation_type(relation_type).get_supertype(borrow(transaction)).map(Concept::RelationType))
+    try_release_map_optional(
+        borrow_as_relation_type(relation_type).get_supertype(borrow(transaction)).transpose(),
+        Concept::RelationType,
+    )
 }
 
 #[no_mangle]
@@ -437,7 +443,10 @@ pub extern "C" fn attribute_type_get_supertype(
     transaction: *mut Transaction<'static>,
     attribute_type: *const Concept,
 ) -> *mut Concept {
-    try_release(borrow_as_attribute_type(attribute_type).get_supertype(borrow(transaction)).map(Concept::AttributeType))
+    try_release_map_optional(
+        borrow_as_attribute_type(attribute_type).get_supertype(borrow(transaction)).transpose(),
+        Concept::AttributeType,
+    )
 }
 
 #[no_mangle]
@@ -599,7 +608,10 @@ pub extern "C" fn role_type_get_supertype(
     transaction: *mut Transaction<'static>,
     role_type: *const Concept,
 ) -> *mut Concept {
-    try_release(borrow_as_role_type(role_type).get_supertype(borrow(transaction)).map(Concept::RoleType))
+    try_release_map_optional(
+        borrow_as_role_type(role_type).get_supertype(borrow(transaction)).transpose(),
+        Concept::RoleType,
+    )
 }
 
 #[no_mangle]

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "de6d94311a319a438a9a417a5384033852d2293b",
+        commit = "23ab120977c42d8e793841d99adc649847456eb5",
     )
 
 def vaticle_typedb_enterprise_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "785acd5463bb54c35cd45a68d20877b9a72cfc7c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "fe5fdc2d18ba4558826459188351d2162847a5d0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "fe5fdc2d18ba4558826459188351d2162847a5d0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "56b33e3483731b043498c6f28fcb77cb97d41874", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():

--- a/java/BUILD
+++ b/java/BUILD
@@ -55,9 +55,9 @@ assemble_maven(
     workspace_refs = "@vaticle_typedb_driver_workspace_refs//:refs.json",
     platform_overrides = {
         ":typedb_driver_jni": json.encode([
-           "com.vaticle.typedb:typedb-driver-jni-linux-aarch64:{pom_version}",
+           "com.vaticle.typedb:typedb-driver-jni-linux-arm64:{pom_version}",
            "com.vaticle.typedb:typedb-driver-jni-linux-x86_64:{pom_version}",
-           "com.vaticle.typedb:typedb-driver-jni-macosx-aarch64:{pom_version}",
+           "com.vaticle.typedb:typedb-driver-jni-macosx-arm64:{pom_version}",
            "com.vaticle.typedb:typedb-driver-jni-macosx-x86_64:{pom_version}",
            "com.vaticle.typedb:typedb-driver-jni-windows-x86_64:{pom_version}",
         ])
@@ -80,9 +80,9 @@ swig_native_java_library(
     enable_cxx = True,
     maven_coordinates = "com.vaticle.typedb:typedb-driver-jni-{platform}:{pom_version}",
     platforms = {
-        "@vaticle_dependencies//util/platform:is_linux_aarch64": "linux-aarch64",
+        "@vaticle_dependencies//util/platform:is_linux_arm64": "linux-arm64",
         "@vaticle_dependencies//util/platform:is_linux_x86_64": "linux-x86_64",
-        "@vaticle_dependencies//util/platform:is_mac_aarch64": "macosx-aarch64",
+        "@vaticle_dependencies//util/platform:is_mac_arm64": "macosx-arm64",
         "@vaticle_dependencies//util/platform:is_mac_x86_64": "macosx-x86_64",
         "@vaticle_dependencies//util/platform:is_win_x86_64": "windows-x86_64",
     },

--- a/java/common/Loader.java
+++ b/java/common/Loader.java
@@ -49,9 +49,9 @@ public class Loader {
     private static final Map<Pair<OS, Arch>, String> DRIVER_JNI_JAR_NAME = Map.of(
             new Pair<>(OS.WINDOWS, Arch.x86_64), "windows-x86_64",
             new Pair<>(OS.MAC, Arch.x86_64), "macosx-x86_64",
-            new Pair<>(OS.MAC, Arch.AARCH64), "macosx-arm64",
+            new Pair<>(OS.MAC, Arch.ARM64), "macosx-arm64",
             new Pair<>(OS.LINUX, Arch.x86_64), "linux-x86_64",
-            new Pair<>(OS.LINUX, Arch.AARCH64), "linux-arm64"
+            new Pair<>(OS.LINUX, Arch.ARM64), "linux-arm64"
     );
 
     private static boolean loaded = false;
@@ -121,7 +121,7 @@ public class Loader {
     }
 
     private enum Arch {
-        AARCH64, x86_64;
+        ARM64, x86_64;
 
         static Arch detect() {
             String arch = System.getProperty("os.arch").toLowerCase();
@@ -129,7 +129,7 @@ public class Loader {
             if (arch.equals("amd64") || arch.equals("x86_64") || arch.contains("x64")) {
                 return x86_64;
             } else if (arch.equals("aarch64") || arch.contains("arm64")) {
-                return AARCH64;
+                return ARM64;
             } else {
                 throw new TypeDBDriverException(UNRECOGNISED_ARCH, arch);
             }

--- a/java/common/Loader.java
+++ b/java/common/Loader.java
@@ -49,9 +49,9 @@ public class Loader {
     private static final Map<Pair<OS, Arch>, String> DRIVER_JNI_JAR_NAME = Map.of(
             new Pair<>(OS.WINDOWS, Arch.x86_64), "windows-x86_64",
             new Pair<>(OS.MAC, Arch.x86_64), "macosx-x86_64",
-            new Pair<>(OS.MAC, Arch.AARCH64), "macosx-aarch64",
+            new Pair<>(OS.MAC, Arch.AARCH64), "macosx-arm64",
             new Pair<>(OS.LINUX, Arch.x86_64), "linux-x86_64",
-            new Pair<>(OS.LINUX, Arch.AARCH64), "linux-aarch64"
+            new Pair<>(OS.LINUX, Arch.AARCH64), "linux-arm64"
     );
 
     private static boolean loaded = false;

--- a/java/connection/TypeDBTransactionImpl.java
+++ b/java/connection/TypeDBTransactionImpl.java
@@ -137,7 +137,7 @@ public class TypeDBTransactionImpl extends NativeObject<com.vaticle.typedb.drive
     @Override
     public void close() {
         if (nativeObject.isOwned()) {
-            transaction_force_close(nativeObject.released());
+            transaction_force_close(nativeObject);
             callbacks.clear();
         }
     }

--- a/java/connection/TypeDBTransactionImpl.java
+++ b/java/connection/TypeDBTransactionImpl.java
@@ -32,6 +32,8 @@ import com.vaticle.typedb.driver.concept.ConceptManagerImpl;
 import com.vaticle.typedb.driver.logic.LogicManagerImpl;
 import com.vaticle.typedb.driver.query.QueryManagerImpl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static com.vaticle.typedb.driver.common.exception.ErrorMessage.Driver.TRANSACTION_CLOSED;
@@ -50,6 +52,8 @@ public class TypeDBTransactionImpl extends NativeObject<com.vaticle.typedb.drive
     private final LogicManager logicManager;
     private final QueryManager queryManager;
 
+    private final List<TransactionOnClose> callbacks;
+
     TypeDBTransactionImpl(TypeDBSessionImpl session, Type type, TypeDBOptions options) {
         super(newNative(session, type, options));
         this.type = type;
@@ -58,6 +62,8 @@ public class TypeDBTransactionImpl extends NativeObject<com.vaticle.typedb.drive
         conceptManager = new ConceptManagerImpl(nativeObject);
         logicManager = new LogicManagerImpl(nativeObject);
         queryManager = new QueryManagerImpl(nativeObject);
+
+        callbacks = new ArrayList<>();
     }
 
     private static com.vaticle.typedb.driver.jni.Transaction newNative(TypeDBSessionImpl session, Type type, TypeDBOptions options) {
@@ -102,7 +108,9 @@ public class TypeDBTransactionImpl extends NativeObject<com.vaticle.typedb.drive
     @Override
     public void onClose(Consumer<Throwable> function) {
         if (!nativeObject.isOwned()) throw new TypeDBDriverException(TRANSACTION_CLOSED);
-        transaction_on_close(nativeObject, new TransactionOnClose(function).released());
+        TransactionOnClose callback = new TransactionOnClose(function);
+        callbacks.add(callback);
+        transaction_on_close(nativeObject, callback.released());
     }
 
     @Override
@@ -129,7 +137,8 @@ public class TypeDBTransactionImpl extends NativeObject<com.vaticle.typedb.drive
     @Override
     public void close() {
         if (nativeObject.isOwned()) {
-            transaction_force_close(nativeObject);
+            transaction_force_close(nativeObject.released());
+            callbacks.clear();
         }
     }
 

--- a/python/rules.bzl
+++ b/python/rules.bzl
@@ -96,9 +96,9 @@ def native_driver_versioned(python_versions):
             release = deployment["pypi.release"],
             suffix = version["suffix"],
             distribution_tag = select({
-                "@vaticle_dependencies//util/platform:is_mac_aarch64": "py" + version["suffix"] + "-none-macosx_11_0_arm64",
+                "@vaticle_dependencies//util/platform:is_mac_arm64": "py" + version["suffix"] + "-none-macosx_11_0_arm64",
                 "@vaticle_dependencies//util/platform:is_mac_x86_64": "py" + version["suffix"] + "-none-macosx_11_0_x86_64",
-                "@vaticle_dependencies//util/platform:is_linux_aarch64": "py" + version["suffix"] + "-none-linux_aarch64",
+                "@vaticle_dependencies//util/platform:is_linux_arm64": "py" + version["suffix"] + "-none-linux_arm64",
                 "@vaticle_dependencies//util/platform:is_linux_x86_64": "py" + version["suffix"] + "-none-linux_x86_64",
                 "@vaticle_dependencies//util/platform:is_windows": "py" + version["suffix"] + "-none-win_amd64",
             }),

--- a/rust/src/common/info.rs
+++ b/rust/src/common/info.rs
@@ -24,13 +24,14 @@ use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::{address::Address, SessionID};
+use crate::common::Callback;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SessionInfo {
     pub(crate) address: Address,
     pub(crate) session_id: SessionID,
     pub(crate) network_latency: Duration,
-    pub(crate) on_close_register_sink: UnboundedSender<Box<dyn FnOnce() + Send>>,
+    pub(crate) on_close_register_sink: UnboundedSender<Callback>,
 }
 
 #[derive(Debug)]

--- a/rust/src/common/mod.rs
+++ b/rust/src/common/mod.rs
@@ -36,6 +36,8 @@ pub use self::{
     stream::{box_stream, BoxStream},
 };
 
+pub(crate) type Callback = Box<dyn FnOnce() + Send>;
+
 pub(crate) type StdResult<T, E> = std::result::Result<T, E>;
 pub type Result<T = ()> = StdResult<T, Error>;
 

--- a/rust/src/connection/connection.rs
+++ b/rust/src/connection/connection.rs
@@ -47,7 +47,7 @@ use crate::{
         address::Address,
         error::{ConnectionError, Error},
         info::{DatabaseInfo, SessionInfo},
-        Result, SessionID, SessionType, TransactionType,
+        Callback, Result, SessionID, SessionType, TransactionType,
     },
     connection::message::{Request, Response, TransactionRequest},
     error::InternalError,
@@ -59,7 +59,6 @@ use crate::{
 pub struct Connection {
     server_connections: HashMap<Address, ServerConnection>,
     background_runtime: Arc<BackgroundRuntime>,
-
     username: Option<String>,
 }
 
@@ -451,8 +450,8 @@ impl fmt::Debug for ServerConnection {
 async fn session_pulse(
     session_id: SessionID,
     request_transmitter: Arc<RPCTransmitter>,
-    mut on_close_callback_source: UnboundedReceiver<Box<dyn FnOnce() + Send>>,
-    callback_handler_sink: Sender<(Box<dyn FnOnce() + Send>, AsyncOneshotSender<()>)>,
+    mut on_close_callback_source: UnboundedReceiver<Callback>,
+    callback_handler_sink: Sender<(Callback, AsyncOneshotSender<()>)>,
     mut shutdown_source: UnboundedReceiver<()>,
 ) {
     const PULSE_INTERVAL: Duration = Duration::from_secs(5);

--- a/rust/src/connection/message.rs
+++ b/rust/src/connection/message.rs
@@ -401,14 +401,14 @@ pub(super) enum ThingTypeResponse {
     ThingTypeGetSyntax { syntax: String },
 
     EntityTypeCreate { entity: Entity },
-    EntityTypeGetSupertype { entity_type: EntityType },
+    EntityTypeGetSupertype { entity_type: Option<EntityType> },
     EntityTypeSetSupertype,
     EntityTypeGetSupertypes { entity_types: Vec<EntityType> },
     EntityTypeGetSubtypes { entity_types: Vec<EntityType> },
     EntityTypeGetInstances { entities: Vec<Entity> },
 
     RelationTypeCreate { relation: Relation },
-    RelationTypeGetSupertype { relation_type: RelationType },
+    RelationTypeGetSupertype { relation_type: Option<RelationType> },
     RelationTypeSetSupertype,
     RelationTypeGetSupertypes { relation_types: Vec<RelationType> },
     RelationTypeGetSubtypes { relation_types: Vec<RelationType> },
@@ -421,7 +421,7 @@ pub(super) enum ThingTypeResponse {
 
     AttributeTypePut { attribute: Attribute },
     AttributeTypeGet { attribute: Option<Attribute> },
-    AttributeTypeGetSupertype { attribute_type: AttributeType },
+    AttributeTypeGetSupertype { attribute_type: Option<AttributeType> },
     AttributeTypeSetSupertype,
     AttributeTypeGetSupertypes { attribute_types: Vec<AttributeType> },
     AttributeTypeGetSubtypes { attribute_types: Vec<AttributeType> },
@@ -448,7 +448,7 @@ pub(super) enum RoleTypeRequest {
 pub(super) enum RoleTypeResponse {
     Delete,
     SetLabel,
-    GetSupertype { role_type: RoleType },
+    GetSupertype { role_type: Option<RoleType> },
     GetSupertypes { role_types: Vec<RoleType> },
     GetSubtypes { role_types: Vec<RoleType> },
     GetRelationTypes { relation_types: Vec<RelationType> },

--- a/rust/src/connection/network/proto/message.rs
+++ b/rust/src/connection/network/proto/message.rs
@@ -884,11 +884,7 @@ impl TryFromProto<thing_type::Res> for ThingTypeResponse {
                 })
             }
             Some(thing_type::res::Res::EntityTypeGetSupertypeRes(entity_type::get_supertype::Res { entity_type })) => {
-                Ok(Self::EntityTypeGetSupertype {
-                    entity_type: EntityType::from_proto(
-                        entity_type.ok_or(ConnectionError::MissingResponseField("entity_type"))?,
-                    ),
-                })
+                Ok(Self::EntityTypeGetSupertype { entity_type: entity_type.map(EntityType::from_proto) })
             }
             Some(thing_type::res::Res::EntityTypeSetSupertypeRes(_)) => Ok(Self::EntityTypeSetSupertype),
             Some(thing_type::res::Res::RelationTypeCreateRes(relation_type::create::Res { relation })) => {
@@ -900,11 +896,7 @@ impl TryFromProto<thing_type::Res> for ThingTypeResponse {
             }
             Some(thing_type::res::Res::RelationTypeGetSupertypeRes(relation_type::get_supertype::Res {
                 relation_type,
-            })) => Ok(Self::RelationTypeGetSupertype {
-                relation_type: RelationType::from_proto(
-                    relation_type.ok_or(ConnectionError::MissingResponseField("relation_type"))?,
-                ),
-            }),
+            })) => Ok(Self::RelationTypeGetSupertype { relation_type: relation_type.map(RelationType::from_proto) }),
             Some(thing_type::res::Res::RelationTypeSetSupertypeRes(_)) => Ok(Self::RelationTypeSetSupertype),
             Some(thing_type::res::Res::RelationTypeGetRelatesForRoleLabelRes(
                 relation_type::get_relates_for_role_label::Res { role_type },
@@ -927,9 +919,7 @@ impl TryFromProto<thing_type::Res> for ThingTypeResponse {
             Some(thing_type::res::Res::AttributeTypeGetSupertypeRes(attribute_type::get_supertype::Res {
                 attribute_type,
             })) => Ok(Self::AttributeTypeGetSupertype {
-                attribute_type: AttributeType::try_from_proto(
-                    attribute_type.ok_or(ConnectionError::MissingResponseField("attribute_type"))?,
-                )?,
+                attribute_type: attribute_type.map(AttributeType::try_from_proto).transpose()?,
             }),
             Some(thing_type::res::Res::AttributeTypeSetSupertypeRes(_)) => Ok(Self::AttributeTypeSetSupertype),
             Some(thing_type::res::Res::AttributeTypeGetRegexRes(attribute_type::get_regex::Res { regex })) => {
@@ -1075,11 +1065,7 @@ impl TryFromProto<role_type::Res> for RoleTypeResponse {
             Some(role_type::res::Res::RoleTypeDeleteRes(_)) => Ok(Self::Delete),
             Some(role_type::res::Res::RoleTypeSetLabelRes(_)) => Ok(Self::SetLabel),
             Some(role_type::res::Res::RoleTypeGetSupertypeRes(role_type::get_supertype::Res { role_type })) => {
-                Ok(Self::GetSupertype {
-                    role_type: RoleType::from_proto(
-                        role_type.ok_or(ConnectionError::MissingResponseField("role_type"))?,
-                    ),
-                })
+                Ok(Self::GetSupertype { role_type: role_type.map(RoleType::from_proto) })
             }
             None => Err(ConnectionError::MissingResponseField("res").into()),
         }

--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -53,7 +53,7 @@ use crate::{
     common::{
         error::ConnectionError,
         stream::{NetworkStream, Stream},
-        RequestID, Result,
+        Callback, RequestID, Result,
     },
     connection::{
         message::{TransactionRequest, TransactionResponse},
@@ -81,7 +81,7 @@ impl TransactionTransmitter {
         background_runtime: &BackgroundRuntime,
         request_sink: UnboundedSender<transaction::Client>,
         response_source: Streaming<transaction::Server>,
-        callback_handler_sink: Sender<(Box<dyn FnOnce() + Send>, AsyncOneshotSender<()>)>,
+        callback_handler_sink: Sender<(Callback, AsyncOneshotSender<()>)>,
     ) -> Self {
         let (buffer_sink, buffer_source) = unbounded_async();
         let (on_close_register_sink, on_close_register_source) = unbounded_async();
@@ -167,7 +167,7 @@ impl TransactionTransmitter {
         is_open: Arc<AtomicCell<bool>>,
         error: Arc<RwLock<Option<ConnectionError>>>,
         on_close_callback_source: UnboundedReceiver<Box<dyn FnOnce(ConnectionError) + Send + Sync>>,
-        callback_handler_sink: Sender<(Box<dyn FnOnce() + Send>, AsyncOneshotSender<()>)>,
+        callback_handler_sink: Sender<(Callback, AsyncOneshotSender<()>)>,
         shutdown_sink: UnboundedSender<()>,
         shutdown_signal: UnboundedReceiver<()>,
     ) {
@@ -289,7 +289,7 @@ struct ResponseCollector {
     is_open: Arc<AtomicCell<bool>>,
     error: Arc<RwLock<Option<ConnectionError>>>,
     on_close: Arc<RwLock<Vec<Box<dyn FnOnce(ConnectionError) + Send + Sync>>>>,
-    callback_handler_sink: Sender<(Box<dyn FnOnce() + Send>, AsyncOneshotSender<()>)>,
+    callback_handler_sink: Sender<(Callback, AsyncOneshotSender<()>)>,
 }
 
 impl ResponseCollector {

--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -25,7 +25,7 @@ use std::{
     time::Duration,
 };
 
-use crossbeam::atomic::AtomicCell;
+use crossbeam::{atomic::AtomicCell, channel::Sender};
 use futures::StreamExt;
 #[cfg(not(feature = "sync"))]
 use futures::TryStreamExt;
@@ -37,7 +37,10 @@ use prost::Message;
 use tokio::sync::oneshot::channel as oneshot;
 use tokio::{
     select,
-    sync::mpsc::{error::SendError, unbounded_channel as unbounded_async, UnboundedReceiver, UnboundedSender},
+    sync::{
+        mpsc::{error::SendError, unbounded_channel as unbounded_async, UnboundedReceiver, UnboundedSender},
+        oneshot::{channel as oneshot_async, Sender as AsyncOneshotSender},
+    },
     time::{sleep_until, Instant},
 };
 use tonic::Streaming;
@@ -78,6 +81,7 @@ impl TransactionTransmitter {
         background_runtime: &BackgroundRuntime,
         request_sink: UnboundedSender<transaction::Client>,
         response_source: Streaming<transaction::Server>,
+        callback_handler_sink: Sender<(Box<dyn FnOnce() + Send>, AsyncOneshotSender<()>)>,
     ) -> Self {
         let (buffer_sink, buffer_source) = unbounded_async();
         let (on_close_register_sink, on_close_register_source) = unbounded_async();
@@ -92,6 +96,7 @@ impl TransactionTransmitter {
             is_open.clone(),
             error.clone(),
             on_close_register_source,
+            callback_handler_sink,
             shutdown_sink.clone(),
             shutdown_source,
         ));
@@ -162,6 +167,7 @@ impl TransactionTransmitter {
         is_open: Arc<AtomicCell<bool>>,
         error: Arc<RwLock<Option<ConnectionError>>>,
         on_close_callback_source: UnboundedReceiver<Box<dyn FnOnce(ConnectionError) + Send + Sync>>,
+        callback_handler_sink: Sender<(Box<dyn FnOnce() + Send>, AsyncOneshotSender<()>)>,
         shutdown_sink: UnboundedSender<()>,
         shutdown_signal: UnboundedReceiver<()>,
     ) {
@@ -171,6 +177,7 @@ impl TransactionTransmitter {
             is_open,
             error,
             on_close: Default::default(),
+            callback_handler_sink,
         };
         tokio::spawn(Self::dispatch_loop(
             queue_source,
@@ -282,6 +289,7 @@ struct ResponseCollector {
     is_open: Arc<AtomicCell<bool>>,
     error: Arc<RwLock<Option<ConnectionError>>>,
     on_close: Arc<RwLock<Vec<Box<dyn FnOnce(ConnectionError) + Send + Sync>>>>,
+    callback_handler_sink: Sender<(Box<dyn FnOnce() + Send>, AsyncOneshotSender<()>)>,
 }
 
 impl ResponseCollector {
@@ -344,8 +352,12 @@ impl ResponseCollector {
         for (_, listener) in listeners.drain() {
             listener.error(error.clone());
         }
-        for callback in self.on_close.write().unwrap().drain(..) {
-            callback(error.clone());
+        let callbacks = std::mem::take(&mut *self.on_close.write().unwrap());
+        for callback in callbacks {
+            let error = error.clone();
+            let (response_sink, response) = oneshot_async();
+            self.callback_handler_sink.send((Box::new(move || callback(error)), response_sink)).unwrap();
+            response.await.ok();
         }
     }
 }

--- a/rust/src/connection/runtime.rs
+++ b/rust/src/connection/runtime.rs
@@ -115,7 +115,7 @@ impl Drop for BackgroundRuntime {
         self.is_open.store(false);
         self.shutdown_sink.send(()).ok();
         if let Err(err) = self.callback_handler.take().unwrap().join() {
-			error!("Error shutting down the callback handler thread: {:?}", err);
-		}
+            error!("Error shutting down the callback handler thread: {:?}", err);
+        }
     }
 }

--- a/rust/src/connection/transaction_stream.rs
+++ b/rust/src/connection/transaction_stream.rs
@@ -489,7 +489,10 @@ impl TransactionStream {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn relation_type_get_supertype(&self, relation_type: RelationType) -> Result<Option<RelationType>> {
+    pub(crate) async fn relation_type_get_supertype(
+        &self,
+        relation_type: RelationType,
+    ) -> Result<Option<RelationType>> {
         match self.thing_type_single(ThingTypeRequest::RelationTypeGetSupertype { relation_type }).await? {
             ThingTypeResponse::RelationTypeGetSupertype { relation_type } => Ok(relation_type),
             other => Err(InternalError::UnexpectedResponseType(format!("{other:?}")).into()),
@@ -648,7 +651,10 @@ impl TransactionStream {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn attribute_type_get_supertype(&self, attribute_type: AttributeType) -> Result<Option<AttributeType>> {
+    pub(crate) async fn attribute_type_get_supertype(
+        &self,
+        attribute_type: AttributeType,
+    ) -> Result<Option<AttributeType>> {
         match self.thing_type_single(ThingTypeRequest::AttributeTypeGetSupertype { attribute_type }).await? {
             ThingTypeResponse::AttributeTypeGetSupertype { attribute_type } => Ok(attribute_type),
             other => Err(InternalError::UnexpectedResponseType(format!("{other:?}")).into()),

--- a/rust/src/connection/transaction_stream.rs
+++ b/rust/src/connection/transaction_stream.rs
@@ -423,7 +423,7 @@ impl TransactionStream {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn entity_type_get_supertype(&self, entity_type: EntityType) -> Result<EntityType> {
+    pub(crate) async fn entity_type_get_supertype(&self, entity_type: EntityType) -> Result<Option<EntityType>> {
         match self.thing_type_single(ThingTypeRequest::EntityTypeGetSupertype { entity_type }).await? {
             ThingTypeResponse::EntityTypeGetSupertype { entity_type } => Ok(entity_type),
             other => Err(InternalError::UnexpectedResponseType(format!("{other:?}")).into()),
@@ -489,7 +489,7 @@ impl TransactionStream {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn relation_type_get_supertype(&self, relation_type: RelationType) -> Result<RelationType> {
+    pub(crate) async fn relation_type_get_supertype(&self, relation_type: RelationType) -> Result<Option<RelationType>> {
         match self.thing_type_single(ThingTypeRequest::RelationTypeGetSupertype { relation_type }).await? {
             ThingTypeResponse::RelationTypeGetSupertype { relation_type } => Ok(relation_type),
             other => Err(InternalError::UnexpectedResponseType(format!("{other:?}")).into()),
@@ -648,7 +648,7 @@ impl TransactionStream {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn attribute_type_get_supertype(&self, attribute_type: AttributeType) -> Result<AttributeType> {
+    pub(crate) async fn attribute_type_get_supertype(&self, attribute_type: AttributeType) -> Result<Option<AttributeType>> {
         match self.thing_type_single(ThingTypeRequest::AttributeTypeGetSupertype { attribute_type }).await? {
             ThingTypeResponse::AttributeTypeGetSupertype { attribute_type } => Ok(attribute_type),
             other => Err(InternalError::UnexpectedResponseType(format!("{other:?}")).into()),
@@ -774,7 +774,7 @@ impl TransactionStream {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn role_type_get_supertype(&self, role_type: RoleType) -> Result<RoleType> {
+    pub(crate) async fn role_type_get_supertype(&self, role_type: RoleType) -> Result<Option<RoleType>> {
         match self.role_type_single(RoleTypeRequest::GetSupertype { role_type }).await? {
             RoleTypeResponse::GetSupertype { role_type } => Ok(role_type),
             other => Err(InternalError::UnexpectedResponseType(format!("{other:?}")).into()),

--- a/rust/src/transaction/concept/api/type_.rs
+++ b/rust/src/transaction/concept/api/type_.rs
@@ -221,7 +221,7 @@ pub trait EntityTypeAPI: ThingTypeAPI + Clone + Into<EntityType> {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<EntityType> {
+    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<Option<EntityType>> {
         transaction.concept().transaction_stream.entity_type_get_supertype(self.clone().into()).await
     }
 
@@ -299,7 +299,7 @@ pub trait RelationTypeAPI: ThingTypeAPI + Clone + Into<RelationType> {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<RelationType> {
+    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<Option<RelationType>> {
         transaction.concept().transaction_stream.relation_type_get_supertype(self.clone().into()).await
     }
 
@@ -441,7 +441,7 @@ pub trait AttributeTypeAPI: ThingTypeAPI + Clone + Into<AttributeType> {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<AttributeType> {
+    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<Option<AttributeType>> {
         transaction.concept().transaction_stream.attribute_type_get_supertype(self.clone().into()).await
     }
 
@@ -555,7 +555,7 @@ pub trait RoleTypeAPI: Clone + Into<RoleType> + Sync + Send {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<RoleType> {
+    async fn get_supertype(&self, transaction: &Transaction<'_>) -> Result<Option<RoleType>> {
         transaction.concept().transaction_stream.role_type_get_supertype(self.clone().into()).await
     }
 

--- a/rust/tests/behaviour/concept/type_/attributetype/steps.rs
+++ b/rust/tests/behaviour/concept/type_/attributetype/steps.rs
@@ -141,7 +141,7 @@ generic_step_impl! {
         supertype: LabelParam,
     ) -> TypeDBResult {
         let tx = context.transaction();
-        assert_eq!(context.get_attribute_type(type_label.name).await?.get_supertype(tx).await?.label, supertype.name);
+        assert_eq!(context.get_attribute_type(type_label.name).await?.get_supertype(tx).await?.map(|st| st.label), Some(supertype.name));
         Ok(())
     }
 
@@ -485,7 +485,7 @@ generic_step_impl! {
     ) -> TypeDBResult {
         let tx = context.transaction();
         let supertype = context.get_attribute_type(type_label.name).await?.get_supertype(tx).await?;
-        assert_eq!(supertype.value_type, value_type.value_type);
+        assert_eq!(supertype.map(|st| st.value_type), Some(value_type.value_type));
         Ok(())
     }
 

--- a/rust/tests/behaviour/concept/type_/entitytype/steps.rs
+++ b/rust/tests/behaviour/concept/type_/entitytype/steps.rs
@@ -137,7 +137,7 @@ generic_step_impl! {
         supertype: LabelParam,
     ) -> TypeDBResult {
         let tx = context.transaction();
-        assert_eq!(context.get_entity_type(type_label.name).await?.get_supertype(tx).await?.label, supertype.name);
+        assert_eq!(context.get_entity_type(type_label.name).await?.get_supertype(tx).await?.map(|st| st.label), Some(supertype.name));
         Ok(())
     }
 

--- a/rust/tests/behaviour/concept/type_/relationtype/steps.rs
+++ b/rust/tests/behaviour/concept/type_/relationtype/steps.rs
@@ -141,7 +141,7 @@ generic_step_impl! {
         supertype: LabelParam,
     ) -> TypeDBResult {
         let tx = context.transaction();
-        assert_eq!(context.get_relation_type(type_label.name).await?.get_supertype(tx).await?.label, supertype.name);
+        assert_eq!(context.get_relation_type(type_label.name).await?.get_supertype(tx).await?.map(|st| st.label), Some(supertype.name));
         Ok(())
     }
 
@@ -524,7 +524,7 @@ generic_step_impl! {
         let tx = context.transaction();
         let relation_type = context.get_relation_type(type_label.name).await?;
         let role_type = relation_type.get_relates_for_role_label(tx, role_name.name).await?.unwrap();
-        assert_eq!(role_type.get_supertype(tx).await?.label, supertype.label);
+        assert_eq!(role_type.get_supertype(tx).await?.map(|st| st.label), Some(supertype.label));
         Ok(())
     }
 

--- a/rust/tests/integration/queries.rs
+++ b/rust/tests/integration/queries.rs
@@ -106,6 +106,23 @@ test_for_each_arg! {
         Ok(())
     }
 
+    async fn networking_in_on_close(connection: Connection) -> typedb_driver::Result {
+        common::create_test_database_with_schema(connection.clone(), "define person sub entity;").await?;
+        let databases = DatabaseManager::new(connection);
+        assert!(databases.contains(common::TEST_DATABASE).await?);
+
+        let session = Arc::new(Session::new(databases.get(common::TEST_DATABASE).await?, Data).await?);
+        let transaction = session.transaction(Read).await?;
+
+		transaction.on_close({
+			let session = session.clone();
+			move |_| { session.force_close().ok(); }
+		});
+		transaction.force_close();
+
+        Ok(())
+    }
+
     async fn query_options(connection: Connection) -> typedb_driver::Result {
         let schema = r#"define
             person sub entity,

--- a/rust/tests/integration/queries.rs
+++ b/rust/tests/integration/queries.rs
@@ -114,11 +114,11 @@ test_for_each_arg! {
         let session = Arc::new(Session::new(databases.get(common::TEST_DATABASE).await?, Data).await?);
         let transaction = session.transaction(Read).await?;
 
-		transaction.on_close({
-			let session = session.clone();
-			move |_| { session.force_close().ok(); }
-		});
-		transaction.force_close();
+        transaction.on_close({
+            let session = session.clone();
+            move |_| { session.force_close().ok(); }
+        });
+        transaction.force_close();
 
         Ok(())
     }


### PR DESCRIPTION
## What is the goal of this PR?

Previously, if the user were to submit a `transaction.on_close()` callback that attempted to perform a network request (e.g., open a new transaction on failure), the networking thread would deadlock: the transactiopn stream would block the async runtime waiting for the request to resolve by that same runtime.

As a solution, we introduce a worker thread that can handle the blocking callbacks, and await on them asynchronously. This way, `on_close()` will still not progress until the callbacks resolve, but will now be able to yield to the other tasks running on the async runtime. 

## What are the changes implemented in this PR?

- callbacks are persisted s.t. they are not garbage collected before being executed;
- callbacks are executed in a non-blocking fashion so that they cannot block the networking thread;
- drive-by: getSupertype() now returns an optional since the root types have no supertype.
