### PR TITLE
Remove stray factory dependency

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -925,7 +925,6 @@ build:
         - build
         - test-rust-integration-core
         - test-rust-integration-enterprise
-        - test-rust-integration-runtimes
         - test-rust-behaviour-concept
         - test-rust-behaviour-connection
         - test-rust-behaviour-query-read


### PR DESCRIPTION
## What is the goal of this PR?

We remove the dependency of a snaphsot deployment job on a recently removed test job.