### PR TITLE
Wrap native exceptions with python driver exception

### DIFF
--- a/c/swig/typedb_driver_python.swg
+++ b/c/swig/typedb_driver_python.swg
@@ -77,15 +77,15 @@
     free((char *) $1);
 }
 
-/* Introduce TypeDBDriverException and use it to wrap all native exceptions */
+/* Introduce TypeDBDriverExceptionNative and use it to wrap all native exceptions */
 %{
 static PyObject* PyExc_TypeDBDriverError;
 %}
 
 %init %{
-    PyExc_TypeDBDriverError = PyErr_NewException("native_driver_python.TypeDBDriverException", NULL, NULL);
+    PyExc_TypeDBDriverError = PyErr_NewException("native_driver_python.TypeDBDriverExceptionNative", NULL, NULL);
     Py_INCREF(PyExc_TypeDBDriverError);
-    PyModule_AddObject(m, "TypeDBDriverException", PyExc_TypeDBDriverError);
+    PyModule_AddObject(m, "TypeDBDriverExceptionNative", PyExc_TypeDBDriverError);
 %}
 
 %exception {
@@ -97,7 +97,7 @@ static PyObject* PyExc_TypeDBDriverError;
 }
 
 %pythoncode %{
-    TypeDBDriverException = native_driver_python.TypeDBDriverException
+    TypeDBDriverExceptionNative = native_driver_python.TypeDBDriverExceptionNative
 %}
 
 /* ValueType* needs special handling */

--- a/java/concept/type/ThingTypeImpl.java
+++ b/java/concept/type/ThingTypeImpl.java
@@ -73,32 +73,56 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
 
     @Override
     public final boolean isRoot() {
-        return thing_type_is_root(nativeObject);
+        try {
+            return thing_type_is_root(nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final boolean isAbstract() {
-        return thing_type_is_abstract(nativeObject);
+        try {
+            return thing_type_is_abstract(nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public Label getLabel() {
-        return Label.of(thing_type_get_label(nativeObject));
+        try {
+            return Label.of(thing_type_get_label(nativeObject));
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public void delete(TypeDBTransaction transaction) {
-        thing_type_delete(nativeTransaction(transaction), nativeObject);
+        try {
+            thing_type_delete(nativeTransaction(transaction), nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public boolean isDeleted(TypeDBTransaction transaction) {
-        return thing_type_is_deleted(nativeTransaction(transaction), nativeObject);
+        try {
+            return thing_type_is_deleted(nativeTransaction(transaction), nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final void setLabel(TypeDBTransaction transaction, String newLabel) {
-        thing_type_set_label(nativeTransaction(transaction), nativeObject, newLabel);
+        try {
+            thing_type_set_label(nativeTransaction(transaction), nativeObject, newLabel);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
@@ -121,23 +145,39 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
 
     @Override
     public final void setAbstract(TypeDBTransaction transaction) {
-        thing_type_set_abstract(nativeTransaction(transaction), nativeObject);
+        try {
+            thing_type_set_abstract(nativeTransaction(transaction), nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final void unsetAbstract(TypeDBTransaction transaction) {
-        thing_type_unset_abstract(nativeTransaction(transaction), nativeObject);
+        try {
+            thing_type_unset_abstract(nativeTransaction(transaction), nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final void setPlays(TypeDBTransaction transaction, RoleType roleType) {
-        thing_type_set_plays(nativeTransaction(transaction), nativeObject, ((RoleTypeImpl) roleType).nativeObject, null);
+        try {
+            thing_type_set_plays(nativeTransaction(transaction), nativeObject, ((RoleTypeImpl) roleType).nativeObject, null);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final void setPlays(TypeDBTransaction transaction, RoleType roleType, RoleType overriddenRoleType) {
-        thing_type_set_plays(nativeTransaction(transaction),
-                nativeObject, ((RoleTypeImpl) roleType).nativeObject, ((RoleTypeImpl) overriddenRoleType).nativeObject);
+        try {
+            thing_type_set_plays(nativeTransaction(transaction),
+                    nativeObject, ((RoleTypeImpl) roleType).nativeObject, ((RoleTypeImpl) overriddenRoleType).nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
@@ -157,9 +197,13 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
 
     @Override
     public final void setOwns(TypeDBTransaction transaction, AttributeType attributeType, AttributeType overriddenType, Set<Annotation> annotations) {
-        com.vaticle.typedb.driver.jni.Concept overriddenTypeNative = overriddenType != null ? ((AttributeTypeImpl) overriddenType).nativeObject : null;
-        com.vaticle.typedb.driver.jni.Annotation[] annotationsArray = annotations.stream().map(anno -> anno.nativeObject).toArray(com.vaticle.typedb.driver.jni.Annotation[]::new);
-        thing_type_set_owns(nativeTransaction(transaction), nativeObject, ((AttributeTypeImpl) attributeType).nativeObject, overriddenTypeNative, annotationsArray);
+        try {
+            com.vaticle.typedb.driver.jni.Concept overriddenTypeNative = overriddenType != null ? ((AttributeTypeImpl) overriddenType).nativeObject : null;
+            com.vaticle.typedb.driver.jni.Annotation[] annotationsArray = annotations.stream().map(anno -> anno.nativeObject).toArray(com.vaticle.typedb.driver.jni.Annotation[]::new);
+            thing_type_set_owns(nativeTransaction(transaction), nativeObject, ((AttributeTypeImpl) attributeType).nativeObject, overriddenTypeNative, annotationsArray);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
@@ -169,15 +213,23 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
 
     @Override
     public final Stream<RoleTypeImpl> getPlays(TypeDBTransaction transaction, Transitivity transitivity) {
-        return thing_type_get_plays(nativeTransaction(transaction), nativeObject, transitivity.nativeObject).stream().map(RoleTypeImpl::new);
+        try {
+            return thing_type_get_plays(nativeTransaction(transaction), nativeObject, transitivity.nativeObject).stream().map(RoleTypeImpl::new);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public RoleTypeImpl getPlaysOverridden(TypeDBTransaction transaction, RoleType roleType) {
-        com.vaticle.typedb.driver.jni.Concept res = thing_type_get_plays_overridden(nativeTransaction(transaction),
-                nativeObject, ((RoleTypeImpl) roleType).nativeObject);
-        if (res != null) return new RoleTypeImpl(res);
-        else return null;
+        try {
+            com.vaticle.typedb.driver.jni.Concept res = thing_type_get_plays_overridden(nativeTransaction(transaction),
+                    nativeObject, ((RoleTypeImpl) roleType).nativeObject);
+            if (res != null) return new RoleTypeImpl(res);
+            else return null;
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
@@ -225,33 +277,53 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     }
 
     private Stream<AttributeTypeImpl> getOwns(TypeDBTransaction transaction, Value.Type valueType, Transitivity transitivity, Set<Annotation> annotations) {
-        return thing_type_get_owns(nativeTransaction(transaction), nativeObject, valueType == null ? null : valueType.nativeObject, transitivity.nativeObject,
-                annotations.stream().map(anno -> anno.nativeObject).toArray(com.vaticle.typedb.driver.jni.Annotation[]::new)
-        ).stream().map(AttributeTypeImpl::new);
+        try {
+            return thing_type_get_owns(nativeTransaction(transaction), nativeObject, valueType == null ? null : valueType.nativeObject, transitivity.nativeObject,
+                    annotations.stream().map(anno -> anno.nativeObject).toArray(com.vaticle.typedb.driver.jni.Annotation[]::new)
+            ).stream().map(AttributeTypeImpl::new);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public AttributeTypeImpl getOwnsOverridden(TypeDBTransaction transaction, AttributeType attributeType) {
-        com.vaticle.typedb.driver.jni.Concept res = thing_type_get_owns_overridden(nativeTransaction(transaction),
-                nativeObject, ((AttributeTypeImpl) attributeType).nativeObject);
-        if (res != null) return new AttributeTypeImpl(res);
-        else return null;
+        try {
+            com.vaticle.typedb.driver.jni.Concept res = thing_type_get_owns_overridden(nativeTransaction(transaction),
+                    nativeObject, ((AttributeTypeImpl) attributeType).nativeObject);
+            if (res != null) return new AttributeTypeImpl(res);
+            else return null;
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final void unsetOwns(TypeDBTransaction transaction, AttributeType attributeType) {
-        thing_type_unset_owns(nativeTransaction(transaction),
-                nativeObject, ((AttributeTypeImpl) attributeType).nativeObject);
+        try {
+            thing_type_unset_owns(nativeTransaction(transaction),
+                    nativeObject, ((AttributeTypeImpl) attributeType).nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final void unsetPlays(TypeDBTransaction transaction, RoleType roleType) {
-        thing_type_unset_plays(nativeTransaction(transaction), nativeObject, ((RoleTypeImpl) roleType).nativeObject);
+        try {
+            thing_type_unset_plays(nativeTransaction(transaction), nativeObject, ((RoleTypeImpl) roleType).nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     @Override
     public final String getSyntax(TypeDBTransaction transaction) {
-        return thing_type_get_syntax(nativeTransaction(transaction), nativeObject);
+        try {
+            return thing_type_get_syntax(nativeTransaction(transaction), nativeObject);
+        } catch (com.vaticle.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
     }
 
     public static class Root extends ThingTypeImpl {

--- a/python/docs/TypeDBDriverException.adoc
+++ b/python/docs/TypeDBDriverException.adoc
@@ -1,13 +1,11 @@
-[#_TypeDBDriverExceptionExt]
+[#_TypeDBDriverException]
 === TypeDBDriverException
 
 *Supertypes:*
 
-* `TypeDBDriverException`
+* `RuntimeError`
 
 Exceptions raised by the driver.
-
-For exceptions handling use ``TypeDBDriverException`` instead of this class.
 
 [caption=""]
 .TypeDBDriverException examples
@@ -18,7 +16,7 @@ For exceptions handling use ``TypeDBDriverException`` instead of this class.
 try:
     transaction.commit()
 except TypeDBDriverException as err:
-    println("Error:", err)
+    print("Error:", err)
 ----
 
 ====

--- a/python/docs/TypeDBDriverExceptionExt.adoc
+++ b/python/docs/TypeDBDriverExceptionExt.adoc
@@ -1,5 +1,5 @@
 [#_TypeDBDriverExceptionExt]
-=== TypeDBDriverExceptionExt
+=== TypeDBDriverException
 
 *Supertypes:*
 
@@ -10,7 +10,7 @@ Exceptions raised by the driver.
 For exceptions handling use ``TypeDBDriverException`` instead of this class.
 
 [caption=""]
-.TypeDBDriverExceptionExt examples
+.TypeDBDriverException examples
 ====
 
 [source,python]

--- a/python/typedb/api/concept/concept.py
+++ b/python/typedb/api/concept/concept.py
@@ -209,7 +209,7 @@ class Concept(ABC):
 
             concept.as_type()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Type"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Type"))
 
     def as_thing_type(self) -> ThingType:
         """
@@ -223,7 +223,7 @@ class Concept(ABC):
 
             concept.as_thing_type()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "ThingType"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "ThingType"))
 
     def as_entity_type(self) -> EntityType:
         """
@@ -237,7 +237,7 @@ class Concept(ABC):
 
             concept.as_entity_type()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "EntityType"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "EntityType"))
 
     def as_attribute_type(self) -> AttributeType:
         """
@@ -251,7 +251,7 @@ class Concept(ABC):
 
             concept.as_attribute_type()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "AttributeType"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "AttributeType"))
 
     def as_relation_type(self) -> RelationType:
         """
@@ -265,7 +265,7 @@ class Concept(ABC):
 
             concept.as_relation_type()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RelationType"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RelationType"))
 
     def as_role_type(self) -> RoleType:
         """
@@ -279,7 +279,7 @@ class Concept(ABC):
 
             concept.as_role_type()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RoleType"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RoleType"))
 
     def as_thing(self) -> Thing:
         """
@@ -293,7 +293,7 @@ class Concept(ABC):
 
             concept.as_thing()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Thing"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Thing"))
 
     def as_entity(self) -> Entity:
         """
@@ -307,7 +307,7 @@ class Concept(ABC):
 
             concept.as_entity()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Entity"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Entity"))
 
     def as_attribute(self) -> Attribute:
         """
@@ -321,7 +321,7 @@ class Concept(ABC):
 
             concept.as_attribute()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Attribute"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Attribute"))
 
     def as_relation(self) -> Relation:
         """
@@ -335,7 +335,7 @@ class Concept(ABC):
 
             concept.as_relation()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Relation"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Relation"))
 
     def as_value(self) -> Value:
         """
@@ -349,7 +349,7 @@ class Concept(ABC):
 
             concept.as_value()
         """
-        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Value"))
+        raise TypeDBDriverException(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Value"))
 
     @abstractmethod
     def to_json(self) -> Mapping[str, Union[str, int, float, bool, datetime]]:

--- a/python/typedb/api/concept/concept.py
+++ b/python/typedb/api/concept/concept.py
@@ -25,7 +25,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Mapping, Union, TYPE_CHECKING
 
-from typedb.common.exception import TypeDBDriverExceptionExt, INVALID_CONCEPT_CASTING
+from typedb.common.exception import TypeDBDriverException, INVALID_CONCEPT_CASTING
 
 if TYPE_CHECKING:
     from typedb.api.concept.thing.attribute import Attribute
@@ -209,7 +209,7 @@ class Concept(ABC):
 
             concept.as_type()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Type"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Type"))
 
     def as_thing_type(self) -> ThingType:
         """
@@ -223,7 +223,7 @@ class Concept(ABC):
 
             concept.as_thing_type()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "ThingType"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "ThingType"))
 
     def as_entity_type(self) -> EntityType:
         """
@@ -237,7 +237,7 @@ class Concept(ABC):
 
             concept.as_entity_type()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "EntityType"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "EntityType"))
 
     def as_attribute_type(self) -> AttributeType:
         """
@@ -251,7 +251,7 @@ class Concept(ABC):
 
             concept.as_attribute_type()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "AttributeType"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "AttributeType"))
 
     def as_relation_type(self) -> RelationType:
         """
@@ -265,7 +265,7 @@ class Concept(ABC):
 
             concept.as_relation_type()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RelationType"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RelationType"))
 
     def as_role_type(self) -> RoleType:
         """
@@ -279,7 +279,7 @@ class Concept(ABC):
 
             concept.as_role_type()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RoleType"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "RoleType"))
 
     def as_thing(self) -> Thing:
         """
@@ -293,7 +293,7 @@ class Concept(ABC):
 
             concept.as_thing()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Thing"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Thing"))
 
     def as_entity(self) -> Entity:
         """
@@ -307,7 +307,7 @@ class Concept(ABC):
 
             concept.as_entity()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Entity"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Entity"))
 
     def as_attribute(self) -> Attribute:
         """
@@ -321,7 +321,7 @@ class Concept(ABC):
 
             concept.as_attribute()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Attribute"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Attribute"))
 
     def as_relation(self) -> Relation:
         """
@@ -335,7 +335,7 @@ class Concept(ABC):
 
             concept.as_relation()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Relation"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Relation"))
 
     def as_value(self) -> Value:
         """
@@ -349,7 +349,7 @@ class Concept(ABC):
 
             concept.as_value()
         """
-        raise TypeDBDriverExceptionExt.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Value"))
+        raise TypeDBDriverException.of(INVALID_CONCEPT_CASTING, (self.__class__.__name__, "Value"))
 
     @abstractmethod
     def to_json(self) -> Mapping[str, Union[str, int, float, bool, datetime]]:

--- a/python/typedb/api/concept/value/value.py
+++ b/python/typedb/api/concept/value/value.py
@@ -29,7 +29,7 @@ from typing import Mapping, Union
 from typedb.native_driver_wrapper import Object, Boolean, Long, Double, String, DateTime
 
 from typedb.api.concept.concept import Concept
-from typedb.common.exception import TypeDBDriverExceptionExt, UNEXPECTED_NATIVE_VALUE
+from typedb.common.exception import TypeDBDriverException, UNEXPECTED_NATIVE_VALUE
 
 
 class Value(Concept, ABC):
@@ -315,4 +315,4 @@ class ValueType(Enum):
         for type_ in ValueType:
             if type_.native_object == value_type:
                 return type_
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)

--- a/python/typedb/api/connection/credential.py
+++ b/python/typedb/api/connection/credential.py
@@ -50,9 +50,9 @@ class TypeDBCredential(NativeWrapper[NativeCredential]):
     def __init__(self, username: str, password: str, *, tls_root_ca_path: Optional[str] = None,
                  tls_enabled: bool = True):
         if tls_root_ca_path is not None and not tls_enabled:
-            raise TypeDBDriverException.of(ENTERPRISE_CREDENTIAL_INCONSISTENT)
+            raise TypeDBDriverException(ENTERPRISE_CREDENTIAL_INCONSISTENT)
         super().__init__(credential_new(username, password, tls_root_ca_path, tls_enabled))
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)

--- a/python/typedb/api/connection/credential.py
+++ b/python/typedb/api/connection/credential.py
@@ -23,7 +23,7 @@ from typing import Optional
 
 from typedb.native_driver_wrapper import credential_new, Credential as NativeCredential
 
-from typedb.common.exception import TypeDBDriverExceptionExt, ENTERPRISE_CREDENTIAL_INCONSISTENT, ILLEGAL_STATE
+from typedb.common.exception import TypeDBDriverException, ENTERPRISE_CREDENTIAL_INCONSISTENT, ILLEGAL_STATE
 from typedb.common.native_wrapper import NativeWrapper
 
 
@@ -50,9 +50,9 @@ class TypeDBCredential(NativeWrapper[NativeCredential]):
     def __init__(self, username: str, password: str, *, tls_root_ca_path: Optional[str] = None,
                  tls_enabled: bool = True):
         if tls_root_ca_path is not None and not tls_enabled:
-            raise TypeDBDriverExceptionExt.of(ENTERPRISE_CREDENTIAL_INCONSISTENT)
+            raise TypeDBDriverException.of(ENTERPRISE_CREDENTIAL_INCONSISTENT)
         super().__init__(credential_new(username, password, tls_root_ca_path, tls_enabled))
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)

--- a/python/typedb/api/connection/options.py
+++ b/python/typedb/api/connection/options.py
@@ -34,7 +34,7 @@ from typedb.native_driver_wrapper import options_new, options_has_infer, options
     options_has_schema_lock_acquire_timeout_millis, options_set_schema_lock_acquire_timeout_millis, \
     options_set_read_any_replica, options_get_read_any_replica, options_has_read_any_replica, Options as NativeOptions
 
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_STATE, POSITIVE_VALUE_REQUIRED
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE, POSITIVE_VALUE_REQUIRED
 from typedb.common.native_wrapper import NativeWrapper
 
 
@@ -90,8 +90,8 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
             self.read_any_replica = read_any_replica
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     @property
     def infer(self) -> Optional[bool]:
@@ -163,7 +163,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @prefetch_size.setter
     def prefetch_size(self, prefetch_size: int):
         if prefetch_size < 1:
-            raise TypeDBDriverExceptionExt.of(POSITIVE_VALUE_REQUIRED, prefetch_size)
+            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, prefetch_size)
         options_set_prefetch_size(self.native_object, prefetch_size)
 
     @property
@@ -178,7 +178,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @session_idle_timeout_millis.setter
     def session_idle_timeout_millis(self, session_idle_timeout_millis: int):
         if session_idle_timeout_millis < 1:
-            raise TypeDBDriverExceptionExt.of(POSITIVE_VALUE_REQUIRED, session_idle_timeout_millis)
+            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, session_idle_timeout_millis)
         options_set_session_idle_timeout_millis(self.native_object, session_idle_timeout_millis)
 
     @property
@@ -193,7 +193,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @transaction_timeout_millis.setter
     def transaction_timeout_millis(self, transaction_timeout_millis: int):
         if transaction_timeout_millis < 1:
-            raise TypeDBDriverExceptionExt.of(POSITIVE_VALUE_REQUIRED, transaction_timeout_millis)
+            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, transaction_timeout_millis)
         options_set_transaction_timeout_millis(self.native_object, transaction_timeout_millis)
 
     @property
@@ -208,7 +208,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @schema_lock_acquire_timeout_millis.setter
     def schema_lock_acquire_timeout_millis(self, schema_lock_acquire_timeout_millis: int):
         if schema_lock_acquire_timeout_millis < 1:
-            raise TypeDBDriverExceptionExt.of(POSITIVE_VALUE_REQUIRED, schema_lock_acquire_timeout_millis)
+            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, schema_lock_acquire_timeout_millis)
         options_set_schema_lock_acquire_timeout_millis(self.native_object, schema_lock_acquire_timeout_millis)
 
     @property

--- a/python/typedb/api/connection/options.py
+++ b/python/typedb/api/connection/options.py
@@ -91,7 +91,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     @property
     def infer(self) -> Optional[bool]:
@@ -163,7 +163,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @prefetch_size.setter
     def prefetch_size(self, prefetch_size: int):
         if prefetch_size < 1:
-            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, prefetch_size)
+            raise TypeDBDriverException(POSITIVE_VALUE_REQUIRED, prefetch_size)
         options_set_prefetch_size(self.native_object, prefetch_size)
 
     @property
@@ -178,7 +178,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @session_idle_timeout_millis.setter
     def session_idle_timeout_millis(self, session_idle_timeout_millis: int):
         if session_idle_timeout_millis < 1:
-            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, session_idle_timeout_millis)
+            raise TypeDBDriverException(POSITIVE_VALUE_REQUIRED, session_idle_timeout_millis)
         options_set_session_idle_timeout_millis(self.native_object, session_idle_timeout_millis)
 
     @property
@@ -193,7 +193,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @transaction_timeout_millis.setter
     def transaction_timeout_millis(self, transaction_timeout_millis: int):
         if transaction_timeout_millis < 1:
-            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, transaction_timeout_millis)
+            raise TypeDBDriverException(POSITIVE_VALUE_REQUIRED, transaction_timeout_millis)
         options_set_transaction_timeout_millis(self.native_object, transaction_timeout_millis)
 
     @property
@@ -208,7 +208,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     @schema_lock_acquire_timeout_millis.setter
     def schema_lock_acquire_timeout_millis(self, schema_lock_acquire_timeout_millis: int):
         if schema_lock_acquire_timeout_millis < 1:
-            raise TypeDBDriverException.of(POSITIVE_VALUE_REQUIRED, schema_lock_acquire_timeout_millis)
+            raise TypeDBDriverException(POSITIVE_VALUE_REQUIRED, schema_lock_acquire_timeout_millis)
         options_set_schema_lock_acquire_timeout_millis(self.native_object, schema_lock_acquire_timeout_millis)
 
     @property

--- a/python/typedb/common/exception.py
+++ b/python/typedb/common/exception.py
@@ -26,7 +26,7 @@ from typing import Union, Any
 from typedb.native_driver_wrapper import TypeDBDriverExceptionNative
 
 
-class TypeDBDriverException(TypeDBDriverExceptionNative):
+class TypeDBDriverException(RuntimeError):
     """
     Exceptions raised by the driver.
 
@@ -38,10 +38,10 @@ class TypeDBDriverException(TypeDBDriverExceptionNative):
         try:
             transaction.commit()
         except TypeDBDriverException as err:
-            println("Error:", err)
+            print("Error:", err)
     """
 
-    def __init__(self, msg: Union[ErrorMessage, str], cause: BaseException = None, params: Any = None):
+    def __init__(self, msg: Union[ErrorMessage, str], params: Any = None):
         if isinstance(msg, str):
             self.message = msg
             self.error_message = None
@@ -49,15 +49,14 @@ class TypeDBDriverException(TypeDBDriverExceptionNative):
             self.message = msg.message(params)
             self.error_message = msg
 
-        self.__cause__ = cause
-        super(TypeDBDriverExceptionNative, self).__init__(self.message)
+        super().__init__(self.message)
 
     @staticmethod
-    def of(error_message: ErrorMessage, params: Any = None) -> TypeDBDriverException:
+    def of(exception: TypeDBDriverExceptionNative) -> TypeDBDriverException:
         """
         :meta private:
         """
-        return TypeDBDriverException(msg=error_message, cause=None, params=params)
+        return TypeDBDriverException(str(exception))
 
 
 class ErrorMessage:

--- a/python/typedb/common/exception.py
+++ b/python/typedb/common/exception.py
@@ -23,14 +23,12 @@ from __future__ import annotations
 
 from typing import Union, Any
 
-from typedb.native_driver_wrapper import TypeDBDriverException
+from typedb.native_driver_wrapper import TypeDBDriverExceptionNative
 
 
-class TypeDBDriverExceptionExt(TypeDBDriverException):
+class TypeDBDriverException(TypeDBDriverExceptionNative):
     """
     Exceptions raised by the driver.
-
-    For exceptions handling use ``TypeDBDriverException`` instead of this class.
 
     Examples
     --------
@@ -52,14 +50,14 @@ class TypeDBDriverExceptionExt(TypeDBDriverException):
             self.error_message = msg
 
         self.__cause__ = cause
-        super(TypeDBDriverException, self).__init__(self.message)
+        super(TypeDBDriverExceptionNative, self).__init__(self.message)
 
     @staticmethod
-    def of(error_message: ErrorMessage, params: Any = None) -> TypeDBDriverExceptionExt:
+    def of(error_message: ErrorMessage, params: Any = None) -> TypeDBDriverException:
         """
         :meta private:
         """
-        return TypeDBDriverExceptionExt(msg=error_message, cause=None, params=params)
+        return TypeDBDriverException(msg=error_message, cause=None, params=params)
 
 
 class ErrorMessage:

--- a/python/typedb/common/iterator_wrapper.py
+++ b/python/typedb/common/iterator_wrapper.py
@@ -21,6 +21,9 @@
 
 from typing import Callable
 
+from typedb.native_driver_wrapper import TypeDBDriverExceptionNative
+from typedb.common.exception import TypeDBDriverException
+
 
 class IteratorWrapper:
 
@@ -32,6 +35,9 @@ class IteratorWrapper:
         return self
 
     def __next__(self):
-        if next_item := self._next(self._iterator):
-            return next_item
-        raise StopIteration
+        try:
+            if next_item := self._next(self._iterator):
+                return next_item
+            raise StopIteration
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/common/native_wrapper.py
+++ b/python/typedb/common/native_wrapper.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
-from typedb.common.exception import TypeDBDriverExceptionExt
+from typedb.common.exception import TypeDBDriverException
 
 
 T = TypeVar("T")
@@ -37,7 +37,7 @@ class NativeWrapper(ABC, Generic[T]):
 
     @property
     @abstractmethod
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
         pass
 
     @property

--- a/python/typedb/concept/answer/concept_map.py
+++ b/python/typedb/concept/answer/concept_map.py
@@ -32,7 +32,7 @@ from typedb.native_driver_wrapper import concept_map_get_variables, string_itera
     Explainable as NativeExplainable
 
 from typedb.api.answer.concept_map import ConceptMap
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_STATE, MISSING_VARIABLE, \
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE, MISSING_VARIABLE, \
     NONEXISTENT_EXPLAINABLE_CONCEPT, NONEXISTENT_EXPLAINABLE_OWNERSHIP, NULL_NATIVE_OBJECT, VARIABLE_DOES_NOT_EXIST
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 def _not_blank_var(var: str) -> str:
     if not var or var.isspace():
-        raise TypeDBDriverExceptionExt.of(MISSING_VARIABLE)
+        raise TypeDBDriverException.of(MISSING_VARIABLE)
     return var
 
 
@@ -52,12 +52,12 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
 
     def __init__(self, concept_map: NativeConceptMap):
         if not concept_map:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(concept_map)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def variables(self) -> Iterator[str]:
         return IteratorWrapper(concept_map_get_variables(self.native_object), string_iterator_next)
@@ -69,7 +69,7 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
     def get(self, variable: str) -> Concept:
         concept = concept_map_get(self.native_object, _not_blank_var(variable))
         if not concept:
-            raise TypeDBDriverExceptionExt.of(VARIABLE_DOES_NOT_EXIST, variable)
+            raise TypeDBDriverException.of(VARIABLE_DOES_NOT_EXIST, variable)
         return concept_factory.wrap_concept(concept)
 
     def explainables(self) -> ConceptMap.Explainables:
@@ -92,30 +92,30 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
 
         def __init__(self, explainables: NativeExplainables):
             if not explainables:
-                raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+                raise TypeDBDriverException(NULL_NATIVE_OBJECT)
             super().__init__(explainables)
 
         @property
-        def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-            return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+        def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+            return TypeDBDriverException.of(ILLEGAL_STATE)
 
         def relation(self, variable: str) -> ConceptMap.Explainable:
             explainable = explainables_get_relation(self.native_object, _not_blank_var(variable))
             if not explainable:
-                raise TypeDBDriverExceptionExt.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
+                raise TypeDBDriverException.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
             return _ConceptMap.Explainable(explainable)
 
         def attribute(self, variable: str) -> ConceptMap.Explainable:
             explainable = explainables_get_attribute(self.native_object, _not_blank_var(variable))
             if not explainable:
-                raise TypeDBDriverExceptionExt.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
+                raise TypeDBDriverException.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
             return _ConceptMap.Explainable(explainable)
 
         def ownership(self, owner: str, attribute: str) -> ConceptMap.Explainable:
             explainable = explainables_get_ownership(self.native_object, _not_blank_var(owner),
                                                      _not_blank_var(attribute))
             if not explainable:
-                raise TypeDBDriverExceptionExt.of(NONEXISTENT_EXPLAINABLE_OWNERSHIP, (owner, attribute))
+                raise TypeDBDriverException.of(NONEXISTENT_EXPLAINABLE_OWNERSHIP, (owner, attribute))
             return _ConceptMap.Explainable(explainable)
 
         def relations(self) -> Mapping[str, ConceptMap.Explainable]:
@@ -150,12 +150,12 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
 
         def __init__(self, explainable: NativeExplainable):
             if not explainable:
-                raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+                raise TypeDBDriverException(NULL_NATIVE_OBJECT)
             super().__init__(explainable)
 
         @property
-        def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-            return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+        def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+            return TypeDBDriverException.of(ILLEGAL_STATE)
 
         def conjunction(self) -> str:
             return explainable_get_conjunction(self.native_object)

--- a/python/typedb/concept/answer/concept_map.py
+++ b/python/typedb/concept/answer/concept_map.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 def _not_blank_var(var: str) -> str:
     if not var or var.isspace():
-        raise TypeDBDriverException.of(MISSING_VARIABLE)
+        raise TypeDBDriverException(MISSING_VARIABLE)
     return var
 
 
@@ -57,7 +57,7 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def variables(self) -> Iterator[str]:
         return IteratorWrapper(concept_map_get_variables(self.native_object), string_iterator_next)
@@ -69,7 +69,7 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
     def get(self, variable: str) -> Concept:
         concept = concept_map_get(self.native_object, _not_blank_var(variable))
         if not concept:
-            raise TypeDBDriverException.of(VARIABLE_DOES_NOT_EXIST, variable)
+            raise TypeDBDriverException(VARIABLE_DOES_NOT_EXIST, variable)
         return concept_factory.wrap_concept(concept)
 
     def explainables(self) -> ConceptMap.Explainables:
@@ -97,25 +97,25 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
 
         @property
         def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-            return TypeDBDriverException.of(ILLEGAL_STATE)
+            return TypeDBDriverException(ILLEGAL_STATE)
 
         def relation(self, variable: str) -> ConceptMap.Explainable:
             explainable = explainables_get_relation(self.native_object, _not_blank_var(variable))
             if not explainable:
-                raise TypeDBDriverException.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
+                raise TypeDBDriverException(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
             return _ConceptMap.Explainable(explainable)
 
         def attribute(self, variable: str) -> ConceptMap.Explainable:
             explainable = explainables_get_attribute(self.native_object, _not_blank_var(variable))
             if not explainable:
-                raise TypeDBDriverException.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
+                raise TypeDBDriverException(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
             return _ConceptMap.Explainable(explainable)
 
         def ownership(self, owner: str, attribute: str) -> ConceptMap.Explainable:
             explainable = explainables_get_ownership(self.native_object, _not_blank_var(owner),
                                                      _not_blank_var(attribute))
             if not explainable:
-                raise TypeDBDriverException.of(NONEXISTENT_EXPLAINABLE_OWNERSHIP, (owner, attribute))
+                raise TypeDBDriverException(NONEXISTENT_EXPLAINABLE_OWNERSHIP, (owner, attribute))
             return _ConceptMap.Explainable(explainable)
 
         def relations(self) -> Mapping[str, ConceptMap.Explainable]:
@@ -155,7 +155,7 @@ class _ConceptMap(ConceptMap, NativeWrapper[NativeConceptMap]):
 
         @property
         def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-            return TypeDBDriverException.of(ILLEGAL_STATE)
+            return TypeDBDriverException(ILLEGAL_STATE)
 
         def conjunction(self) -> str:
             return explainable_get_conjunction(self.native_object)

--- a/python/typedb/concept/answer/concept_map_group.py
+++ b/python/typedb/concept/answer/concept_map_group.py
@@ -48,7 +48,7 @@ class _ConceptMapGroup(ConceptMapGroup, NativeWrapper[NativeConceptMapGroup]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def owner(self) -> Concept:
         return concept_factory.wrap_concept(concept_map_group_get_owner(self.native_object))

--- a/python/typedb/concept/answer/concept_map_group.py
+++ b/python/typedb/concept/answer/concept_map_group.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import concept_map_group_get_owner, concept_ma
     ConceptMapGroup as NativeConceptMapGroup
 
 from typedb.api.answer.concept_map_group import ConceptMapGroup
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_STATE, NULL_NATIVE_OBJECT
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE, NULL_NATIVE_OBJECT
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.concept import concept_factory
@@ -43,12 +43,12 @@ class _ConceptMapGroup(ConceptMapGroup, NativeWrapper[NativeConceptMapGroup]):
 
     def __init__(self, concept_map_group: NativeConceptMapGroup):
         if not concept_map_group:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(concept_map_group)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def owner(self) -> Concept:
         return concept_factory.wrap_concept(concept_map_group_get_owner(self.native_object))

--- a/python/typedb/concept/answer/numeric.py
+++ b/python/typedb/concept/answer/numeric.py
@@ -25,7 +25,7 @@ from typedb.native_driver_wrapper import numeric_is_long, numeric_is_double, num
     numeric_get_long, numeric_get_double, numeric_to_string, Numeric as NativeNumeric
 
 from typedb.api.answer.numeric import Numeric
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_CAST, ILLEGAL_STATE, NULL_NATIVE_OBJECT
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_CAST, ILLEGAL_STATE, NULL_NATIVE_OBJECT
 from typedb.common.native_wrapper import NativeWrapper
 
 
@@ -33,12 +33,12 @@ class _Numeric(Numeric, NativeWrapper[NativeNumeric]):
 
     def __init__(self, numeric: NativeNumeric):
         if not numeric:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(numeric)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def is_int(self) -> bool:
         return numeric_is_long(self.native_object)
@@ -51,12 +51,12 @@ class _Numeric(Numeric, NativeWrapper[NativeNumeric]):
 
     def as_int(self):
         if not self.is_int():
-            raise TypeDBDriverExceptionExt.of(ILLEGAL_CAST, "int")
+            raise TypeDBDriverException.of(ILLEGAL_CAST, "int")
         return numeric_get_long(self.native_object)
 
     def as_float(self):
         if not self.is_float():
-            raise TypeDBDriverExceptionExt.of(ILLEGAL_CAST, "float")
+            raise TypeDBDriverException.of(ILLEGAL_CAST, "float")
         return numeric_get_double(self.native_object)
 
     def __repr__(self):

--- a/python/typedb/concept/answer/numeric.py
+++ b/python/typedb/concept/answer/numeric.py
@@ -38,7 +38,7 @@ class _Numeric(Numeric, NativeWrapper[NativeNumeric]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def is_int(self) -> bool:
         return numeric_is_long(self.native_object)
@@ -51,12 +51,12 @@ class _Numeric(Numeric, NativeWrapper[NativeNumeric]):
 
     def as_int(self):
         if not self.is_int():
-            raise TypeDBDriverException.of(ILLEGAL_CAST, "int")
+            raise TypeDBDriverException(ILLEGAL_CAST, "int")
         return numeric_get_long(self.native_object)
 
     def as_float(self):
         if not self.is_float():
-            raise TypeDBDriverException.of(ILLEGAL_CAST, "float")
+            raise TypeDBDriverException(ILLEGAL_CAST, "float")
         return numeric_get_double(self.native_object)
 
     def __repr__(self):

--- a/python/typedb/concept/answer/numeric_group.py
+++ b/python/typedb/concept/answer/numeric_group.py
@@ -27,7 +27,7 @@ from typedb.native_driver_wrapper import numeric_group_get_owner, numeric_group_
     numeric_group_to_string, numeric_group_equals, NumericGroup as NativeNumericGroup
 
 from typedb.api.answer.numeric_group import NumericGroup
-from typedb.common.exception import TypeDBDriverExceptionExt, NULL_NATIVE_OBJECT, ILLEGAL_STATE
+from typedb.common.exception import TypeDBDriverException, NULL_NATIVE_OBJECT, ILLEGAL_STATE
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.concept import concept_factory
 from typedb.concept.answer.numeric import _Numeric
@@ -41,12 +41,12 @@ class _NumericGroup(NumericGroup, NativeWrapper[NativeNumericGroup]):
 
     def __init__(self, numeric_group: NativeNumericGroup):
         if not numeric_group:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(numeric_group)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def owner(self) -> Concept:
         return concept_factory.wrap_concept(numeric_group_get_owner(self.native_object))

--- a/python/typedb/concept/answer/numeric_group.py
+++ b/python/typedb/concept/answer/numeric_group.py
@@ -46,7 +46,7 @@ class _NumericGroup(NumericGroup, NativeWrapper[NativeNumericGroup]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def owner(self) -> Concept:
         return concept_factory.wrap_concept(numeric_group_get_owner(self.native_object))

--- a/python/typedb/concept/concept.py
+++ b/python/typedb/concept/concept.py
@@ -39,7 +39,7 @@ class _Concept(Concept, NativeWrapper[NativeConcept], ABC):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def __repr__(self):
         return concept_to_string(self.native_object)

--- a/python/typedb/concept/concept.py
+++ b/python/typedb/concept/concept.py
@@ -26,7 +26,7 @@ from abc import ABC, abstractmethod
 from typedb.native_driver_wrapper import concept_to_string, concept_equals, Concept as NativeConcept
 
 from typedb.api.concept.concept import Concept
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_STATE, NULL_NATIVE_OBJECT
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE, NULL_NATIVE_OBJECT
 from typedb.common.native_wrapper import NativeWrapper
 
 
@@ -34,12 +34,12 @@ class _Concept(Concept, NativeWrapper[NativeConcept], ABC):
 
     def __init__(self, concept: NativeConcept):
         if not concept:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(concept)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def __repr__(self):
         return concept_to_string(self.native_object)

--- a/python/typedb/concept/concept_factory.py
+++ b/python/typedb/concept/concept_factory.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import \
     concept_is_entity, concept_is_relation, concept_is_attribute, concept_is_value, concept_is_role_type
 
 import typedb.concept
-from typedb.common.exception import TypeDBDriverExceptionExt, UNEXPECTED_NATIVE_VALUE
+from typedb.common.exception import TypeDBDriverException, UNEXPECTED_NATIVE_VALUE
 from typedb.concept.value.value import _Value
 
 if TYPE_CHECKING:
@@ -55,84 +55,84 @@ def wrap_concept(native_concept: NativeConcept) -> _Concept:
     elif concept_is_role_type(native_concept):
         return typedb.concept.type.role_type._RoleType(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_thing_type(native_concept: NativeConcept) -> _ThingType:
     if concept_thing_type := _try_thing_type(native_concept):
         return concept_thing_type
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_thing(native_concept: NativeConcept) -> _Thing:
     if concept_thing := _try_thing(native_concept):
         return concept_thing
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_entity_type(native_concept: NativeConcept) -> _EntityType:
     if concept_is_entity_type(native_concept):
         return typedb.concept.type.entity_type._EntityType(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_attribute_type(native_concept: NativeConcept) -> _AttributeType:
     if concept_is_attribute_type(native_concept):
         return typedb.concept.type.attribute_type._AttributeType(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_relation_type(native_concept: NativeConcept) -> _RelationType:
     if concept_is_relation_type(native_concept):
         return typedb.concept.type.relation_type._RelationType(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_role_type(native_concept: NativeConcept) -> _RoleType:
     if concept_is_role_type(native_concept):
         return typedb.concept.type.role_type._RoleType(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_root(native_concept: NativeConcept) -> _Root:
     if concept_is_root_thing_type(native_concept):
         return typedb.concept.type.thing_type._Root(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_entity(native_concept: NativeConcept) -> _Entity:
     if concept_is_entity(native_concept):
         return typedb.concept.thing.entity._Entity(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_attribute(native_concept: NativeConcept) -> _Attribute:
     if concept_is_attribute(native_concept):
         return typedb.concept.thing.attribute._Attribute(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_relation(native_concept: NativeConcept) -> _Relation:
     if concept_is_relation(native_concept):
         return typedb.concept.thing.relation._Relation(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def wrap_value(native_concept: NativeConcept) -> _Value:
     if concept_is_value(native_concept):
         return typedb.concept.value.value._Value(native_concept)
     else:
-        raise TypeDBDriverExceptionExt(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
 
 def _try_thing_type(native_concept: NativeConcept) -> Optional[_ThingType]:

--- a/python/typedb/concept/concept_manager.py
+++ b/python/typedb/concept/concept_manager.py
@@ -29,7 +29,7 @@ from typedb.native_driver_wrapper import concepts_get_entity_type, concepts_get_
     schema_exception_message, schema_exception_code, Transaction as NativeTransaction
 
 from typedb.api.concept.concept_manager import ConceptManager
-from typedb.common.exception import TypeDBDriverExceptionExt, TypeDBException, MISSING_LABEL, MISSING_IID, \
+from typedb.common.exception import TypeDBDriverException, TypeDBException, MISSING_LABEL, MISSING_IID, \
     TRANSACTION_CLOSED
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.concept.thing.attribute import _Attribute
@@ -45,13 +45,13 @@ if TYPE_CHECKING:
 
 def _not_blank_label(label: str) -> str:
     if not label or label.isspace():
-        raise TypeDBDriverExceptionExt.of(MISSING_LABEL)
+        raise TypeDBDriverException.of(MISSING_LABEL)
     return label
 
 
 def _not_blank_iid(iid: str) -> str:
     if not iid or iid.isspace():
-        raise TypeDBDriverExceptionExt.of(MISSING_IID)
+        raise TypeDBDriverException.of(MISSING_IID)
     return iid
 
 
@@ -61,8 +61,8 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
         super().__init__(transaction)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(TRANSACTION_CLOSED)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(TRANSACTION_CLOSED)
 
     @property
     def native_transaction(self) -> NativeTransaction:

--- a/python/typedb/concept/concept_manager.py
+++ b/python/typedb/concept/concept_manager.py
@@ -26,7 +26,7 @@ from typing import Optional, TYPE_CHECKING
 from typedb.native_driver_wrapper import concepts_get_entity_type, concepts_get_relation_type, \
     concepts_get_attribute_type, concepts_put_entity_type, concepts_put_relation_type, concepts_put_attribute_type, \
     concepts_get_entity, concepts_get_relation, concepts_get_attribute, concepts_get_schema_exceptions, \
-    schema_exception_message, schema_exception_code, Transaction as NativeTransaction
+    schema_exception_message, schema_exception_code, Transaction as NativeTransaction, TypeDBDriverExceptionNative
 
 from typedb.api.concept.concept_manager import ConceptManager
 from typedb.common.exception import TypeDBDriverException, TypeDBException, MISSING_LABEL, MISSING_IID, \
@@ -45,13 +45,13 @@ if TYPE_CHECKING:
 
 def _not_blank_label(label: str) -> str:
     if not label or label.isspace():
-        raise TypeDBDriverException.of(MISSING_LABEL)
+        raise TypeDBDriverException(MISSING_LABEL)
     return label
 
 
 def _not_blank_iid(iid: str) -> str:
     if not iid or iid.isspace():
-        raise TypeDBDriverException.of(MISSING_IID)
+        raise TypeDBDriverException(MISSING_IID)
     return iid
 
 
@@ -62,7 +62,7 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(TRANSACTION_CLOSED)
+        return TypeDBDriverException(TRANSACTION_CLOSED)
 
     @property
     def native_transaction(self) -> NativeTransaction:
@@ -78,45 +78,75 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
         return self.get_attribute_type("attribute")
 
     def get_entity_type(self, label: str) -> Optional[_EntityType]:
-        if _type := concepts_get_entity_type(self.native_transaction, _not_blank_label(label)):
-            return _EntityType(_type)
-        return None
+        try:
+            if _type := concepts_get_entity_type(self.native_transaction, _not_blank_label(label)):
+                return _EntityType(_type)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relation_type(self, label: str) -> Optional[_RelationType]:
-        if _type := concepts_get_relation_type(self.native_transaction, _not_blank_label(label)):
-            return _RelationType(_type)
-        return None
+        try:
+            if _type := concepts_get_relation_type(self.native_transaction, _not_blank_label(label)):
+                return _RelationType(_type)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_attribute_type(self, label: str) -> Optional[_AttributeType]:
-        if _type := concepts_get_attribute_type(self.native_transaction, _not_blank_label(label)):
-            return _AttributeType(_type)
-        return None
+        try:
+            if _type := concepts_get_attribute_type(self.native_transaction, _not_blank_label(label)):
+                return _AttributeType(_type)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def put_entity_type(self, label: str) -> _EntityType:
-        return _EntityType(concepts_put_entity_type(self.native_transaction, _not_blank_label(label)))
+        try:
+            return _EntityType(concepts_put_entity_type(self.native_transaction, _not_blank_label(label)))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def put_relation_type(self, label: str) -> _RelationType:
-        return _RelationType(concepts_put_relation_type(self.native_transaction, _not_blank_label(label)))
+        try:
+            return _RelationType(concepts_put_relation_type(self.native_transaction, _not_blank_label(label)))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def put_attribute_type(self, label: str, value_type: ValueType) -> _AttributeType:
-        return _AttributeType(concepts_put_attribute_type(self.native_transaction, _not_blank_label(label),
-                                                          value_type.native_object))
+        try:
+            return _AttributeType(concepts_put_attribute_type(self.native_transaction, _not_blank_label(label),
+                                                              value_type.native_object))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_entity(self, iid: str) -> Optional[_Entity]:
-        if concept := concepts_get_entity(self.native_transaction, _not_blank_iid(iid)):
-            return _Entity(concept)
-        return None
+        try:
+            if concept := concepts_get_entity(self.native_transaction, _not_blank_iid(iid)):
+                return _Entity(concept)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relation(self, iid: str) -> Optional[_Relation]:
-        if concept := concepts_get_relation(self.native_transaction, _not_blank_iid(iid)):
-            return _Relation(concept)
-        return None
+        try:
+            if concept := concepts_get_relation(self.native_transaction, _not_blank_iid(iid)):
+                return _Relation(concept)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_attribute(self, iid: str) -> Optional[_Attribute]:
-        if concept := concepts_get_attribute(self.native_transaction, _not_blank_iid(iid)):
-            return _Attribute(concept)
-        return None
+        try:
+            if concept := concepts_get_attribute(self.native_transaction, _not_blank_iid(iid)):
+                return _Attribute(concept)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_schema_exception(self) -> list[TypeDBException]:
-        return [TypeDBException(schema_exception_code(e), schema_exception_message(e))
-                for e in concepts_get_schema_exceptions(self.native_transaction)]
+        try:
+            return [TypeDBException(schema_exception_code(e), schema_exception_message(e))
+                    for e in concepts_get_schema_exceptions(self.native_transaction)]
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/concept/concept_manager.py
+++ b/python/typedb/concept/concept_manager.py
@@ -83,7 +83,7 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
                 return _EntityType(_type)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relation_type(self, label: str) -> Optional[_RelationType]:
         try:
@@ -91,7 +91,7 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
                 return _RelationType(_type)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_attribute_type(self, label: str) -> Optional[_AttributeType]:
         try:
@@ -99,26 +99,26 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
                 return _AttributeType(_type)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def put_entity_type(self, label: str) -> _EntityType:
         try:
             return _EntityType(concepts_put_entity_type(self.native_transaction, _not_blank_label(label)))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def put_relation_type(self, label: str) -> _RelationType:
         try:
             return _RelationType(concepts_put_relation_type(self.native_transaction, _not_blank_label(label)))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def put_attribute_type(self, label: str, value_type: ValueType) -> _AttributeType:
         try:
             return _AttributeType(concepts_put_attribute_type(self.native_transaction, _not_blank_label(label),
                                                               value_type.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_entity(self, iid: str) -> Optional[_Entity]:
         try:
@@ -126,7 +126,7 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
                 return _Entity(concept)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relation(self, iid: str) -> Optional[_Relation]:
         try:
@@ -134,7 +134,7 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
                 return _Relation(concept)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_attribute(self, iid: str) -> Optional[_Attribute]:
         try:
@@ -142,11 +142,11 @@ class _ConceptManager(ConceptManager, NativeWrapper[NativeTransaction]):
                 return _Attribute(concept)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_schema_exception(self) -> list[TypeDBException]:
         try:
             return [TypeDBException(schema_exception_code(e), schema_exception_message(e))
                     for e in concepts_get_schema_exceptions(self.native_transaction)]
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/concept/thing/attribute.py
+++ b/python/typedb/concept/thing/attribute.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 from typing import Any, Iterator, Mapping, Optional, TYPE_CHECKING, Union
 
 from typedb.native_driver_wrapper import attribute_get_type, attribute_get_value, attribute_get_owners, \
-    concept_iterator_next
+    concept_iterator_next, TypeDBDriverExceptionNative
 
 from typedb.api.concept.thing.attribute import Attribute
 from typedb.api.concept.value.value import ValueType
+from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.concept.concept_factory import wrap_attribute_type, wrap_thing, wrap_value
 from typedb.concept.thing.thing import _Thing
@@ -88,6 +89,10 @@ class _Attribute(Attribute, _Thing):
         return {"type": self.get_type().get_label().scoped_name()} | self._value().to_json()
 
     def get_owners(self, transaction: _Transaction, owner_type: Optional[_ThingType] = None) -> Iterator[Any]:
-        return map(wrap_thing, IteratorWrapper(attribute_get_owners(transaction.native_object, self.native_object,
-                                                                    owner_type.native_object if owner_type else None),
-                                               concept_iterator_next))
+        try:
+            return map(wrap_thing,
+                       IteratorWrapper(attribute_get_owners(transaction.native_object, self.native_object,
+                                                            owner_type.native_object if owner_type else None),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/concept/thing/attribute.py
+++ b/python/typedb/concept/thing/attribute.py
@@ -95,4 +95,4 @@ class _Attribute(Attribute, _Thing):
                                                             owner_type.native_object if owner_type else None),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/concept/thing/relation.py
+++ b/python/typedb/concept/thing/relation.py
@@ -25,9 +25,11 @@ from typing import Iterator, Any, TYPE_CHECKING
 
 from typedb.native_driver_wrapper import relation_get_type, relation_add_role_player, relation_remove_role_player, \
     relation_get_players_by_role_type, relation_get_role_players, role_player_get_role_type, \
-    role_player_get_player, relation_get_relating, concept_iterator_next, role_player_iterator_next
+    role_player_get_player, relation_get_relating, concept_iterator_next, role_player_iterator_next, \
+    TypeDBDriverExceptionNative
 
 from typedb.api.concept.thing.relation import Relation
+from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.concept.concept_factory import wrap_relation_type, wrap_role_type, wrap_thing
 from typedb.concept.thing.thing import _Thing
@@ -44,30 +46,46 @@ class _Relation(Relation, _Thing):
         return wrap_relation_type(relation_get_type(self.native_object))
 
     def add_player(self, transaction: _Transaction, role_type: _RoleType, player: _Thing) -> None:
-        relation_add_role_player(transaction.native_object, self.native_object,
-                                 role_type.native_object, player.native_object)
+        try:
+            relation_add_role_player(transaction.native_object, self.native_object,
+                                     role_type.native_object, player.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def remove_player(self, transaction: _Transaction, role_type: _RoleType, player: _Thing) -> None:
-        relation_remove_role_player(transaction.native_object, self.native_object,
-                                    role_type.native_object, player.native_object)
+        try:
+            relation_remove_role_player(transaction.native_object, self.native_object,
+                                        role_type.native_object, player.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_players_by_role_type(self, transaction: _Transaction, *role_types: _RoleType) -> Iterator[Any]:
-        native_role_types = [rt.native_object for rt in role_types]
-        return map(wrap_thing, IteratorWrapper(relation_get_players_by_role_type(transaction.native_object,
-                                                                                 self.native_object,
-                                                                                 native_role_types),
-                                               concept_iterator_next))
+        try:
+            native_role_types = [rt.native_object for rt in role_types]
+            return map(wrap_thing, IteratorWrapper(relation_get_players_by_role_type(transaction.native_object,
+                                                                                     self.native_object,
+                                                                                     native_role_types),
+                                                   concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_players(self, transaction: _Transaction) -> dict[_RoleType, list[_Thing]]:
-        role_players = {}
-        for role_player in IteratorWrapper(relation_get_role_players(transaction.native_object, self.native_object),
-                                           role_player_iterator_next):
-            role = wrap_role_type(role_player_get_role_type(role_player))
-            player = wrap_thing(role_player_get_player(role_player))
-            role_players.setdefault(role, [])
-            role_players[role].append(player)
-        return role_players
+        try:
+            role_players = {}
+            for role_player in IteratorWrapper(relation_get_role_players(transaction.native_object, self.native_object),
+                                               role_player_iterator_next):
+                role = wrap_role_type(role_player_get_role_type(role_player))
+                player = wrap_thing(role_player_get_player(role_player))
+                role_players.setdefault(role, [])
+                role_players[role].append(player)
+            return role_players
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relating(self, transaction: _Transaction) -> Iterator[_RoleType]:
-        return map(wrap_role_type, IteratorWrapper(relation_get_relating(transaction.native_object, self.native_object),
-                                                   concept_iterator_next))
+        try:
+            return map(wrap_role_type, IteratorWrapper(relation_get_relating(transaction.native_object,
+                                                                             self.native_object),
+                                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/concept/thing/relation.py
+++ b/python/typedb/concept/thing/relation.py
@@ -50,14 +50,14 @@ class _Relation(Relation, _Thing):
             relation_add_role_player(transaction.native_object, self.native_object,
                                      role_type.native_object, player.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def remove_player(self, transaction: _Transaction, role_type: _RoleType, player: _Thing) -> None:
         try:
             relation_remove_role_player(transaction.native_object, self.native_object,
                                         role_type.native_object, player.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_players_by_role_type(self, transaction: _Transaction, *role_types: _RoleType) -> Iterator[Any]:
         try:
@@ -67,7 +67,7 @@ class _Relation(Relation, _Thing):
                                                                                      native_role_types),
                                                    concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_players(self, transaction: _Transaction) -> dict[_RoleType, list[_Thing]]:
         try:
@@ -80,7 +80,7 @@ class _Relation(Relation, _Thing):
                 role_players[role].append(player)
             return role_players
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relating(self, transaction: _Transaction) -> Iterator[_RoleType]:
         try:
@@ -88,4 +88,4 @@ class _Relation(Relation, _Thing):
                                                                              self.native_object),
                                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/concept/thing/thing.py
+++ b/python/typedb/concept/thing/thing.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import thing_get_iid, thing_get_is_inferred, t
     thing_get_playing, thing_set_has, thing_unset_has, thing_delete, thing_is_deleted, concept_iterator_next
 
 from typedb.api.concept.thing.thing import Thing
-from typedb.common.exception import TypeDBDriverExceptionExt, GET_HAS_WITH_MULTIPLE_FILTERS
+from typedb.common.exception import TypeDBDriverException, GET_HAS_WITH_MULTIPLE_FILTERS
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.concept.concept import _Concept
 from typedb.concept.concept_factory import wrap_attribute, wrap_relation, wrap_role_type
@@ -58,7 +58,7 @@ class _Thing(Thing, _Concept, ABC):
                 annotations: set[Annotation] = frozenset()
                 ) -> Iterator[_Attribute]:
         if [bool(attribute_type), bool(attribute_types), bool(annotations)].count(True) > 1:
-            raise TypeDBDriverExceptionExt.of(GET_HAS_WITH_MULTIPLE_FILTERS)
+            raise TypeDBDriverException.of(GET_HAS_WITH_MULTIPLE_FILTERS)
         if attribute_type:
             attribute_types = [attribute_type]
         native_attribute_types = [type_.native_object for type_ in attribute_types]

--- a/python/typedb/concept/thing/thing.py
+++ b/python/typedb/concept/thing/thing.py
@@ -70,7 +70,7 @@ class _Thing(Thing, _Concept, ABC):
                                                      native_attribute_types, native_annotations),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relations(self, transaction: _Transaction, *role_types: _RoleType) -> Iterator[_Relation]:
         try:
@@ -80,7 +80,7 @@ class _Thing(Thing, _Concept, ABC):
                                                            native_role_types),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_playing(self, transaction: _Transaction) -> Iterator[_RoleType]:
         try:
@@ -88,31 +88,31 @@ class _Thing(Thing, _Concept, ABC):
                        IteratorWrapper(thing_get_playing(transaction.native_object, self.native_object),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def set_has(self, transaction: _Transaction, attribute: _Attribute) -> None:
         try:
             thing_set_has(transaction.native_object, self.native_object, attribute.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def unset_has(self, transaction: _Transaction, attribute: _Attribute) -> None:
         try:
             thing_unset_has(transaction.native_object, self.native_object, attribute.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def delete(self, transaction: _Transaction) -> None:
         try:
             thing_delete(transaction.native_object, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def is_deleted(self, transaction: _Transaction) -> bool:
         try:
             return thing_is_deleted(transaction.native_object, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def __repr__(self):
         return "%s[%s:%s]" % (type(self).__name__, self.get_type().get_label(), self.get_iid())

--- a/python/typedb/concept/type/attribute_type.py
+++ b/python/typedb/concept/type/attribute_type.py
@@ -67,7 +67,7 @@ class _AttributeType(AttributeType, _ThingType):
             attribute_type_set_supertype(transaction.native_object, self.native_object,
                                          super_attribute_type.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_AttributeType]:
         try:
@@ -75,7 +75,7 @@ class _AttributeType(AttributeType, _ThingType):
                 return _AttributeType(res)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_AttributeType]:
         try:
@@ -83,7 +83,7 @@ class _AttributeType(AttributeType, _ThingType):
                        IteratorWrapper(attribute_type_get_supertypes(transaction.native_object, self.native_object),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_AttributeType]:
@@ -93,7 +93,7 @@ class _AttributeType(AttributeType, _ThingType):
                                                                    transitivity.value),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_subtypes_with_value_type(self, transaction: _Transaction, value_type: ValueType,
                                      transitivity: Transitivity = Transitivity.TRANSITIVE
@@ -106,7 +106,7 @@ class _AttributeType(AttributeType, _ThingType):
                                                                                    transitivity.value),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                       ) -> Iterator[_Attribute]:
@@ -116,7 +116,7 @@ class _AttributeType(AttributeType, _ThingType):
                                                                     transitivity.value),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_owners(self, transaction: _Transaction,
                    annotations: Optional[set[Annotation]] = None,
@@ -128,14 +128,14 @@ class _AttributeType(AttributeType, _ThingType):
                                                                  transitivity.value, annotations_array),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def put(self, transaction: _Transaction, value: Union[Value, bool, int, float, str, datetime]) -> _Attribute:
         try:
             return wrap_attribute(attribute_type_put(transaction.native_object, self.native_object,
                                                      _Value.of(value).native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get(self, transaction: _Transaction, value: Union[Value, bool, int, float, str, datetime]
             ) -> Optional[_Attribute]:
@@ -144,22 +144,22 @@ class _AttributeType(AttributeType, _ThingType):
                 return wrap_attribute(res)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_regex(self, transaction: _Transaction) -> str:
         try:
             return attribute_type_get_regex(transaction.native_object, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def set_regex(self, transaction: _Transaction, regex: str) -> None:
         try:
             attribute_type_set_regex(transaction.native_object, self.native_object, regex)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def unset_regex(self, transaction: _Transaction) -> None:
         try:
             attribute_type_unset_regex(transaction.native_object, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/concept/type/attribute_type.py
+++ b/python/typedb/concept/type/attribute_type.py
@@ -28,10 +28,11 @@ from typedb.native_driver_wrapper import attribute_type_set_supertype, attribute
     attribute_type_get_supertypes, attribute_type_get_subtypes, attribute_type_get_subtypes_with_value_type, \
     attribute_type_get_instances, attribute_type_get_owners, attribute_type_put, attribute_type_get, \
     attribute_type_get_regex, attribute_type_set_regex, attribute_type_unset_regex, attribute_type_get_value_type, \
-    concept_iterator_next
+    concept_iterator_next, TypeDBDriverExceptionNative
 
 from typedb.api.concept.type.attribute_type import AttributeType
 from typedb.api.concept.value.value import ValueType
+from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.transitivity import Transitivity
 from typedb.concept.concept_factory import wrap_attribute, wrap_thing_type
@@ -62,67 +63,103 @@ class _AttributeType(AttributeType, _ThingType):
         return super(_AttributeType, self).__hash__()
 
     def set_supertype(self, transaction: _Transaction, super_attribute_type: _AttributeType) -> None:
-        attribute_type_set_supertype(transaction.native_object, self.native_object,
-                                     super_attribute_type.native_object)
+        try:
+            attribute_type_set_supertype(transaction.native_object, self.native_object,
+                                         super_attribute_type.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_AttributeType]:
-        if res := attribute_type_get_supertype(transaction.native_object, self.native_object):
-            return _AttributeType(res)
-        return None
+        try:
+            if res := attribute_type_get_supertype(transaction.native_object, self.native_object):
+                return _AttributeType(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_AttributeType]:
-        return map(_AttributeType,
-                   IteratorWrapper(attribute_type_get_supertypes(transaction.native_object, self.native_object),
-                                   concept_iterator_next))
+        try:
+            return map(_AttributeType,
+                       IteratorWrapper(attribute_type_get_supertypes(transaction.native_object, self.native_object),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_AttributeType]:
-        return map(_AttributeType,
-                   IteratorWrapper(attribute_type_get_subtypes(transaction.native_object, self.native_object,
-                                                               transitivity.value),
-                                   concept_iterator_next))
+        try:
+            return map(_AttributeType,
+                       IteratorWrapper(attribute_type_get_subtypes(transaction.native_object, self.native_object,
+                                                                   transitivity.value),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_subtypes_with_value_type(self, transaction: _Transaction, value_type: ValueType,
                                      transitivity: Transitivity = Transitivity.TRANSITIVE
                                      ) -> Iterator[_AttributeType]:
-        return map(_AttributeType,
-                   IteratorWrapper(attribute_type_get_subtypes_with_value_type(transaction.native_object,
-                                                                               self.native_object,
-                                                                               value_type.native_object,
-                                                                               transitivity.value),
-                                   concept_iterator_next))
+        try:
+            return map(_AttributeType,
+                       IteratorWrapper(attribute_type_get_subtypes_with_value_type(transaction.native_object,
+                                                                                   self.native_object,
+                                                                                   value_type.native_object,
+                                                                                   transitivity.value),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                       ) -> Iterator[_Attribute]:
-        return map(wrap_attribute,
-                   IteratorWrapper(attribute_type_get_instances(transaction.native_object, self.native_object,
-                                                                transitivity.value),
-                                   concept_iterator_next))
+        try:
+            return map(wrap_attribute,
+                       IteratorWrapper(attribute_type_get_instances(transaction.native_object, self.native_object,
+                                                                    transitivity.value),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_owners(self, transaction: _Transaction,
                    annotations: Optional[set[Annotation]] = None,
                    transitivity: Transitivity = Transitivity.TRANSITIVE) -> Iterator[Any]:
-        annotations_array = [anno.native_object for anno in annotations] if annotations else []
-        return map(wrap_thing_type,
-                   IteratorWrapper(attribute_type_get_owners(transaction.native_object, self.native_object,
-                                                             transitivity.value, annotations_array),
-                                   concept_iterator_next))
+        try:
+            annotations_array = [anno.native_object for anno in annotations] if annotations else []
+            return map(wrap_thing_type,
+                       IteratorWrapper(attribute_type_get_owners(transaction.native_object, self.native_object,
+                                                                 transitivity.value, annotations_array),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def put(self, transaction: _Transaction, value: Union[Value, bool, int, float, str, datetime]) -> _Attribute:
-        return wrap_attribute(attribute_type_put(transaction.native_object, self.native_object,
-                                                 _Value.of(value).native_object))
+        try:
+            return wrap_attribute(attribute_type_put(transaction.native_object, self.native_object,
+                                                     _Value.of(value).native_object))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get(self, transaction: _Transaction, value: Union[Value, bool, int, float, str, datetime]
             ) -> Optional[_Attribute]:
-        if res := attribute_type_get(transaction.native_object, self.native_object, _Value.of(value).native_object):
-            return wrap_attribute(res)
-        return None
+        try:
+            if res := attribute_type_get(transaction.native_object, self.native_object, _Value.of(value).native_object):
+                return wrap_attribute(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_regex(self, transaction: _Transaction) -> str:
-        return attribute_type_get_regex(transaction.native_object, self.native_object)
+        try:
+            return attribute_type_get_regex(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def set_regex(self, transaction: _Transaction, regex: str) -> None:
-        attribute_type_set_regex(transaction.native_object, self.native_object, regex)
+        try:
+            attribute_type_set_regex(transaction.native_object, self.native_object, regex)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def unset_regex(self, transaction: _Transaction) -> None:
-        attribute_type_unset_regex(transaction.native_object, self.native_object)
+        try:
+            attribute_type_unset_regex(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/concept/type/entity_type.py
+++ b/python/typedb/concept/type/entity_type.py
@@ -24,9 +24,11 @@ from __future__ import annotations
 from typing import Iterator, Optional, TYPE_CHECKING
 
 from typedb.native_driver_wrapper import entity_type_create, entity_type_get_subtypes, entity_type_get_instances, \
-    entity_type_get_supertypes, entity_type_get_supertype, entity_type_set_supertype, concept_iterator_next
+    entity_type_get_supertypes, entity_type_get_supertype, entity_type_set_supertype, concept_iterator_next, \
+    TypeDBDriverExceptionNative
 
 from typedb.api.concept.type.entity_type import EntityType
+from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.transitivity import Transitivity
 from typedb.concept.concept_factory import wrap_entity
@@ -40,30 +42,50 @@ if TYPE_CHECKING:
 class _EntityType(EntityType, _ThingType):
 
     def create(self, transaction: _Transaction) -> _Entity:
-        return wrap_entity(entity_type_create(transaction.native_object, self.native_object))
+        try:
+            return wrap_entity(entity_type_create(transaction.native_object, self.native_object))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def set_supertype(self, transaction: _Transaction, super_entity_type: _EntityType) -> None:
-        entity_type_set_supertype(transaction.native_object, self.native_object,
-                                  super_entity_type.native_object)
+        try:
+            entity_type_set_supertype(transaction.native_object, self.native_object,
+                                      super_entity_type.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_EntityType]:
-        if res := entity_type_get_supertype(transaction.native_object, self.native_object):
-            return _EntityType(res)
-        return None
+        try:
+            if res := entity_type_get_supertype(transaction.native_object, self.native_object):
+                return _EntityType(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_EntityType]:
-        return map(_EntityType, IteratorWrapper(entity_type_get_supertypes(transaction.native_object,
-                                                                           self.native_object),
-                                                concept_iterator_next))
+        try:
+            return map(_EntityType, IteratorWrapper(entity_type_get_supertypes(transaction.native_object,
+                                                                               self.native_object),
+                                                    concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_EntityType]:
-        return map(_EntityType, IteratorWrapper(entity_type_get_subtypes(transaction.native_object, self.native_object,
-                                                                         transitivity.value),
-                                                concept_iterator_next))
+        try:
+            return map(_EntityType, IteratorWrapper(entity_type_get_subtypes(transaction.native_object,
+                                                                             self.native_object,
+                                                                             transitivity.value),
+                                                    concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                       ) -> Iterator[_Entity]:
-        return map(wrap_entity, IteratorWrapper(entity_type_get_instances(transaction.native_object, self.native_object,
-                                                                          transitivity.value),
-                                                concept_iterator_next))
+        try:
+            return map(wrap_entity, IteratorWrapper(entity_type_get_instances(transaction.native_object,
+                                                                              self.native_object,
+                                                                              transitivity.value),
+                                                    concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/concept/type/entity_type.py
+++ b/python/typedb/concept/type/entity_type.py
@@ -45,14 +45,14 @@ class _EntityType(EntityType, _ThingType):
         try:
             return wrap_entity(entity_type_create(transaction.native_object, self.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def set_supertype(self, transaction: _Transaction, super_entity_type: _EntityType) -> None:
         try:
             entity_type_set_supertype(transaction.native_object, self.native_object,
                                       super_entity_type.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_EntityType]:
         try:
@@ -60,7 +60,7 @@ class _EntityType(EntityType, _ThingType):
                 return _EntityType(res)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_EntityType]:
         try:
@@ -68,7 +68,7 @@ class _EntityType(EntityType, _ThingType):
                                                                                self.native_object),
                                                     concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_EntityType]:
@@ -78,7 +78,7 @@ class _EntityType(EntityType, _ThingType):
                                                                              transitivity.value),
                                                     concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                       ) -> Iterator[_Entity]:
@@ -88,4 +88,4 @@ class _EntityType(EntityType, _ThingType):
                                                                               transitivity.value),
                                                     concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/concept/type/relation_type.py
+++ b/python/typedb/concept/type/relation_type.py
@@ -26,9 +26,10 @@ from typing import Iterator, Optional, Union, TYPE_CHECKING
 from typedb.native_driver_wrapper import relation_type_create, relation_type_set_supertype, \
     relation_type_get_relates_for_role_label, relation_type_get_relates, relation_type_get_relates_overridden, \
     relation_type_set_relates, relation_type_unset_relates, relation_type_get_supertype, relation_type_get_supertypes, \
-    relation_type_get_subtypes, relation_type_get_instances, concept_iterator_next
+    relation_type_get_subtypes, relation_type_get_instances, concept_iterator_next, TypeDBDriverExceptionNative
 
 from typedb.api.concept.type.relation_type import RelationType
+from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.transitivity import Transitivity
 from typedb.concept.concept_factory import wrap_relation, wrap_role_type
@@ -43,55 +44,86 @@ if TYPE_CHECKING:
 class _RelationType(RelationType, _ThingType):
 
     def create(self, transaction: _Transaction) -> _Relation:
-        return wrap_relation(relation_type_create(transaction.native_object, self.native_object))
+        try:
+            return wrap_relation(relation_type_create(transaction.native_object, self.native_object))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                       ) -> Iterator[_Relation]:
-        return map(wrap_relation,
-                   IteratorWrapper(relation_type_get_instances(transaction.native_object,
-                                                               self.native_object, transitivity.value),
-                                   concept_iterator_next))
+        try:
+            return map(wrap_relation,
+                       IteratorWrapper(relation_type_get_instances(transaction.native_object,
+                                                                   self.native_object, transitivity.value),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relates(self, transaction: _Transaction, role_label: Optional[str] = None,
                     transitivity: Transitivity = Transitivity.TRANSITIVE) \
             -> Union[Optional[_RoleType], Iterator[_RoleType]]:
-        if role_label:
-            if res := relation_type_get_relates_for_role_label(transaction.native_object,
-                                                               self.native_object, role_label):
-                return wrap_role_type(res)
-            return None
-        return map(wrap_role_type, IteratorWrapper(relation_type_get_relates(transaction.native_object,
-                                                                             self.native_object,
-                                                                             transitivity.value),
-                                                   concept_iterator_next))
+        try:
+            if role_label:
+                if res := relation_type_get_relates_for_role_label(transaction.native_object,
+                                                                   self.native_object, role_label):
+                    return wrap_role_type(res)
+                return None
+            return map(wrap_role_type, IteratorWrapper(relation_type_get_relates(transaction.native_object,
+                                                                                 self.native_object,
+                                                                                 transitivity.value),
+                                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relates_overridden(self, transaction: _Transaction, role_label: str) -> Optional[_RoleType]:
-        if res := relation_type_get_relates_overridden(transaction.native_object, self.native_object, role_label):
-            return wrap_role_type(res)
-        return None
+        try:
+            if res := relation_type_get_relates_overridden(transaction.native_object, self.native_object, role_label):
+                return wrap_role_type(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def set_relates(self, transaction: _Transaction, role_label: str, overridden_label: Optional[str] = None) -> None:
-        relation_type_set_relates(transaction.native_object, self.native_object, role_label, overridden_label)
+        try:
+            relation_type_set_relates(transaction.native_object, self.native_object, role_label, overridden_label)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def unset_relates(self, transaction: _Transaction, role_label: str) -> None:
-        relation_type_unset_relates(transaction.native_object, self.native_object, role_label)
+        try:
+            relation_type_unset_relates(transaction.native_object, self.native_object, role_label)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_RelationType]:
-        return map(_RelationType, IteratorWrapper(relation_type_get_subtypes(transaction.native_object,
-                                                                             self.native_object,
-                                                                             transitivity.value),
-                                                  concept_iterator_next))
+        try:
+            return map(_RelationType, IteratorWrapper(relation_type_get_subtypes(transaction.native_object,
+                                                                                 self.native_object,
+                                                                                 transitivity.value),
+                                                      concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_RelationType]:
-        if res := relation_type_get_supertype(transaction.native_object, self.native_object):
-            return _RelationType(res)
-        return None
+        try:
+            if res := relation_type_get_supertype(transaction.native_object, self.native_object):
+                return _RelationType(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_RelationType]:
-        return map(_RelationType, IteratorWrapper(relation_type_get_supertypes(transaction.native_object,
-                                                                               self.native_object),
-                                                  concept_iterator_next))
+        try:
+            return map(_RelationType, IteratorWrapper(relation_type_get_supertypes(transaction.native_object,
+                                                                                   self.native_object),
+                                                      concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def set_supertype(self, transaction: _Transaction, super_relation_type: _RelationType) -> None:
-        relation_type_set_supertype(transaction.native_object, self.native_object, super_relation_type.native_object)
+        try:
+            relation_type_set_supertype(transaction.native_object, self.native_object,
+                                        super_relation_type.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/concept/type/relation_type.py
+++ b/python/typedb/concept/type/relation_type.py
@@ -47,7 +47,7 @@ class _RelationType(RelationType, _ThingType):
         try:
             return wrap_relation(relation_type_create(transaction.native_object, self.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                       ) -> Iterator[_Relation]:
@@ -57,7 +57,7 @@ class _RelationType(RelationType, _ThingType):
                                                                    self.native_object, transitivity.value),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relates(self, transaction: _Transaction, role_label: Optional[str] = None,
                     transitivity: Transitivity = Transitivity.TRANSITIVE) \
@@ -73,7 +73,7 @@ class _RelationType(RelationType, _ThingType):
                                                                                  transitivity.value),
                                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relates_overridden(self, transaction: _Transaction, role_label: str) -> Optional[_RoleType]:
         try:
@@ -81,19 +81,19 @@ class _RelationType(RelationType, _ThingType):
                 return wrap_role_type(res)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def set_relates(self, transaction: _Transaction, role_label: str, overridden_label: Optional[str] = None) -> None:
         try:
             relation_type_set_relates(transaction.native_object, self.native_object, role_label, overridden_label)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def unset_relates(self, transaction: _Transaction, role_label: str) -> None:
         try:
             relation_type_unset_relates(transaction.native_object, self.native_object, role_label)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_RelationType]:
@@ -103,7 +103,7 @@ class _RelationType(RelationType, _ThingType):
                                                                                  transitivity.value),
                                                       concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_RelationType]:
         try:
@@ -111,7 +111,7 @@ class _RelationType(RelationType, _ThingType):
                 return _RelationType(res)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_RelationType]:
         try:
@@ -119,11 +119,11 @@ class _RelationType(RelationType, _ThingType):
                                                                                    self.native_object),
                                                       concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def set_supertype(self, transaction: _Transaction, super_relation_type: _RelationType) -> None:
         try:
             relation_type_set_supertype(transaction.native_object, self.native_object,
                                         super_relation_type.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/concept/type/role_type.py
+++ b/python/typedb/concept/type/role_type.py
@@ -27,9 +27,10 @@ from typedb.native_driver_wrapper import role_type_is_root, role_type_is_abstrac
     role_type_get_name, role_type_delete, role_type_is_deleted, role_type_set_label, role_type_get_supertype, \
     role_type_get_supertypes, role_type_get_subtypes, role_type_get_relation_instances, \
     role_type_get_player_instances, role_type_get_relation_type, role_type_get_relation_types, \
-    role_type_get_player_types, concept_iterator_next
+    role_type_get_player_types, concept_iterator_next, TypeDBDriverExceptionNative
 
 from typedb.api.concept.type.role_type import RoleType
+from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.label import Label
 from typedb.common.transitivity import Transitivity
@@ -55,54 +56,88 @@ class _RoleType(_Type, RoleType):
         return Label.of(role_type_get_scope(self.native_object), role_type_get_name(self.native_object))
 
     def delete(self, transaction: _Transaction) -> None:
-        role_type_delete(transaction.native_object, self.native_object)
+        try:
+            role_type_delete(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def is_deleted(self, transaction: _Transaction) -> bool:
-        return role_type_is_deleted(transaction.native_object, self.native_object)
+        try:
+            return role_type_is_deleted(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def set_label(self, transaction: _Transaction, new_label: Label) -> None:
-        role_type_set_label(transaction.native_object, self.native_object, new_label)
+        try:
+            role_type_set_label(transaction.native_object, self.native_object, new_label)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_RoleType]:
-        if res := role_type_get_supertype(transaction.native_object, self.native_object):
-            return _RoleType(res)
-        return None
+        try:
+            if res := role_type_get_supertype(transaction.native_object, self.native_object):
+                return _RoleType(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_RoleType]:
-        return map(_RoleType, IteratorWrapper(role_type_get_supertypes(transaction.native_object, self.native_object),
-                                              concept_iterator_next))
+        try:
+            return map(_RoleType, IteratorWrapper(role_type_get_supertypes(transaction.native_object,
+                                                                           self.native_object),
+                                                  concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_RoleType]:
-        return map(_RoleType, IteratorWrapper(role_type_get_subtypes(transaction.native_object, self.native_object,
-                                                                     transitivity.value),
-                                              concept_iterator_next))
+        try:
+            return map(_RoleType, IteratorWrapper(role_type_get_subtypes(transaction.native_object, self.native_object,
+                                                                         transitivity.value),
+                                                  concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relation_type(self, transaction: _Transaction) -> _RelationType:
-        return wrap_relation_type(role_type_get_relation_type(transaction.native_object, self.native_object))
+        try:
+            return wrap_relation_type(role_type_get_relation_type(transaction.native_object, self.native_object))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relation_types(self, transaction: _Transaction) -> Iterator[_RelationType]:
-        return map(wrap_relation_type,
-                   IteratorWrapper(role_type_get_relation_types(transaction.native_object, self.native_object),
-                                   concept_iterator_next))
+        try:
+            return map(wrap_relation_type,
+                       IteratorWrapper(role_type_get_relation_types(transaction.native_object, self.native_object),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_player_types(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                          ) -> Iterator[Any]:
-        return map(wrap_thing_type,
-                   IteratorWrapper(role_type_get_player_types(transaction.native_object, self.native_object,
-                                                              transitivity.value),
-                                   concept_iterator_next))
+        try:
+            return map(wrap_thing_type,
+                       IteratorWrapper(role_type_get_player_types(transaction.native_object, self.native_object,
+                                                                  transitivity.value),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_relation_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                                ) -> Iterator[_Relation]:
-        return map(wrap_relation,
-                   IteratorWrapper(role_type_get_relation_instances(transaction.native_object,
-                                                                    self.native_object, transitivity.value),
-                                   concept_iterator_next))
+        try:
+            return map(wrap_relation,
+                       IteratorWrapper(role_type_get_relation_instances(transaction.native_object,
+                                                                        self.native_object, transitivity.value),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_player_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                              ) -> Iterator[_Thing]:
-        return map(wrap_thing, IteratorWrapper(role_type_get_player_instances(transaction.native_object,
-                                                                              self.native_object,
-                                                                              transitivity.value),
-                                               concept_iterator_next))
+        try:
+            return map(wrap_thing, IteratorWrapper(role_type_get_player_instances(transaction.native_object,
+                                                                                  self.native_object,
+                                                                                  transitivity.value),
+                                                   concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/concept/type/role_type.py
+++ b/python/typedb/concept/type/role_type.py
@@ -59,19 +59,19 @@ class _RoleType(_Type, RoleType):
         try:
             role_type_delete(transaction.native_object, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def is_deleted(self, transaction: _Transaction) -> bool:
         try:
             return role_type_is_deleted(transaction.native_object, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def set_label(self, transaction: _Transaction, new_label: Label) -> None:
         try:
             role_type_set_label(transaction.native_object, self.native_object, new_label)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertype(self, transaction: _Transaction) -> Optional[_RoleType]:
         try:
@@ -79,7 +79,7 @@ class _RoleType(_Type, RoleType):
                 return _RoleType(res)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_supertypes(self, transaction: _Transaction) -> Iterator[_RoleType]:
         try:
@@ -87,7 +87,7 @@ class _RoleType(_Type, RoleType):
                                                                            self.native_object),
                                                   concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_subtypes(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                      ) -> Iterator[_RoleType]:
@@ -96,13 +96,13 @@ class _RoleType(_Type, RoleType):
                                                                          transitivity.value),
                                                   concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relation_type(self, transaction: _Transaction) -> _RelationType:
         try:
             return wrap_relation_type(role_type_get_relation_type(transaction.native_object, self.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relation_types(self, transaction: _Transaction) -> Iterator[_RelationType]:
         try:
@@ -110,7 +110,7 @@ class _RoleType(_Type, RoleType):
                        IteratorWrapper(role_type_get_relation_types(transaction.native_object, self.native_object),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_player_types(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                          ) -> Iterator[Any]:
@@ -120,7 +120,7 @@ class _RoleType(_Type, RoleType):
                                                                   transitivity.value),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_relation_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                                ) -> Iterator[_Relation]:
@@ -130,7 +130,7 @@ class _RoleType(_Type, RoleType):
                                                                         self.native_object, transitivity.value),
                                        concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_player_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                              ) -> Iterator[_Thing]:
@@ -140,4 +140,4 @@ class _RoleType(_Type, RoleType):
                                                                                   transitivity.value),
                                                    concept_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/concept/type/thing_type.py
+++ b/python/typedb/concept/type/thing_type.py
@@ -29,9 +29,10 @@ from typedb.native_driver_wrapper import thing_type_is_root, thing_type_is_abstr
     thing_type_get_label, thing_type_delete, thing_type_is_deleted, thing_type_set_label, thing_type_set_abstract, \
     thing_type_unset_abstract, thing_type_set_plays, thing_type_unset_plays, thing_type_set_owns, thing_type_get_owns, \
     thing_type_get_plays, thing_type_get_owns_overridden, thing_type_unset_owns, thing_type_get_syntax, \
-    thing_type_get_plays_overridden, concept_iterator_next
+    thing_type_get_plays_overridden, concept_iterator_next, TypeDBDriverExceptionNative
 
 from typedb.api.concept.type.thing_type import ThingType
+from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.label import Label
 from typedb.common.transitivity import Transitivity
@@ -53,92 +54,143 @@ class _ThingType(ThingType, _Type, ABC):
         return self
 
     def is_root(self) -> bool:
-        return thing_type_is_root(self.native_object)
+        try:
+            return thing_type_is_root(self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def is_abstract(self) -> bool:
-        return thing_type_is_abstract(self.native_object)
+        try:
+            return thing_type_is_abstract(self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def get_label(self) -> Label:
-        return Label.of(thing_type_get_label(self.native_object))
+        try:
+            return Label.of(thing_type_get_label(self.native_object))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def delete(self, transaction: _Transaction) -> None:
-        thing_type_delete(transaction.native_object, self.native_object)
+        try:
+            thing_type_delete(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def is_deleted(self, transaction: _Transaction) -> bool:
-        return thing_type_is_deleted(transaction.native_object, self.native_object)
+        try:
+            return thing_type_is_deleted(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def set_label(self, transaction: _Transaction, new_label: Label) -> None:
-        thing_type_set_label(transaction.native_object, self.native_object, new_label)
+        try:
+            thing_type_set_label(transaction.native_object, self.native_object, new_label)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     @abstractmethod
     def get_instances(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE):
         pass
 
     def set_abstract(self, transaction: _Transaction) -> None:
-        thing_type_set_abstract(transaction.native_object, self.native_object)
+        try:
+            thing_type_set_abstract(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def unset_abstract(self, transaction: _Transaction) -> None:
-        thing_type_unset_abstract(transaction.native_object, self.native_object)
+        try:
+            thing_type_unset_abstract(transaction.native_object, self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def set_plays(self, transaction: _Transaction,
                   role_type: _RoleType, overridden_role_type: Optional[_RoleType] = None) -> None:
-        thing_type_set_plays(transaction.native_object,
-                             self.native_object, role_type.native_object,
-                             overridden_role_type.native_object if overridden_role_type else None)
+        try:
+            thing_type_set_plays(transaction.native_object,
+                                 self.native_object, role_type.native_object,
+                                 overridden_role_type.native_object if overridden_role_type else None)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def unset_plays(self, transaction: _Transaction, role_type: _RoleType) -> None:
-        thing_type_unset_plays(transaction.native_object, self.native_object, role_type.native_object)
+        try:
+            thing_type_unset_plays(transaction.native_object, self.native_object, role_type.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def set_owns(self, transaction: _Transaction, attribute_type: _AttributeType,
                  overridden_type: Optional[_AttributeType] = None, annotations: Optional[set[Annotation]] = None
                  ) -> None:
-        overridden_type_native = overridden_type.native_object if overridden_type else None
-        annotations_array = [anno.native_object for anno in annotations] if annotations else []
-        thing_type_set_owns(
-            transaction.native_object,
-            self.native_object,
-            attribute_type.native_object,
-            overridden_type_native,
-            annotations_array,
-        )
+        try:
+            overridden_type_native = overridden_type.native_object if overridden_type else None
+            annotations_array = [anno.native_object for anno in annotations] if annotations else []
+            thing_type_set_owns(
+                transaction.native_object,
+                self.native_object,
+                attribute_type.native_object,
+                overridden_type_native,
+                annotations_array,
+            )
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def unset_owns(self, transaction: _Transaction, attribute_type: _AttributeType) -> None:
-        thing_type_unset_owns(transaction.native_object,
-                              self.native_object, attribute_type.native_object)
+        try:
+            thing_type_unset_owns(transaction.native_object,
+                                  self.native_object, attribute_type.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def get_plays(self, transaction: _Transaction, transitivity: Transitivity = Transitivity.TRANSITIVE
                   ) -> Iterator[_RoleType]:
-        return map(wrap_role_type,
-                   IteratorWrapper(thing_type_get_plays(transaction.native_object, self.native_object,
-                                                        transitivity.value),
-                                   concept_iterator_next))
+        try:
+            return map(wrap_role_type,
+                       IteratorWrapper(thing_type_get_plays(transaction.native_object, self.native_object,
+                                                            transitivity.value),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def get_plays_overridden(self, transaction: _Transaction, role_type: _RoleType) -> Optional[_RoleType]:
-        if res := thing_type_get_plays_overridden(transaction.native_object,
-                                                  self.native_object, role_type.native_object):
-            return wrap_role_type(res)
-        return None
+        try:
+            if res := thing_type_get_plays_overridden(transaction.native_object,
+                                                      self.native_object, role_type.native_object):
+                return wrap_role_type(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def get_owns(self, transaction: _Transaction, value_type: Optional[ValueType] = None,
                  transitivity: Transitivity = Transitivity.TRANSITIVE, annotations: Optional[set[Annotation]] = None
                  ) -> Iterator[AttributeType]:
-        return map(wrap_attribute_type,
-                   IteratorWrapper(thing_type_get_owns(transaction.native_object,
-                                                       self.native_object,
-                                                       value_type.native_object if value_type else None,
-                                                       transitivity.value,
-                                                       [anno.native_object for anno in annotations] if annotations
-                                                       else []),
-                                   concept_iterator_next))
+        try:
+            return map(wrap_attribute_type,
+                       IteratorWrapper(thing_type_get_owns(transaction.native_object,
+                                                           self.native_object,
+                                                           value_type.native_object if value_type else None,
+                                                           transitivity.value,
+                                                           [anno.native_object for anno in annotations] if annotations
+                                                           else []),
+                                       concept_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def get_owns_overridden(self, transaction: _Transaction, attribute_type: _AttributeType) -> Optional[AttributeType]:
-        if res := thing_type_get_owns_overridden(transaction.native_object,
-                                                 self.native_object, attribute_type.native_object):
-            return wrap_attribute_type(res)
-        return None
+        try:
+            if res := thing_type_get_owns_overridden(transaction.native_object,
+                                                     self.native_object, attribute_type.native_object):
+                return wrap_attribute_type(res)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
     def get_syntax(self, transaction: _Transaction) -> str:
-        return thing_type_get_syntax(transaction.native_object, self.native_object, )
+        try:
+            return thing_type_get_syntax(transaction.native_object, self.native_object, )
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e)
 
 
 class _Root(_ThingType):

--- a/python/typedb/concept/value/value.py
+++ b/python/typedb/concept/value/value.py
@@ -39,7 +39,7 @@ class _Value(Value, _Concept):
 
     @singledispatchmethod
     def of(value):
-        raise TypeDBDriverException.of(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException(UNEXPECTED_NATIVE_VALUE)
 
     @of.register
     def _(value: bool):

--- a/python/typedb/concept/value/value.py
+++ b/python/typedb/concept/value/value.py
@@ -31,7 +31,7 @@ from typedb.native_driver_wrapper import value_new_boolean, value_new_long, valu
     value_get_date_time_as_millis
 
 from typedb.api.concept.value.value import Value, ValueType
-from typedb.common.exception import TypeDBDriverExceptionExt, UNEXPECTED_NATIVE_VALUE, ILLEGAL_STATE, MISSING_VALUE
+from typedb.common.exception import TypeDBDriverException, UNEXPECTED_NATIVE_VALUE, ILLEGAL_STATE, MISSING_VALUE
 from typedb.concept.concept import _Concept
 
 
@@ -39,7 +39,7 @@ class _Value(Value, _Concept):
 
     @singledispatchmethod
     def of(value):
-        raise TypeDBDriverExceptionExt.of(UNEXPECTED_NATIVE_VALUE)
+        raise TypeDBDriverException.of(UNEXPECTED_NATIVE_VALUE)
 
     @of.register
     def _(value: bool):
@@ -56,7 +56,7 @@ class _Value(Value, _Concept):
     @of.register
     def _(value: str):
         if not value:
-            raise TypeDBDriverExceptionExt(MISSING_VALUE)
+            raise TypeDBDriverException(MISSING_VALUE)
         return _Value(value_new_string(value))
 
     @of.register
@@ -79,7 +79,7 @@ class _Value(Value, _Concept):
         elif self.is_datetime():
             return ValueType.DATETIME
         else:
-            raise TypeDBDriverExceptionExt(ILLEGAL_STATE)
+            raise TypeDBDriverException(ILLEGAL_STATE)
 
     def get(self) -> Union[bool, int, float, str, datetime]:
         if self.is_boolean():
@@ -93,7 +93,7 @@ class _Value(Value, _Concept):
         elif self.is_datetime():
             return self.as_datetime()
         else:
-            raise TypeDBDriverExceptionExt(ILLEGAL_STATE)
+            raise TypeDBDriverException(ILLEGAL_STATE)
 
     def is_boolean(self) -> bool:
         return value_is_boolean(self.native_object)

--- a/python/typedb/connection/database.py
+++ b/python/typedb/connection/database.py
@@ -29,7 +29,7 @@ from typedb.native_driver_wrapper import database_get_name, database_schema, dat
     database_get_preferred_replica_info, replica_info_iterator_next, Database as NativeDatabase
 
 from typedb.api.connection.database import Database, Replica
-from typedb.common.exception import TypeDBDriverExceptionExt, DATABASE_DELETED, NULL_NATIVE_OBJECT
+from typedb.common.exception import TypeDBDriverException, DATABASE_DELETED, NULL_NATIVE_OBJECT
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
 
@@ -38,13 +38,13 @@ class _Database(Database, NativeWrapper[NativeDatabase]):
 
     def __init__(self, database: NativeDatabase):
         if not database:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(database)
         self._name = database_get_name(database)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(DATABASE_DELETED)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(DATABASE_DELETED)
 
     @property
     def name(self) -> str:

--- a/python/typedb/connection/database.py
+++ b/python/typedb/connection/database.py
@@ -57,33 +57,33 @@ class _Database(Database, NativeWrapper[NativeDatabase]):
         try:
             return database_schema(self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def rule_schema(self) -> str:
         try:
             return database_rule_schema(self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def type_schema(self) -> str:
         try:
             return database_type_schema(self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def delete(self) -> None:
         try:
             self.native_object.thisown = 0
             database_delete(self._native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def replicas(self) -> set[Replica]:
         try:
             repl_iter = IteratorWrapper(database_get_replicas_info(self.native_object), replica_info_iterator_next)
             return set(_Database.Replica(replica_info) for replica_info in repl_iter)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def primary_replica(self) -> Optional[Replica]:
         if res := database_get_primary_replica_info(self.native_object):

--- a/python/typedb/connection/database_manager.py
+++ b/python/typedb/connection/database_manager.py
@@ -27,7 +27,7 @@ from typedb.native_driver_wrapper import databases_contains, databases_create, d
     databases_all, database_iterator_next, DatabaseManager as NativeDatabaseManager
 
 from typedb.api.connection.database import DatabaseManager
-from typedb.common.exception import TypeDBDriverExceptionExt, DATABASE_DELETED, ILLEGAL_STATE, MISSING_DB_NAME
+from typedb.common.exception import TypeDBDriverException, DATABASE_DELETED, ILLEGAL_STATE, MISSING_DB_NAME
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.connection.database import _Database
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 def _not_blank(name: str) -> str:
     if not name or name.isspace():
-        raise TypeDBDriverExceptionExt.of(MISSING_DB_NAME)
+        raise TypeDBDriverException.of(MISSING_DB_NAME)
     return name
 
 
@@ -48,12 +48,12 @@ class _DatabaseManager(DatabaseManager, NativeWrapper[NativeDatabaseManager]):
         super().__init__(database_manager_new(connection))
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def get(self, name: str) -> _Database:
         if not self.contains(name):
-            raise TypeDBDriverExceptionExt.of(DATABASE_DELETED, name)
+            raise TypeDBDriverException.of(DATABASE_DELETED, name)
         return _Database(databases_get(self.native_object, name))
 
     def contains(self, name: str) -> bool:

--- a/python/typedb/connection/database_manager.py
+++ b/python/typedb/connection/database_manager.py
@@ -57,22 +57,22 @@ class _DatabaseManager(DatabaseManager, NativeWrapper[NativeDatabaseManager]):
                 raise TypeDBDriverException(DATABASE_DELETED, name)
             return _Database(databases_get(self.native_object, name))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def contains(self, name: str) -> bool:
         try:
             return databases_contains(self.native_object, _not_blank(name))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def create(self, name: str) -> None:
         try:
             databases_create(self.native_object, _not_blank(name))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def all(self) -> list[_Database]:
         try:
             return list(map(_Database, IteratorWrapper(databases_all(self.native_object), database_iterator_next)))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -47,12 +47,12 @@ class _Driver(TypeDBDriver, NativeWrapper[NativeConnection]):
             try:
                 native_connection = connection_open_enterprise(addresses, credential.native_object)
             except TypeDBDriverExceptionNative as e:
-                raise TypeDBDriverException(e)
+                raise TypeDBDriverException.of(e)
         else:
             try:
                 native_connection = connection_open_core(addresses[0])
             except TypeDBDriverExceptionNative as e:
-                raise TypeDBDriverException(e)
+                raise TypeDBDriverException.of(e)
         super().__init__(native_connection)
         self._database_manager = _DatabaseManager(native_connection)
         self._user_manager = _UserManager(native_connection)

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import connection_open_core, connection_open_e
 
 from typedb.api.connection.driver import TypeDBDriver
 from typedb.api.connection.options import TypeDBOptions
-from typedb.common.exception import TypeDBDriverExceptionExt, DRIVER_CLOSED
+from typedb.common.exception import TypeDBDriverException, DRIVER_CLOSED
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.connection.database_manager import _DatabaseManager
 from typedb.connection.session import _Session
@@ -52,8 +52,8 @@ class _Driver(TypeDBDriver, NativeWrapper[NativeConnection]):
         self._user_manager = _UserManager(native_connection)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(DRIVER_CLOSED)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(DRIVER_CLOSED)
 
     @property
     def _native_connection(self) -> NativeConnection:

--- a/python/typedb/connection/session.py
+++ b/python/typedb/connection/session.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import session_new, session_on_close, session_
 
 from typedb.api.connection.options import TypeDBOptions
 from typedb.api.connection.session import TypeDBSession
-from typedb.common.exception import TypeDBDriverExceptionExt, SESSION_CLOSED
+from typedb.common.exception import TypeDBDriverException, SESSION_CLOSED
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.connection.transaction import _Transaction
 
@@ -49,8 +49,8 @@ class _Session(TypeDBSession, NativeWrapper[NativeSession]):
         super().__init__(session_new(database_manager.native_object, database_name, session_type.value, options.native_object))
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(SESSION_CLOSED)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(SESSION_CLOSED)
 
     def is_open(self) -> bool:
         return session_is_open(self.native_object)

--- a/python/typedb/connection/session.py
+++ b/python/typedb/connection/session.py
@@ -49,7 +49,7 @@ class _Session(TypeDBSession, NativeWrapper[NativeSession]):
         try:
             super().__init__(session_new(database_manager.native_object, database_name, session_type.value, options.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:

--- a/python/typedb/connection/transaction.py
+++ b/python/typedb/connection/transaction.py
@@ -51,7 +51,7 @@ class _Transaction(TypeDBTransaction, NativeWrapper[NativeTransaction]):
         try:
             super().__init__(transaction_new(session.native_object, transaction_type.value, options.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
         self._concept_manager = _ConceptManager(self._native_object)
         self._query_manager = _QueryManager(self._native_object)
         self._logic_manager = _LogicManager(self._native_object)
@@ -102,13 +102,13 @@ class _Transaction(TypeDBTransaction, NativeWrapper[NativeTransaction]):
             self.native_object.thisown = 0
             transaction_commit(self._native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def rollback(self):
         try:
             transaction_rollback(self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def close(self):
         if self._native_object.thisown:

--- a/python/typedb/connection/transaction.py
+++ b/python/typedb/connection/transaction.py
@@ -29,7 +29,7 @@ from typedb.native_driver_wrapper import error_code, error_message, transaction_
 
 from typedb.api.connection.options import TypeDBOptions
 from typedb.api.connection.transaction import TypeDBTransaction
-from typedb.common.exception import TypeDBDriverExceptionExt, TRANSACTION_CLOSED, TypeDBException
+from typedb.common.exception import TypeDBDriverException, TRANSACTION_CLOSED, TypeDBException
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.concept.concept_manager import _ConceptManager
 from typedb.logic.logic_manager import _LogicManager
@@ -54,8 +54,8 @@ class _Transaction(TypeDBTransaction, NativeWrapper[NativeTransaction]):
         self._logic_manager = _LogicManager(self._native_object)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(TRANSACTION_CLOSED)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(TRANSACTION_CLOSED)
 
     @property
     def transaction_type(self) -> TransactionType:

--- a/python/typedb/logic/explanation.py
+++ b/python/typedb/logic/explanation.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import explanation_get_rule, explanation_get_c
     explanation_get_mapping, explanation_to_string, explanation_equals, Explanation as NativeExplanation
 
 from typedb.api.logic.explanation import Explanation
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_STATE, MISSING_VARIABLE, NULL_NATIVE_OBJECT
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE, MISSING_VARIABLE, NULL_NATIVE_OBJECT
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.concept.answer.concept_map import _ConceptMap
@@ -43,12 +43,12 @@ class _Explanation(Explanation, NativeWrapper[NativeExplanation]):
 
     def __init__(self, explanation: NativeExplanation):
         if not explanation:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(explanation)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def rule(self) -> Rule:
         return _Rule(explanation_get_rule(self.native_object))
@@ -64,7 +64,7 @@ class _Explanation(Explanation, NativeWrapper[NativeExplanation]):
 
     def query_variable_mapping(self, var: str) -> set[str]:
         if not var:
-            raise TypeDBDriverExceptionExt(MISSING_VARIABLE)
+            raise TypeDBDriverException(MISSING_VARIABLE)
         return set(IteratorWrapper(explanation_get_mapping(self.native_object, var), string_iterator_next))
 
     def __repr__(self):

--- a/python/typedb/logic/explanation.py
+++ b/python/typedb/logic/explanation.py
@@ -48,7 +48,7 @@ class _Explanation(Explanation, NativeWrapper[NativeExplanation]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def rule(self) -> Rule:
         return _Rule(explanation_get_rule(self.native_object))

--- a/python/typedb/logic/logic_manager.py
+++ b/python/typedb/logic/logic_manager.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import Optional
 
 from typedb.native_driver_wrapper import logic_manager_get_rule, logic_manager_get_rules, rule_iterator_next, \
-    logic_manager_put_rule, Transaction as NativeTransaction
+    logic_manager_put_rule, Transaction as NativeTransaction, TypeDBDriverExceptionNative
 
 from typedb.api.logic.logic_manager import LogicManager
 from typedb.api.logic.rule import Rule
@@ -36,7 +36,7 @@ from typedb.logic.rule import _Rule
 
 def _not_blank_label(label: str) -> str:
     if not label or label.isspace():
-        raise TypeDBDriverException.of(MISSING_LABEL)
+        raise TypeDBDriverException(MISSING_LABEL)
     return label
 
 
@@ -47,19 +47,28 @@ class _LogicManager(LogicManager, NativeWrapper[NativeTransaction]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(TRANSACTION_CLOSED)
+        return TypeDBDriverException(TRANSACTION_CLOSED)
 
     @property
     def _native_transaction(self) -> NativeTransaction:
         return self.native_object
 
     def get_rule(self, label: str) -> Optional[Rule]:
-        if rule := logic_manager_get_rule(self._native_transaction, _not_blank_label(label)):
-            return _Rule(rule)
-        return None
+        try:
+            if rule := logic_manager_get_rule(self._native_transaction, _not_blank_label(label)):
+                return _Rule(rule)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_rules(self):
-        return map(_Rule, IteratorWrapper(logic_manager_get_rules(self._native_transaction), rule_iterator_next))
+        try:
+            return map(_Rule, IteratorWrapper(logic_manager_get_rules(self._native_transaction), rule_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def put_rule(self, label: str, when: str, then: str):
-        return _Rule(logic_manager_put_rule(self._native_transaction, _not_blank_label(label), when, then))
+        try:
+            return _Rule(logic_manager_put_rule(self._native_transaction, _not_blank_label(label), when, then))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/logic/logic_manager.py
+++ b/python/typedb/logic/logic_manager.py
@@ -28,7 +28,7 @@ from typedb.native_driver_wrapper import logic_manager_get_rule, logic_manager_g
 
 from typedb.api.logic.logic_manager import LogicManager
 from typedb.api.logic.rule import Rule
-from typedb.common.exception import TypeDBDriverExceptionExt, MISSING_LABEL, TRANSACTION_CLOSED
+from typedb.common.exception import TypeDBDriverException, MISSING_LABEL, TRANSACTION_CLOSED
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.logic.rule import _Rule
@@ -36,7 +36,7 @@ from typedb.logic.rule import _Rule
 
 def _not_blank_label(label: str) -> str:
     if not label or label.isspace():
-        raise TypeDBDriverExceptionExt.of(MISSING_LABEL)
+        raise TypeDBDriverException.of(MISSING_LABEL)
     return label
 
 
@@ -46,8 +46,8 @@ class _LogicManager(LogicManager, NativeWrapper[NativeTransaction]):
         super().__init__(transaction)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(TRANSACTION_CLOSED)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(TRANSACTION_CLOSED)
 
     @property
     def _native_transaction(self) -> NativeTransaction:

--- a/python/typedb/logic/logic_manager.py
+++ b/python/typedb/logic/logic_manager.py
@@ -59,16 +59,16 @@ class _LogicManager(LogicManager, NativeWrapper[NativeTransaction]):
                 return _Rule(rule)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_rules(self):
         try:
             return map(_Rule, IteratorWrapper(logic_manager_get_rules(self._native_transaction), rule_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def put_rule(self, label: str, when: str, then: str):
         try:
             return _Rule(logic_manager_put_rule(self._native_transaction, _not_blank_label(label), when, then))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/logic/rule.py
+++ b/python/typedb/logic/rule.py
@@ -58,7 +58,7 @@ class _Rule(Rule, NativeWrapper[NativeRule]):
         try:
             rule_set_label(transaction.logic, self.native_object, new_label)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     @property
     def when(self) -> str:
@@ -72,13 +72,13 @@ class _Rule(Rule, NativeWrapper[NativeRule]):
         try:
             rule_delete(transaction.logic, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def is_deleted(self, transaction: _Transaction) -> bool:
         try:
             return rule_is_deleted(transaction.logic, self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def __repr__(self):
         return rule_to_string(self.native_object)

--- a/python/typedb/logic/rule.py
+++ b/python/typedb/logic/rule.py
@@ -27,7 +27,7 @@ from typedb.native_driver_wrapper import rule_get_when, rule_get_then, rule_get_
     rule_is_deleted, rule_to_string, Rule as NativeRule
 
 from typedb.api.logic.rule import Rule
-from typedb.common.exception import TypeDBDriverExceptionExt, MISSING_LABEL, NULL_NATIVE_OBJECT, ILLEGAL_STATE
+from typedb.common.exception import TypeDBDriverException, MISSING_LABEL, NULL_NATIVE_OBJECT, ILLEGAL_STATE
 from typedb.common.native_wrapper import NativeWrapper
 
 if TYPE_CHECKING:
@@ -38,15 +38,15 @@ class _Rule(Rule, NativeWrapper[NativeRule]):
 
     def __init__(self, rule: NativeRule):
         if not rule:
-            raise TypeDBDriverExceptionExt(NULL_NATIVE_OBJECT)
+            raise TypeDBDriverException(NULL_NATIVE_OBJECT)
         super().__init__(rule)
         self._rule = rule
         self._when = rule_get_when(self._rule)
         self._then = rule_get_then(self._rule)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     @property
     def label(self) -> str:
@@ -54,7 +54,7 @@ class _Rule(Rule, NativeWrapper[NativeRule]):
 
     def set_label(self, transaction: _Transaction, new_label: str) -> None:
         if not new_label:
-            raise TypeDBDriverExceptionExt(MISSING_LABEL)
+            raise TypeDBDriverException(MISSING_LABEL)
         rule_set_label(transaction.logic, self.native_object, new_label)
 
     @property

--- a/python/typedb/query/query_manager.py
+++ b/python/typedb/query/query_manager.py
@@ -30,7 +30,7 @@ from typedb.native_driver_wrapper import query_match, concept_map_iterator_next,
 
 from typedb.api.connection.options import TypeDBOptions
 from typedb.api.query.query_manager import QueryManager
-from typedb.common.exception import TypeDBDriverExceptionExt, MISSING_QUERY, TRANSACTION_CLOSED
+from typedb.common.exception import TypeDBDriverException, MISSING_QUERY, TRANSACTION_CLOSED
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.concept.answer.concept_map import _ConceptMap
@@ -53,8 +53,8 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
         super().__init__(transaction)
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(TRANSACTION_CLOSED)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(TRANSACTION_CLOSED)
 
     @property
     def _native_transaction(self) -> NativeTransaction:
@@ -62,7 +62,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
 
     def match(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMap]:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return map(_ConceptMap, IteratorWrapper(query_match(self._native_transaction, query, options.native_object),
@@ -70,14 +70,14 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
 
     def match_aggregate(self, query: str, options: Optional[TypeDBOptions] = None) -> Numeric:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return _Numeric(query_match_aggregate(self._native_transaction, query, options.native_object))
 
     def match_group(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMapGroup]:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return map(_ConceptMapGroup, IteratorWrapper(query_match_group(self._native_transaction, query,
@@ -86,7 +86,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
 
     def match_group_aggregate(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[NumericGroup]:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return map(_NumericGroup, IteratorWrapper(query_match_group_aggregate(self._native_transaction, query,
@@ -95,7 +95,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
 
     def insert(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMap]:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return map(_ConceptMap, IteratorWrapper(query_insert(self._native_transaction, query, options.native_object),
@@ -103,14 +103,14 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
 
     def delete(self, query: str, options: Optional[TypeDBOptions] = None) -> None:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return query_delete(self._native_transaction, query, options.native_object)
 
     def update(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMap]:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return map(_ConceptMap, IteratorWrapper(query_update(self._native_transaction, query, options.native_object),
@@ -118,14 +118,14 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
 
     def define(self, query: str, options: TypeDBOptions = None) -> None:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return query_define(self._native_transaction, query, options.native_object)
 
     def undefine(self, query: str, options: TypeDBOptions = None) -> None:
         if not query:
-            raise TypeDBDriverExceptionExt(MISSING_QUERY)
+            raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
         return query_undefine(self._native_transaction, query, options.native_object)

--- a/python/typedb/query/query_manager.py
+++ b/python/typedb/query/query_manager.py
@@ -69,7 +69,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
             return map(_ConceptMap, IteratorWrapper(query_match(self._native_transaction, query, options.native_object),
                                                     concept_map_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def match_aggregate(self, query: str, options: Optional[TypeDBOptions] = None) -> Numeric:
         if not query:
@@ -79,7 +79,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
         try:
             return _Numeric(query_match_aggregate(self._native_transaction, query, options.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def match_group(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMapGroup]:
         if not query:
@@ -91,7 +91,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
                                                                            options.native_object),
                                                          concept_map_group_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def match_group_aggregate(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[NumericGroup]:
         if not query:
@@ -103,7 +103,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
                                                                                   options.native_object),
                                                       numeric_group_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def insert(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMap]:
         if not query:
@@ -114,7 +114,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
             return map(_ConceptMap, IteratorWrapper(query_insert(self._native_transaction, query, options.native_object),
                                                     concept_map_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def delete(self, query: str, options: Optional[TypeDBOptions] = None) -> None:
         if not query:
@@ -124,7 +124,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
         try:
             return query_delete(self._native_transaction, query, options.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def update(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMap]:
         if not query:
@@ -135,7 +135,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
             return map(_ConceptMap, IteratorWrapper(query_update(self._native_transaction, query, options.native_object),
                                                     concept_map_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def define(self, query: str, options: TypeDBOptions = None) -> None:
         if not query:
@@ -145,7 +145,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
         try:
             return query_define(self._native_transaction, query, options.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def undefine(self, query: str, options: TypeDBOptions = None) -> None:
         if not query:
@@ -155,7 +155,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
         try:
             return query_undefine(self._native_transaction, query, options.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def explain(self, explainable: ConceptMap.Explainable, options: Optional[TypeDBOptions] = None
                 ) -> Iterator[Explanation]:
@@ -166,4 +166,4 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
                                                                    options.native_object),
                                                      explanation_iterator_next))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/query/query_manager.py
+++ b/python/typedb/query/query_manager.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Iterator, Optional
 from typedb.native_driver_wrapper import query_match, concept_map_iterator_next, query_match_group, \
     concept_map_group_iterator_next, query_insert, query_update, query_explain, explanation_iterator_next, \
     query_match_aggregate, numeric_group_iterator_next, query_match_group_aggregate, query_delete, query_define, \
-    query_undefine, Transaction as NativeTransaction
+    query_undefine, Transaction as NativeTransaction, TypeDBDriverExceptionNative
 
 from typedb.api.connection.options import TypeDBOptions
 from typedb.api.query.query_manager import QueryManager
@@ -54,7 +54,7 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(TRANSACTION_CLOSED)
+        return TypeDBDriverException(TRANSACTION_CLOSED)
 
     @property
     def _native_transaction(self) -> NativeTransaction:
@@ -65,75 +65,105 @@ class _QueryManager(QueryManager, NativeWrapper[NativeTransaction]):
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return map(_ConceptMap, IteratorWrapper(query_match(self._native_transaction, query, options.native_object),
-                                                concept_map_iterator_next))
+        try:
+            return map(_ConceptMap, IteratorWrapper(query_match(self._native_transaction, query, options.native_object),
+                                                    concept_map_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def match_aggregate(self, query: str, options: Optional[TypeDBOptions] = None) -> Numeric:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return _Numeric(query_match_aggregate(self._native_transaction, query, options.native_object))
+        try:
+            return _Numeric(query_match_aggregate(self._native_transaction, query, options.native_object))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def match_group(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMapGroup]:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return map(_ConceptMapGroup, IteratorWrapper(query_match_group(self._native_transaction, query,
-                                                                       options.native_object),
-                                                     concept_map_group_iterator_next))
+        try:
+            return map(_ConceptMapGroup, IteratorWrapper(query_match_group(self._native_transaction, query,
+                                                                           options.native_object),
+                                                         concept_map_group_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def match_group_aggregate(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[NumericGroup]:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return map(_NumericGroup, IteratorWrapper(query_match_group_aggregate(self._native_transaction, query,
-                                                                              options.native_object),
-                                                  numeric_group_iterator_next))
+        try:
+            return map(_NumericGroup, IteratorWrapper(query_match_group_aggregate(self._native_transaction, query,
+                                                                                  options.native_object),
+                                                      numeric_group_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def insert(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMap]:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return map(_ConceptMap, IteratorWrapper(query_insert(self._native_transaction, query, options.native_object),
-                                                concept_map_iterator_next))
+        try:
+            return map(_ConceptMap, IteratorWrapper(query_insert(self._native_transaction, query, options.native_object),
+                                                    concept_map_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def delete(self, query: str, options: Optional[TypeDBOptions] = None) -> None:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return query_delete(self._native_transaction, query, options.native_object)
+        try:
+            return query_delete(self._native_transaction, query, options.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def update(self, query: str, options: Optional[TypeDBOptions] = None) -> Iterator[ConceptMap]:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return map(_ConceptMap, IteratorWrapper(query_update(self._native_transaction, query, options.native_object),
-                                                concept_map_iterator_next))
+        try:
+            return map(_ConceptMap, IteratorWrapper(query_update(self._native_transaction, query, options.native_object),
+                                                    concept_map_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def define(self, query: str, options: TypeDBOptions = None) -> None:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return query_define(self._native_transaction, query, options.native_object)
+        try:
+            return query_define(self._native_transaction, query, options.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def undefine(self, query: str, options: TypeDBOptions = None) -> None:
         if not query:
             raise TypeDBDriverException(MISSING_QUERY)
         if not options:
             options = TypeDBOptions()
-        return query_undefine(self._native_transaction, query, options.native_object)
+        try:
+            return query_undefine(self._native_transaction, query, options.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def explain(self, explainable: ConceptMap.Explainable, options: Optional[TypeDBOptions] = None
                 ) -> Iterator[Explanation]:
         if not options:
             options = TypeDBOptions()
-        return map(_Explanation, IteratorWrapper(query_explain(self._native_transaction, explainable._native_object,
-                                                               options.native_object),
-                                                 explanation_iterator_next))
+        try:
+            return map(_Explanation, IteratorWrapper(query_explain(self._native_transaction, explainable._native_object,
+                                                                   options.native_object),
+                                                     explanation_iterator_next))
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/user/user.py
+++ b/python/typedb/user/user.py
@@ -27,7 +27,7 @@ from typedb.native_driver_wrapper import user_get_username, user_get_password_ex
     User as NativeUser
 
 from typedb.api.user.user import User
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_STATE
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE
 from typedb.common.native_wrapper import NativeWrapper
 
 if TYPE_CHECKING:
@@ -41,8 +41,8 @@ class _User(User, NativeWrapper[NativeUser]):
         self._user_manager = user_manager
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def username(self) -> str:
         return user_get_username(self.native_object)

--- a/python/typedb/user/user.py
+++ b/python/typedb/user/user.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from typedb.native_driver_wrapper import user_get_username, user_get_password_expiry_seconds, user_password_update, \
-    User as NativeUser
+    User as NativeUser, TypeDBDriverExceptionNative
 
 from typedb.api.user.user import User
 from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE
@@ -42,7 +42,7 @@ class _User(User, NativeWrapper[NativeUser]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def username(self) -> str:
         return user_get_username(self.native_object)
@@ -53,4 +53,7 @@ class _User(User, NativeWrapper[NativeUser]):
         return None
 
     def password_update(self, password_old: str, password_new: str) -> None:
-        user_password_update(self.native_object, self._user_manager.native_object, password_old, password_new)
+        try:
+            user_password_update(self.native_object, self._user_manager.native_object, password_old, password_new)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/user/user.py
+++ b/python/typedb/user/user.py
@@ -56,4 +56,4 @@ class _User(User, NativeWrapper[NativeUser]):
         try:
             user_password_update(self.native_object, self._user_manager.native_object, password_old, password_new)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -51,25 +51,25 @@ class _UserManager(UserManager, NativeWrapper[NativeUserManager]):
         try:
             return users_contains(self.native_object, username)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def create(self, username: str, password: str) -> None:
         try:
             users_create(self.native_object, username, password)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def delete(self, username: str) -> None:
         try:
             users_delete(self.native_object, username)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def all(self) -> list[User]:
         try:
             return [_User(user, self) for user in IteratorWrapper(users_all(self.native_object), user_iterator_next)]
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get(self, username: str) -> Optional[User]:
         try:
@@ -77,16 +77,16 @@ class _UserManager(UserManager, NativeWrapper[NativeUserManager]):
                 return _User(user, self)
             return None
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def password_set(self, username: str, password: str) -> None:
         try:
             users_set_password(self.native_object, username, password)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)
 
     def get_current_user(self) -> User:
         try:
             return _User(users_current_user(self.native_object), self)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException(e)
+            raise TypeDBDriverException.of(e)

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -24,7 +24,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from typedb.native_driver_wrapper import user_manager_new, users_contains, users_create, users_delete, users_all, \
-    users_get, users_set_password, users_current_user, user_iterator_next, UserManager as NativeUserManager
+    users_get, users_set_password, users_current_user, user_iterator_next, UserManager as NativeUserManager, \
+    TypeDBDriverExceptionNative
 
 from typedb.api.user.user import UserManager
 from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE
@@ -44,27 +45,48 @@ class _UserManager(UserManager, NativeWrapper[NativeUserManager]):
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
-        return TypeDBDriverException.of(ILLEGAL_STATE)
+        return TypeDBDriverException(ILLEGAL_STATE)
 
     def contains(self, username: str) -> bool:
-        return users_contains(self.native_object, username)
+        try:
+            return users_contains(self.native_object, username)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def create(self, username: str, password: str) -> None:
-        users_create(self.native_object, username, password)
+        try:
+            users_create(self.native_object, username, password)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def delete(self, username: str) -> None:
-        users_delete(self.native_object, username)
+        try:
+            users_delete(self.native_object, username)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def all(self) -> list[User]:
-        return [_User(user, self) for user in IteratorWrapper(users_all(self.native_object), user_iterator_next)]
+        try:
+            return [_User(user, self) for user in IteratorWrapper(users_all(self.native_object), user_iterator_next)]
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get(self, username: str) -> Optional[User]:
-        if user := users_get(self.native_object, username):
-            return _User(user, self)
-        return None
+        try:
+            if user := users_get(self.native_object, username):
+                return _User(user, self)
+            return None
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def password_set(self, username: str, password: str) -> None:
-        users_set_password(self.native_object, username, password)
+        try:
+            users_set_password(self.native_object, username, password)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)
 
     def get_current_user(self) -> User:
-        return _User(users_current_user(self.native_object), self)
+        try:
+            return _User(users_current_user(self.native_object), self)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException(e)

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -27,7 +27,7 @@ from typedb.native_driver_wrapper import user_manager_new, users_contains, users
     users_get, users_set_password, users_current_user, user_iterator_next, UserManager as NativeUserManager
 
 from typedb.api.user.user import UserManager
-from typedb.common.exception import TypeDBDriverExceptionExt, ILLEGAL_STATE
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.user.user import _User
@@ -43,8 +43,8 @@ class _UserManager(UserManager, NativeWrapper[NativeUserManager]):
         super().__init__(user_manager_new(connection))
 
     @property
-    def _native_object_not_owned_exception(self) -> TypeDBDriverExceptionExt:
-        return TypeDBDriverExceptionExt.of(ILLEGAL_STATE)
+    def _native_object_not_owned_exception(self) -> TypeDBDriverException:
+        return TypeDBDriverException.of(ILLEGAL_STATE)
 
     def contains(self, username: str) -> bool:
         return users_contains(self.native_object, username)


### PR DESCRIPTION
## What is the goal of this PR?

We had two exception classes: `TypeDBDriverException`, that could be raised by native calls, and `TypeDBDriverExceptionExt(TypeDBDriverException)`, that was raised by python driver methods. In order to catch all driver exceptions we had to use `TypeDBDriverException`, but this class couldn't be commented properly, because it is defined in the SWIG-generated file, that we wouldn't like to expose.

Now all raised exceptions are `TypeDBDriverException`s, and this class is properly documented.

## What are the changes implemented in this PR?

We catch all native TypeDB exceptions, that could be thrown by native functions calls, and raise `TypeDBDriverException` (formerly known as `TypeDBDriverExceptionExt`).
