### PR TITLE
Update pest 2.4.0 => 2.7.4

### DIFF
--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Documentation: https://typedb.com/docs/drivers/2.x/drivers
+Documentation: https://typedb.com/docs/clients/2.x/clients
 
 ## Distribution
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,8 +24,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "72ef3d0550492342ced5859e8f972dbf5d60677b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
+        commit = "ce0b804565aac066fc2e90e3b8c8850c54c0e19a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
@@ -38,8 +38,8 @@ def vaticle_typedb_common():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        tag = "2.24.5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/dmitrii-ubskii/typeql",
+        commit = "d986bcdc802d1eb2dc5f839349a3d62b9e7a255a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,8 +24,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
-        commit = "ce0b804565aac066fc2e90e3b8c8850c54c0e19a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "fcc9a56b65e6ab69bbf0f1680affe38e12617ed6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
@@ -38,8 +38,8 @@ def vaticle_typedb_common():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/dmitrii-ubskii/typeql",
-        commit = "d986bcdc802d1eb2dc5f839349a3d62b9e7a255a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/vaticle/typeql",
+        commit = "6dce697f5a0b5f67194e531d3efa3bbcbd31a088",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():

--- a/java/BUILD
+++ b/java/BUILD
@@ -46,8 +46,8 @@ java_library(
 
 assemble_maven(
     name = "assemble-maven",
-    project_description = "TypeDB Driver API for Java",
-    project_name = "TypeDB Driver Java",
+    project_description = "TypeDB Java Driver",
+    project_name = "TypeDB Java Driver",
     project_url = "https://github.com/vaticle/typedb-driver-java",
     scm_url = "https://github.com/vaticle/typedb-driver-java",
     target = ":driver-java",
@@ -90,8 +90,8 @@ swig_native_java_library(
 
 assemble_maven(
     name = "assemble-maven-jni",
-    project_description = "TypeDB Driver JNI",
-    project_name = "TypeDB Driver Java",
+    project_description = "Java TypeDB Driver JNI",
+    project_name = "Java TypeDB Driver JNI",
     project_url = "https://github.com/vaticle/typedb-driver-java",
     scm_url = "https://github.com/vaticle/typedb-driver-java",
     target = ":typedb_driver_jni",

--- a/java/README.md
+++ b/java/README.md
@@ -1,4 +1,4 @@
-# TypeDB Driver for Java
+# TypeDB Java Driver
 
 ## Driver Architecture
 To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Clients Overview](https://typedb.com/docs/clients/2.x/clients).

--- a/java/README.md
+++ b/java/README.md
@@ -1,10 +1,10 @@
 # TypeDB Driver for Java
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Clients Overview](https://typedb.com/docs/clients/2.x/clients).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Java, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/java/java-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver Java, refer to the [API Reference](https://typedb.com/docs/clients/2.x/java/java-api-ref).
 
 ## Import TypeDB Driver for Java through Maven
 
@@ -25,7 +25,7 @@ To learn about the methods available for executing queries and retrieving their 
 </dependencies>
 ```
 
-Further documentation: https://typedb.com/docs/drivers/2.x/java/java-overview
+Further documentation: https://typedb.com/docs/clients/2.x/java/java-overview
 
 ## Build TypeDB Driver for Java from Source
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -7,10 +7,10 @@
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Clients Overview](https://typedb.com/docs/clients/2.x/clients).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver NodeJS, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/node-js/node-js-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver NodeJS, refer to the [API Reference](https://typedb.com/docs/clients/2.x/node-js/node-js-api-ref).
 
 ## Installation
 
@@ -19,7 +19,7 @@ To learn about the methods available for executing queries and retrieving their 
 ```shell script
 npm install typedb-driver
 ```
-Further documentation: https://typedb.com/docs/drivers/2.x/node-js/node-js-overview
+Further documentation: https://typedb.com/docs/clients/2.x/node-js/node-js-overview
 
 ## Using TypeScript
 `typedb-driver` is a TypeScript project and provides its own type definitions out of the box - for example:

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1,4 +1,4 @@
-# TypeDB Driver for Node.js
+# TypeDB Node.js Driver
 
 [![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-driver-nodejs/badge.svg)](https://factory.vaticle.com/vaticle/typedb-driver-nodejs)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedb-driver",
   "version": "0.0.0",
-  "description": "TypeDB Driver for Node.js",
+  "description": "TypeDB Node.js Driver",
   "author": "Vaticle",
   "license": "Apache-2.0",
   "homepage": "https://vaticle.com",

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,4 @@
-# TypeDB Driver for Python
+# TypeDB Python Driver
 
 ## Driver Architecture
 To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Clients Overview](https://typedb.com/docs/clients/2.x/clients).

--- a/python/README.md
+++ b/python/README.md
@@ -1,10 +1,10 @@
 # TypeDB Driver for Python
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Clients Overview](https://typedb.com/docs/clients/2.x/clients).
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Python, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/python/python-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver Python, refer to the [API Reference](https://typedb.com/docs/clients/2.x/python/python-api-ref).
 
 ## Install TypeDB Driver for Python through Pip
 ```

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -71,7 +71,7 @@ rust_library(
 
 assemble_crate(
     name = "assemble_crate",
-    description = "TypeDB Driver API for Rust",
+    description = "TypeDB Rust Driver",
     homepage = "https://github.com/vaticle/typedb-driver",
     license = "Apache-2.0",
     license_file = "//:LICENSE",

--- a/rust/README.md
+++ b/rust/README.md
@@ -8,12 +8,12 @@
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
 
 ## Driver Architecture
-To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Driver Overview](https://typedb.com/docs/drivers/2.x/drivers).
+To learn about the mechanism that a TypeDB Driver uses to set up communication with databases running on the TypeDB Server, refer to the [Clients Overview](https://typedb.com/docs/clients/2.x/clients).
 
 The TypeDB Driver for Rust provides a fully async API that supports multiple async runtimes or a synchronous interface gated by the `sync` feature.
 
 ## API Reference
-To learn about the methods available for executing queries and retrieving their answers using Driver Rust, refer to the [API Reference](https://typedb.com/docs/drivers/2.x/rust/rust-api-ref).
+To learn about the methods available for executing queries and retrieving their answers using Driver Rust, refer to the [API Reference](https://typedb.com/docs/clients/2.x/rust/rust-api-ref).
 
 ## Quickstart
 1. Import `typedb-driver` through Cargo:

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,5 +1,4 @@
-
-# TypeDB Driver for Rust
+# TypeDB Rust Driver
 
 [![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-driver/badge.svg)](https://factory.vaticle.com/vaticle/typedb-driver)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)


### PR DESCRIPTION
## What is the goal of this PR?

We update to pest and pest-derive v2.7.4, which among other things purports to fix the error where [deriving Parser fails on "undeclared crate or module `alloc`"](https://github.com/pest-parser/pest/issues/899) (https://github.com/pest-parser/pest/pull/900).

## What are the changes implemented in this PR?

We also update README URLs and project descriptions.