### PR TITLE
Split rust behaviour typeql write and fix Java Relation API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ commands:
           $TYPEDB_DIST_DIR/typedb server &
           PID=$!
           
-          sed -i -e "s/CLIENT_JAVA_VERSION_MARKER/$CIRCLE_SHA1/g" java/test/deployment/pom.xml
+          sed -i -e "s/DRIVER_JAVA_VERSION_MARKER/$CIRCLE_SHA1/g" java/test/deployment/pom.xml
           cat java/test/deployment/pom.xml
           cd java/test/deployment && mvn test
           kill $PID

--- a/.circleci/windows/java/test_deploy_snapshot.bat
+++ b/.circleci/windows/java/test_deploy_snapshot.bat
@@ -29,7 +29,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
 START /B "" typedb-server-windows\typedb server
 
-powershell -Command "(gc java\test\deployment\pom.xml) -replace 'CLIENT_JAVA_VERSION_MARKER', '%CIRCLE_SHA1%' | Out-File -encoding ASCII java\test\deployment\pom.xml"
+powershell -Command "(gc java\test\deployment\pom.xml) -replace 'DRIVER_JAVA_VERSION_MARKER', '%CIRCLE_SHA1%' | Out-File -encoding ASCII java\test\deployment\pom.xml"
 type java\test\deployment\pom.xml
 cd java\test\deployment
 CALL mvn test

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -150,9 +150,9 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
         bazel test //rust/tests --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=behaviour::typeql::match_ \
-          --test_arg=behaviour::typeql::get \
-          --test_arg=behaviour::typeql::expression \
+          --test_arg=behaviour::typeql::language::match_ \
+          --test_arg=behaviour::typeql::language::get \
+          --test_arg=behaviour::typeql::language::expression \
           --test_output=streamed && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -169,12 +169,12 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
         bazel test //rust/tests --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=behaviour::typeql::define \
-          --test_arg=behaviour::typeql::undefine \
-          --test_arg=behaviour::typeql::insert \
-          --test_arg=behaviour::typeql::delete \
-          --test_arg=behaviour::typeql::update \
-          --test_arg=behaviour::typeql::rule_validation \
+          --test_arg=behaviour::typeql::language::define \
+          --test_arg=behaviour::typeql::language::undefine \
+          --test_arg=behaviour::typeql::language::insert \
+          --test_arg=behaviour::typeql::language::delete \
+          --test_arg=behaviour::typeql::language::update \
+          --test_arg=behaviour::typeql::language::rule_validation \
           --test_output=streamed && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -138,7 +138,7 @@ build:
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
 
-    test-rust-behaviour-typeql:
+    test-rust-behaviour-typeql-read:
       machine: 8-core-32-gb
       image: vaticle-ubuntu-22.04
       dependencies:
@@ -149,7 +149,33 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        bazel test //rust/tests --test_env=ROOT_CA=$ROOT_CA --test_arg=-- --test_arg=behaviour::typeql --test_output=streamed && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        bazel test //rust/tests --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+          --test_arg=behaviour::typeql::match_ \
+          --test_arg=behaviour::typeql::get \
+          --test_arg=behaviour::typeql::expression \
+          --test_output=streamed && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-enterprise-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-typeql-write:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
+        bazel test //rust/tests --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+          --test_arg=behaviour::typeql::define \
+          --test_arg=behaviour::typeql::undefine \
+          --test_arg=behaviour::typeql::insert \
+          --test_arg=behaviour::typeql::delete \
+          --test_arg=behaviour::typeql::update \
+          --test_arg=behaviour::typeql::rule_validation \
+          --test_output=streamed && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,10 +1,10 @@
 # TypeDB Driver for Java
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Java, refer to the [API Reference](https://typedb.com/docs/clients/2.x/java/java-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver Java, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/java/java-api-ref).
 
 ## Import TypeDB Driver for Java through Maven
 
@@ -25,7 +25,7 @@ To learn about the methods available for executing queries and retrieving their 
 </dependencies>
 ```
 
-Further documentation: https://typedb.com/docs/clients/2.x/java/java-overview
+Further documentation: https://typedb.com/docs/drivers/2.x/java/java-overview
 
 ## Build TypeDB Driver for Java from Source
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,10 +1,10 @@
 # TypeDB Driver for Java
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to [TypeDB > Development > TypeDB Driver API](https://typedb.com/docs/typedb/2.x/development/api.html).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Java, refer to [TypeDB Drivers > Java Driver > Java Driver API reference](https://typedb.com/docs/drivers/2.x/java/java-api-ref.html).
+To learn about the methods available for executing queries and retrieving their answers using Driver Java, refer to the [API Reference](https://typedb.com/docs/clients/2.x/java/java-api-ref).
 
 ## Import TypeDB Driver for Java through Maven
 
@@ -25,7 +25,7 @@ To learn about the methods available for executing queries and retrieving their 
 </dependencies>
 ```
 
-Further documentation: https://typedb.com/docs/drivers/2.x/java/java-install.html
+Further documentation: https://typedb.com/docs/clients/2.x/java/java-overview
 
 ## Build TypeDB Driver for Java from Source
 

--- a/java/api/concept/thing/Relation.java
+++ b/java/api/concept/thing/Relation.java
@@ -52,10 +52,10 @@ public interface Relation extends Thing {
     void removePlayer(TypeDBTransaction transaction, RoleType roleType, Thing player);
 
     @CheckReturnValue
-    Stream<? extends Thing> getPlayers(TypeDBTransaction transaction, RoleType... roleTypes);
+    Stream<? extends Thing> getPlayersByRoleType(TypeDBTransaction transaction, RoleType... roleTypes);
 
     @CheckReturnValue
-    Map<? extends RoleType, ? extends List<? extends Thing>> getPlayersByRoleType(TypeDBTransaction transaction);
+    Map<? extends RoleType, ? extends List<? extends Thing>> getPlayers(TypeDBTransaction transaction);
 
     @CheckReturnValue
     Stream<? extends RoleType> getRelating(TypeDBTransaction transaction);

--- a/java/api/concept/thing/Thing.java
+++ b/java/api/concept/thing/Thing.java
@@ -61,15 +61,15 @@ public interface Thing extends Concept {
         return Json.object().add("type", getType().getLabel().scopedName());
     }
 
-    @CheckReturnValue
-    Stream<? extends Attribute> getHas(TypeDBTransaction transaction, Set<Annotation> annotations);
-
     void setHas(TypeDBTransaction transaction, Attribute attribute);
 
     void unsetHas(TypeDBTransaction transaction, Attribute attribute);
 
     @CheckReturnValue
     Stream<? extends Attribute> getHas(TypeDBTransaction transaction, AttributeType... attributeTypes);
+
+    @CheckReturnValue
+    Stream<? extends Attribute> getHas(TypeDBTransaction transaction, Set<Annotation> annotations);
 
     @CheckReturnValue
     Stream<? extends Relation> getRelations(TypeDBTransaction transaction, RoleType... roleTypes);

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -34,7 +34,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Driver(2, "The architecture '%s' is not recognised.");
         public static final Driver UNRECOGNISED_OS_ARCH =
                 new Driver(3, "The platform os '%s' and architecture '%s' are not supported by this driver.");
-        public static final Driver CLIENT_CLOSED =
+        public static final Driver DRIVER_CLOSED =
                 new Driver(4, "The driver has been closed and no further operation is allowed.");
         public static final Driver SESSION_CLOSED =
                 new Driver(5, "The session has been closed and no further operation is allowed.");

--- a/java/concept/thing/RelationImpl.java
+++ b/java/concept/thing/RelationImpl.java
@@ -78,7 +78,7 @@ public class RelationImpl extends ThingImpl implements Relation {
     }
 
     @Override
-    public Stream<ThingImpl> getPlayers(TypeDBTransaction transaction, RoleType... roleTypes) {
+    public Stream<ThingImpl> getPlayersByRoleType(TypeDBTransaction transaction, RoleType... roleTypes) {
         try {
             return relation_get_players_by_role_type(nativeTransaction(transaction),
                 nativeObject, Arrays.stream(roleTypes).map(rt -> ((RoleTypeImpl) rt).nativeObject).toArray(com.vaticle.typedb.driver.jni.Concept[]::new)).stream().map(ThingImpl::of);
@@ -88,7 +88,7 @@ public class RelationImpl extends ThingImpl implements Relation {
     }
 
     @Override
-    public Map<RoleTypeImpl, List<ThingImpl>> getPlayersByRoleType(TypeDBTransaction transaction) {
+    public Map<RoleTypeImpl, List<ThingImpl>> getPlayers(TypeDBTransaction transaction) {
         Map<RoleTypeImpl, List<ThingImpl>> rolePlayerMap = new HashMap<>();
         try {
             relation_get_role_players(nativeTransaction(transaction), nativeObject).stream().forEach(rolePlayer -> {

--- a/java/test/behaviour/concept/thing/relation/RelationSteps.java
+++ b/java/test/behaviour/concept/thing/relation/RelationSteps.java
@@ -124,7 +124,7 @@ public class RelationSteps {
     @Then("relation {var} get players contain:")
     public void relation_get_players_contain(String var, Map<String, String> players) {
         Relation relation = get(var).asRelation();
-        players.forEach((rt, var2) -> assertTrue(relation.getPlayersByRoleType(tx()).get(relation.getType().getRelates(tx(), rt)).contains(get(var2.substring(1)))));
+        players.forEach((rt, var2) -> assertTrue(relation.getPlayers(tx()).get(relation.getType().getRelates(tx(), rt)).contains(get(var2.substring(1)))));
     }
 
     @Then("relation {var} get players do not contain:")
@@ -132,7 +132,7 @@ public class RelationSteps {
         Relation relation = get(var).asRelation();
         players.forEach((rt, var2) -> {
             List<? extends Thing> p;
-            if ((p = relation.getPlayersByRoleType(tx()).get(relation.getType().getRelates(tx(), rt))) != null) {
+            if ((p = relation.getPlayers(tx()).get(relation.getType().getRelates(tx(), rt))) != null) {
                 assertFalse(p.contains(get(var2.substring(1))));
             }
         });
@@ -140,21 +140,21 @@ public class RelationSteps {
 
     @Then("relation {var} get players contain: {var}")
     public void relation_get_players_contain(String var1, String var2) {
-        assertTrue(get(var1).asRelation().getPlayers(tx()).anyMatch(p -> p.equals(get(var2))));
+        assertTrue(get(var1).asRelation().getPlayersByRoleType(tx()).anyMatch(p -> p.equals(get(var2))));
     }
 
     @Then("relation {var} get players do not contain: {var}")
     public void relation_get_players_do_not_contain(String var1, String var2) {
-        assertTrue(get(var1).asRelation().getPlayers(tx()).noneMatch(p -> p.equals(get(var2))));
+        assertTrue(get(var1).asRelation().getPlayersByRoleType(tx()).noneMatch(p -> p.equals(get(var2))));
     }
 
     @Then("relation {var} get players for role\\( ?{type_label} ?) contain: {var}")
     public void relation_get_players_for_role_contain(String var1, String roleTypeLabel, String var2) {
-        assertTrue(get(var1).asRelation().getPlayers(tx(), get(var1).asRelation().getType().getRelates(tx(), roleTypeLabel)).anyMatch(p -> p.equals(get(var2))));
+        assertTrue(get(var1).asRelation().getPlayersByRoleType(tx(), get(var1).asRelation().getType().getRelates(tx(), roleTypeLabel)).anyMatch(p -> p.equals(get(var2))));
     }
 
     @Then("relation {var} get players for role\\( ?{type_label} ?) do not contain: {var}")
     public void relation_get_players_for_role_do_not_contain(String var1, String roleTypeLabel, String var2) {
-        assertTrue(get(var1).asRelation().getPlayers(tx(), get(var1).asRelation().getType().getRelates(tx(), roleTypeLabel)).noneMatch(p -> p.equals(get(var2))));
+        assertTrue(get(var1).asRelation().getPlayersByRoleType(tx(), get(var1).asRelation().getType().getRelates(tx(), roleTypeLabel)).noneMatch(p -> p.equals(get(var2))));
     }
 }

--- a/java/test/deployment/pom.xml
+++ b/java/test/deployment/pom.xml
@@ -57,7 +57,7 @@ under the License.
         <dependency>
             <groupId>com.vaticle.typedb</groupId>
             <artifactId>typedb-driver</artifactId>
-            <version>CLIENT_JAVA_VERSION_MARKER</version>
+            <version>DRIVER_JAVA_VERSION_MARKER</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -7,13 +7,10 @@
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to [TypeDB > Driver API > Overview](http://docs.vaticle.com/docs/driver-api/overview).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Node.js, refer to [TypeDB > Driver API > Node.js > API Reference](http://docs.vaticle.com/docs/driver-api/nodejs#api-reference).
-
-## Concept API
-To learn about the methods available on the concepts retrieved as the answers to TypeQL queries, refer to [TypeDB > Concept API > Overview](http://docs.vaticle.com/docs/concept-api/overview).
+To learn about the methods available for executing queries and retrieving their answers using Driver NodeJS, refer to the [API Reference](https://typedb.com/docs/clients/2.x/node-js/node-js-api-ref).
 
 ## Installation
 
@@ -22,7 +19,7 @@ To learn about the methods available on the concepts retrieved as the answers to
 ```shell script
 npm install typedb-driver
 ```
-Further documentation: https://docs.vaticle.com/docs/driver-api/nodejs
+Further documentation: https://typedb.com/docs/clients/2.x/node-js/node-js-overview
 
 ## Using TypeScript
 `typedb-driver` is a TypeScript project and provides its own type definitions out of the box - for example:

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -7,10 +7,10 @@
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver NodeJS, refer to the [API Reference](https://typedb.com/docs/clients/2.x/node-js/node-js-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver NodeJS, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/node-js/node-js-api-ref).
 
 ## Installation
 
@@ -19,7 +19,7 @@ To learn about the methods available for executing queries and retrieving their 
 ```shell script
 npm install typedb-driver
 ```
-Further documentation: https://typedb.com/docs/clients/2.x/node-js/node-js-overview
+Further documentation: https://typedb.com/docs/drivers/2.x/node-js/node-js-overview
 
 ## Using TypeScript
 `typedb-driver` is a TypeScript project and provides its own type definitions out of the box - for example:

--- a/nodejs/common/errors/ErrorMessage.ts
+++ b/nodejs/common/errors/ErrorMessage.ts
@@ -74,7 +74,7 @@ export namespace ErrorMessage {
 
     export namespace Driver {
         export const RPC_METHOD_UNAVAILABLE = new Driver(1, (args: Stringable[]) => `The server does not support this method. Please ensure that the TypeDB Driver and TypeDB Server versions are compatible:\n'${args[0]}'.`);
-        export const CLIENT_NOT_OPEN = new Driver(2, (args: Stringable[]) => `The driver is not open.`);
+        export const DRIVER_NOT_OPEN = new Driver(2, (args: Stringable[]) => `The driver is not open.`);
         export const SESSION_ID_EXISTS = new Driver(3, (args: Stringable[]) => `The newly opened session id '${args[0]}' already exists`);
         export const SESSION_CLOSED = new Driver(4, () => `Session is closed.`);
         export const TRANSACTION_CLOSED = new Driver(5, () => `The transaction has been closed and no further operation is allowed.`);

--- a/nodejs/connection/TypeDBDriverImpl.ts
+++ b/nodejs/connection/TypeDBDriverImpl.ts
@@ -34,7 +34,7 @@ import {UserManagerImpl} from "../user/UserManagerImpl";
 import {TypeDBDatabaseManagerImpl} from "./TypeDBDatabaseManagerImpl";
 import {TypeDBSessionImpl} from "./TypeDBSessionImpl";
 import {TypeDBStubImpl} from "./TypeDBStubImpl";
-import CLIENT_NOT_OPEN = ErrorMessage.Driver.CLIENT_NOT_OPEN;
+import DRIVER_NOT_OPEN = ErrorMessage.Driver.DRIVER_NOT_OPEN;
 import ENTERPRISE_UNABLE_TO_CONNECT = ErrorMessage.Driver.ENTPERPRISE_UNABLE_TO_CONNECT;
 import SESSION_ID_EXISTS = ErrorMessage.Driver.SESSION_ID_EXISTS;
 
@@ -104,7 +104,7 @@ export class TypeDBDriverImpl implements TypeDBDriver {
     }
 
     async session(databaseName: string, type: SessionType, options?: TypeDBOptions): Promise<TypeDBSessionImpl> {
-        if (!this.isOpen()) throw new TypeDBDriverError(CLIENT_NOT_OPEN);
+        if (!this.isOpen()) throw new TypeDBDriverError(DRIVER_NOT_OPEN);
         if (!options) options = new TypeDBOptions();
         const session = new TypeDBSessionImpl(databaseName, type, options, this);
         await session.open();
@@ -114,17 +114,17 @@ export class TypeDBDriverImpl implements TypeDBDriver {
     }
 
     get databases(): TypeDBDatabaseManagerImpl {
-        if (!this.isOpen()) throw new TypeDBDriverError(CLIENT_NOT_OPEN);
+        if (!this.isOpen()) throw new TypeDBDriverError(DRIVER_NOT_OPEN);
         return this._databases;
     }
 
     async user(): Promise<UserImpl> {
-        if (!this.isOpen()) throw new TypeDBDriverError(CLIENT_NOT_OPEN);
+        if (!this.isOpen()) throw new TypeDBDriverError(DRIVER_NOT_OPEN);
         return await this.users.get(this._credential.username)
     }
 
     get users(): UserManagerImpl {
-        if (!this.isOpen()) throw new TypeDBDriverError(CLIENT_NOT_OPEN);
+        if (!this.isOpen()) throw new TypeDBDriverError(DRIVER_NOT_OPEN);
         return this._userManager;
     }
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,10 +1,10 @@
 # TypeDB Driver for Python
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Python, refer to the [API Reference](https://typedb.com/docs/clients/2.x/python/python-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver Python, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/python/python-api-ref).
 
 ## Install TypeDB Driver for Python through Pip
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -1,13 +1,10 @@
 # TypeDB Driver for Python
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to [TypeDB > Driver API > Overview](http://docs.vaticle.com/docs/driver-api/overview).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Python, refer to [TypeDB > Driver API > Python > API Reference](http://docs.vaticle.com/docs/driver-api/python#api-reference).
-
-## Concept API
-To learn about the methods available on the concepts retrieved as the answers to TypeQL queries, refer to [TypeDB > Concept API > Overview](http://docs.vaticle.com/docs/concept-api/overview)
+To learn about the methods available for executing queries and retrieving their answers using Driver Python, refer to the [API Reference](https://typedb.com/docs/clients/2.x/python/python-api-ref).
 
 ## Install TypeDB Driver for Python through Pip
 ```

--- a/python/tests/deployment/requirements.txt
+++ b/python/tests/deployment/requirements.txt
@@ -21,4 +21,4 @@
 
 --extra-index-url https://repo.vaticle.com/repository/pypi-snapshot/simple
 
-typedb-driver==CLIENT_PYTHON_VERSION_MARKER
+typedb-driver==DRIVER_PYTHON_VERSION_MARKER

--- a/python/typedb/common/exception.py
+++ b/python/typedb/common/exception.py
@@ -68,7 +68,7 @@ class DriverErrorMessage(ErrorMessage):
                                                  message_body=message)
 
 
-CLIENT_CLOSED = DriverErrorMessage(1, "The driver has been closed and no further operation is allowed.")
+DRIVER_CLOSED = DriverErrorMessage(1, "The driver has been closed and no further operation is allowed.")
 SESSION_CLOSED = DriverErrorMessage(2, "The session has been closed and no further operation is allowed.")
 TRANSACTION_CLOSED = DriverErrorMessage(3, "The transaction has been closed and no further operation is allowed.")
 DATABASE_DELETED = DriverErrorMessage(4, "The database '%s' has been deleted and no further operation is allowed.")

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import connection_open_plaintext, connection_o
 
 from typedb.api.connection.driver import TypeDBDriver
 from typedb.api.connection.options import TypeDBOptions
-from typedb.common.exception import TypeDBDriverExceptionExt, CLIENT_CLOSED
+from typedb.common.exception import TypeDBDriverExceptionExt, DRIVER_CLOSED
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.connection.database_manager import _DatabaseManager
 from typedb.connection.session import _Session
@@ -53,7 +53,7 @@ class _Driver(TypeDBDriver, NativeWrapper[NativeConnection]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(CLIENT_CLOSED)
+        return TypeDBDriverExceptionExt.of(DRIVER_CLOSED)
 
     @property
     def _native_connection(self) -> NativeConnection:

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -94,6 +94,11 @@ checkstyle_test(
         "*",
         "src/**/*",
     ]),
+    exclude = glob([
+        "README.md",
+        "**/Cargo.toml",
+        "**/Cargo.lock",
+    ]),
     license_type = "apache-header",
 )
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -10,7 +10,7 @@
 ## Driver Architecture
 To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
 
-The TypeDB Client for Rust provides a fully async API that supports the [`tokio`](https://crates.io/crates/tokio) **multi-threaded** runtime.
+The TypeDB Driver for Rust provides a fully async API that supports multiple async runtimes or a synchronous interface gated by the `sync` feature.
 
 ## API Reference
 To learn about the methods available for executing queries and retrieving their answers using Driver Rust, refer to the [API Reference](https://typedb.com/docs/clients/2.x/rust/rust-api-ref).

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,47 @@
+
+# TypeDB Client for Rust
+
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-client-rust/badge.svg)](https://factory.vaticle.com/vaticle/typedb-client-rust)
+[![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)
+[![Discussion Forum](https://img.shields.io/discourse/https/forum.vaticle.com/topics.svg)](https://forum.vaticle.com)
+[![Stack Overflow](https://img.shields.io/badge/stackoverflow-typedb-796de3.svg)](https://stackoverflow.com/questions/tagged/typedb)
+[![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
+
+## Driver Architecture
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
+
+The TypeDB Client for Rust provides a fully async API that supports the [`tokio`](https://crates.io/crates/tokio) **multi-threaded** runtime.
+
+## API Reference
+To learn about the methods available for executing queries and retrieving their answers using Driver Rust, refer to the [API Reference](https://typedb.com/docs/clients/2.x/rust/rust-api-ref).
+
+## Quickstart
+1. Import `typedb-driver` through Cargo:
+```toml
+typedb-client = "2.24.2"
+```
+2. Make sure the [TypeDB Server](https://docs.vaticle.com/docs/running-typedb/install-and-run#start-the-typedb-server) is running.
+3. See `rust/tests/integration` for examples of usage.
+
+## Build from Source
+> Note: You don't need to compile TypeDB Driver from source if you just want to use it in your code. See the _"Quickstart"_ section above.
+
+1. Make sure you have [Bazel](https://docs.bazel.build/versions/master/install.html) installed on your machine.
+
+2. Build the library:
+
+   a) to build the native/raw rlib:
+   ```
+   bazel build //rust:typedb_driver
+   ```
+   The rlib will be produced at: `bazel-bin/libtypedb_driver-{hash}.rlib`.
+
+   b) to build the crate for a Cargo project:
+   ```
+   bazel build //rust:assemble_crate
+   ```
+   The Cargo crate will be produced at:
+   ```
+   bazel-bin/assemble_crate.crate
+   ```
+   You can then unzip this crate to retrieve `Cargo.toml`. **Please note**: this process has not yet been thoroughly tested. The generated `Cargo.toml` may not be fully correct. See the `Cargo.toml` of the `typedb-driver` crate for reference.

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,24 +1,24 @@
 
-# TypeDB Client for Rust
+# TypeDB Driver for Rust
 
-[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-client-rust/badge.svg)](https://factory.vaticle.com/vaticle/typedb-client-rust)
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-driver-rust/badge.svg)](https://factory.vaticle.com/vaticle/typedb-driver-rust)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)
 [![Discussion Forum](https://img.shields.io/discourse/https/forum.vaticle.com/topics.svg)](https://forum.vaticle.com)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typedb-796de3.svg)](https://stackoverflow.com/questions/tagged/typedb)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/clients/2.x/clients).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
 
 The TypeDB Driver for Rust provides a fully async API that supports multiple async runtimes or a synchronous interface gated by the `sync` feature.
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Rust, refer to the [API Reference](https://typedb.com/docs/clients/2.x/rust/rust-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver Rust, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/rust/rust-api-ref).
 
 ## Quickstart
 1. Import `typedb-driver` through Cargo:
 ```toml
-typedb-client = "2.24.2"
+typedb-driver = "2.24.2"
 ```
 2. Make sure the [TypeDB Server](https://docs.vaticle.com/docs/running-typedb/install-and-run#start-the-typedb-server) is running.
 3. See `rust/tests/integration` for examples of usage.


### PR DESCRIPTION
## What is the goal of this PR?

We split rust behaviour `typeql` behaviour tests into `read` and `write` to cut the runtime of the test. We also add READMEs for Rust, and update the READMEs for the other drivers.

## What are the changes implemented in this PR?
- Update READMEs
- Split TypeQL-Rust behaviour tests in CI, in order to execute more in a more timely manner
- Fix one Java API which had `Relation.getPlayers()` and `Relation.GetPlayersByRoleType` switched
