### PR TITLE
Move CircleCI jobs for MacOS x86_64 drivers to run on mac arm64 machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@2.0.0
+  macos: circleci/macos@2.4.0
 
 executors:
   linux-arm64:
@@ -40,11 +41,6 @@ executors:
     macos:
       xcode: "13.4.1"
     resource_class: macos.m1.medium.gen1
-    working_directory: ~/typedb-driver
-
-  mac-x86_64:
-    macos:
-      xcode: "13.4.1"
     working_directory: ~/typedb-driver
 
 
@@ -65,8 +61,14 @@ commands:
           chmod a+x /usr/local/bin/bazel
 
   install-bazel-mac:
+    parameters:
+      arch:
+        type: string
     steps:
-      - run: brew install bazelisk
+      - run: |
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.arch>>"
+          sudo mv "bazelisk-darwin-<<parameters.arch>>" /usr/local/bin/bazel
+          chmod a+x /usr/local/bin/bazel
 
   ###########################
   # Python deployment steps #
@@ -99,21 +101,25 @@ commands:
       - deploy-pip-snapshot-unix
 
   deploy-pip-snapshot-mac:
+    parameters:
+      arch:
+        type: string
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-mac:
+          arch: "<<parameters.arch>>"
       - install-pip-requirements
       - deploy-pip-snapshot-unix
 
   test-pip-snapshot-unix:
     steps:
       - run: |
-          bazel run //tool/test:typedb-extractor -- typedb-all
-          ./typedb-all/typedb server &
+          tool/test/start-core-server.sh
           python3 -m pip install wheel
           python3 -m pip install --extra-index-url https://repo.vaticle.com/repository/pypi-snapshot/simple typedb-driver==0.0.0+$(git rev-parse HEAD)
-          cd python/tests/deployment/ && python3 -m unittest test && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          kill $(jps | awk '/TypeDBServer/ {print $1}')
+          sleep 3
+          (cd python/tests/deployment/ && python3 -m unittest test && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
+          tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
   test-pip-snapshot-linux:
@@ -128,9 +134,13 @@ commands:
       - test-pip-snapshot-unix
 
   test-pip-snapshot-mac:
+    parameters:
+      arch:
+        type: string
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-mac:
+          arch: "<<parameters.arch>>"
       - install-pip-requirements
       - test-pip-snapshot-unix
 
@@ -155,9 +165,13 @@ commands:
       - deploy-pip-release-unix
 
   deploy-pip-release-mac:
+    parameters:
+      arch:
+        type: string
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-mac:
+          arch: "<<parameters.arch>>"
       - install-pip-requirements
       - deploy-pip-release-unix
 
@@ -188,9 +202,13 @@ commands:
       - deploy-maven-jni-snapshot-unix
 
   deploy-maven-jni-snapshot-mac:
+    parameters:
+      arch:
+        type: string
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-mac:
+          arch: "<<parameters.arch>>"
       - install-maven-mac
       - deploy-maven-jni-snapshot-unix
 
@@ -205,15 +223,11 @@ commands:
   test-maven-snapshot-unix:
     steps:
       - run: |
-          export TYPEDB_DIST_DIR="dist/typedb-all-linux/"
-          bazel run //tool/test:typedb-extractor -- $TYPEDB_DIST_DIR
-          $TYPEDB_DIST_DIR/typedb server &
-          PID=$!
-          
+          tool/test/start-core-server.sh
           sed -i -e "s/DRIVER_JAVA_VERSION_MARKER/$CIRCLE_SHA1/g" java/test/deployment/pom.xml
           cat java/test/deployment/pom.xml
-          cd java/test/deployment && mvn test
-          kill $PID
+          (cd java/test/deployment && mvn test)
+          tool/test/stop-core-server.sh
 
   test-maven-snapshot-linux:
     parameters:
@@ -226,9 +240,13 @@ commands:
       - test-maven-snapshot-unix
 
   test-maven-snapshot-mac:
+    parameters:
+      arch:
+        type: string
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-mac:
+          arch: "<<parameters.arch>>"
       - install-maven-mac
       - test-maven-snapshot-unix
 
@@ -251,9 +269,13 @@ commands:
       - deploy-maven-jni-release-unix
 
   deploy-maven-jni-release-mac:
+    parameters:
+      arch:
+        type: string
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-mac:
+          arch: "<<parameters.arch>>"
       - install-maven-mac
       - deploy-maven-jni-release-unix
 
@@ -287,12 +309,15 @@ jobs:
   deploy-pip-snapshot-mac-arm64:
     executor: mac-arm64
     steps:
-      - deploy-pip-snapshot-mac
+      - deploy-pip-snapshot-mac:
+          arch: arm64
 
   deploy-pip-snapshot-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
-      - deploy-pip-snapshot-mac
+      - macos/install-rosetta
+      - deploy-pip-snapshot-mac:
+          arch: amd64
 
   deploy-pip-snapshot-windows-x86_64:
     executor:
@@ -319,12 +344,15 @@ jobs:
   test-pip-snapshot-mac-arm64:
     executor: mac-arm64
     steps:
-      - test-pip-snapshot-mac
+      - test-pip-snapshot-mac:
+          arch: arm64
 
   test-pip-snapshot-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
-      - test-pip-snapshot-mac
+      - macos/install-rosetta
+      - test-pip-snapshot-mac:
+          arch: amd64
 
   test-pip-snapshot-windows-x86_64:
     executor:
@@ -373,7 +401,8 @@ jobs:
   deploy-pip-release-mac-arm64:
     executor: mac-arm64
     steps:
-      - deploy-pip-release-mac
+      - deploy-pip-release-mac:
+          arch: arm64
       - run: |
           mkdir -p ~/dist
           for f in bazel-bin/python/*.whl; do
@@ -387,9 +416,11 @@ jobs:
           paths: ["./*"]
 
   deploy-pip-release-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
-      - deploy-pip-release-mac
+      - macos/install-rosetta
+      - deploy-pip-release-mac:
+          arch: amd64
       - run: |
           mkdir -p ~/dist
           for f in bazel-bin/python/*.whl; do
@@ -434,12 +465,15 @@ jobs:
   deploy-maven-jni-snapshot-mac-arm64:
     executor: mac-arm64
     steps:
-      - deploy-maven-jni-snapshot-mac
+      - deploy-maven-jni-snapshot-mac:
+          arch: arm64
 
   deploy-maven-jni-snapshot-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
-      - deploy-maven-jni-snapshot-mac
+      - macos/install-rosetta
+      - deploy-maven-jni-snapshot-mac:
+          arch: amd64
 
   deploy-maven-jni-snapshot-windows-x86_64:
     executor:
@@ -474,12 +508,15 @@ jobs:
   test-maven-snapshot-mac-arm64:
     executor: mac-arm64
     steps:
-      - test-maven-snapshot-mac
+      - test-maven-snapshot-mac:
+          arch: arm64
 
   test-maven-snapshot-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
-      - test-maven-snapshot-mac
+      - macos/install-rosetta
+      - test-maven-snapshot-mac:
+          arch: amd64
 
   test-maven-snapshot-windows-x86_64:
     executor:
@@ -518,7 +555,8 @@ jobs:
   deploy-maven-jni-release-mac-arm64:
     executor: mac-arm64
     steps:
-      - deploy-maven-jni-release-mac
+      - deploy-maven-jni-release-mac:
+          arch: arm64
       - run: |
           mkdir -p ~/dist
           cp bazel-bin/java/com.vaticle.typedb-typedb-driver-jni-macosx-arm64.jar ~/dist/typedb-driver-jni-macosx-arm64.jar
@@ -527,9 +565,11 @@ jobs:
           paths: ["./*"]
 
   deploy-maven-jni-release-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
-      - deploy-maven-jni-release-mac
+      - macos/install-rosetta
+      - deploy-maven-jni-release-mac:
+          arch: amd64
       - run: |
           mkdir -p ~/dist
           cp bazel-bin/java/com.vaticle.typedb-typedb-driver-jni-macosx-x86_64.jar ~/dist/typedb-driver-jni-macosx-x86_64.jar

--- a/.circleci/windows/git.patch
+++ b/.circleci/windows/git.patch
@@ -9,5 +9,5 @@ index 7b30ef2e..145bc0ce 100644
 -workspace(name = "vaticle_typedb_driver")
 +workspace(name = "v")
  
- ################################
+ ##############################
  # Load @vaticle_dependencies #

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -104,10 +104,10 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=integration::queries::enterprise \
-          --test_arg=integration::runtimes &&
+        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=integration::queries::enterprise \
+            --test_arg=integration::runtimes &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -121,9 +121,9 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=behaviour::concept &&
+        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::concept &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -137,9 +137,9 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=behaviour::connection &&
+        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::connection &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -154,9 +154,9 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=behaviour::driver &&
+        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::driver &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -174,11 +174,11 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=behaviour::query::language::match_ \
-          --test_arg=behaviour::query::language::get \
-          --test_arg=behaviour::query::language::expression &&
+        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::query::language::match_ \
+            --test_arg=behaviour::query::language::get \
+            --test_arg=behaviour::query::language::expression &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -196,14 +196,14 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-          --test_arg=behaviour::query::language::define \
-          --test_arg=behaviour::query::language::undefine \
-          --test_arg=behaviour::query::language::insert \
-          --test_arg=behaviour::query::language::delete \
-          --test_arg=behaviour::query::language::update \
-          --test_arg=behaviour::query::language::rule_validation &&
+        source tool/test/start-enterprise-servers.sh && 3 # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::query::language::define \
+            --test_arg=behaviour::query::language::undefine \
+            --test_arg=behaviour::query::language::insert \
+            --test_arg=behaviour::query::language::delete \
+            --test_arg=behaviour::query::language::update \
+            --test_arg=behaviour::query::language::rule_validation &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -429,8 +429,8 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           .factory/test-enterprise.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           .factory/test-enterprise.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           .factory/test-enterprise.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
@@ -474,8 +474,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh &&  # use source to receive export vars
+          .factory/test-enterprise.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -516,8 +516,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -566,8 +566,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-enterprise-servers.sh &&  # use source to receive export vars
+          .factory/test-enterprise.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-enterprise.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-enterprise.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -618,8 +618,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-enterprise.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-enterprise.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -669,8 +669,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-enterprise.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
@@ -744,8 +744,8 @@ build:
         bazel build //nodejs/...
         cp -rL bazel-bin/nodejs/node_modules nodejs/.
         cp -rL bazel-bin/nodejs/dist nodejs/.
-        source tool/test/start-enterprise-servers.sh 3 # use source to receive export vars
-        node nodejs/test/integration/test-enterprise-failover.js && 
+        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+          node nodejs/test/integration/test-enterprise-failover.js && 
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -774,8 +774,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
@@ -805,8 +805,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -834,8 +834,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh
         exit $TEST_SUCCESS
@@ -870,8 +870,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -908,8 +908,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -945,8 +945,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh # use source to receive export vars
-        .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
+          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-enterprise-servers.sh

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -87,9 +87,9 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        bazel test //rust/tests --test_output=streamed --test_arg=-- \
-          --test_arg=integration::queries::core &&
+        tool/test/start-core-server.sh &&
+          bazel test //rust/tests --test_output=streamed --test_arg=-- \
+            --test_arg=integration::queries::core &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -217,8 +217,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        bazel test //c/tests/integration:test-driver --test_output=errors &&
+        tool/test/start-core-server.sh &&
+          bazel test //c/tests/integration:test-driver --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -409,8 +409,8 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
           .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
           .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -453,8 +453,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -495,8 +495,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -540,8 +540,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
           .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
           .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -592,8 +592,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
           .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
           .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -644,8 +644,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
           .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
@@ -688,8 +688,8 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 
-        tool/test/start-core-server.sh
-        bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -723,9 +723,8 @@ build:
         bazel build //nodejs/...
         cp -rL bazel-bin/nodejs/node_modules nodejs/.
         cp -rL bazel-bin/nodejs/dist nodejs/.
-        tool/test/start-core-server.sh
-        sleep 10
-        node nodejs/test/integration/test-concept.js &&
+        tool/test/start-core-server.sh &&
+          node nodejs/test/integration/test-concept.js &&
           node nodejs/test/integration/test-connection.js &&
           node nodejs/test/integration/test-query.js && 
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -758,8 +757,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
           .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
           .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -791,8 +790,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -820,8 +819,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -851,8 +850,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -889,8 +888,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -927,8 +926,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh
-        .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,7 +32,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.24.15",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "303ccabdd2bca4bfcaef1201671d4676eef1aab7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():

--- a/tool/test/BUILD
+++ b/tool/test/BUILD
@@ -30,6 +30,13 @@ checkstyle_test(
     license_type = "apache-header",
 )
 
+java_binary(
+    name = "echo-java-home",
+    srcs = ["EchoJavaHome.java"],
+    deps = [],
+    main_class = "com.vaticle.typedb.driver.tool.test.EchoJavaHome"
+)
+
 native_typedb_artifact(
     name = "native-typedb-artifact",
     native_artifacts = {

--- a/tool/test/EchoJavaHome.java
+++ b/tool/test/EchoJavaHome.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.vaticle.typedb.driver.tool.test;
+
+public class EchoJavaHome {
+    public static void main(String[] args) {
+        System.out.println(System.getProperty("java.home"));
+    }
+}

--- a/tool/test/start-core-server.sh
+++ b/tool/test/start-core-server.sh
@@ -25,4 +25,15 @@ set -e
 rm -rf typedb-all
 
 bazel run //tool/test:typedb-extractor -- typedb-all
-./typedb-all/typedb server &
+JAVA_HOME=$(bazel run //tool/test:echo-java-home) ./typedb-all/typedb server &
+
+set +e
+POLL_INTERVAL_SECS=0.5
+RETRY_NUM=10
+while [[ $RETRY_NUM -gt 0 ]]; do
+  lsof -i :1729 > /dev/null
+  if [ $? -eq 0 ]; then exit 0; fi
+  ((RETRY_NUM-=1))
+  sleep $POLL_INTERVAL_SECS
+done
+exit 1

--- a/tool/test/start-core-server.sh
+++ b/tool/test/start-core-server.sh
@@ -25,7 +25,8 @@ set -e
 rm -rf typedb-all
 
 bazel run //tool/test:typedb-extractor -- typedb-all
-JAVA_HOME=$(bazel run //tool/test:echo-java-home) ./typedb-all/typedb server &
+BAZEL_JAVA_HOME=$(bazel run //tool/test:echo-java-home)
+JAVA_HOME=$BAZEL_JAVA_HOME ./typedb-all/typedb server &
 
 set +e
 POLL_INTERVAL_SECS=0.5

--- a/tool/test/start-enterprise-servers.sh
+++ b/tool/test/start-enterprise-servers.sh
@@ -22,6 +22,7 @@
 
 set -e
 
+export BAZEL_JAVA_HOME=$(bazel run //tool/test:echo-java-home)
 NODE_COUNT=${1:-1}
 
 peers=
@@ -32,7 +33,7 @@ for i in $(seq 1 $NODE_COUNT); do
 done
 
 function server_start() {
-  ./${1}/typedb enterprise \
+  JAVA_HOME=$BAZEL_JAVA_HOME ./${1}/typedb enterprise \
     --storage.data=server/data \
     --server.address=localhost:${1}1729 \
     --server.internal-address.zeromq=localhost:${1}1730 \


### PR DESCRIPTION
## What is the goal of this PR?
We reconfigure our CircleCI pipeline to use MacOS arm64 machines for running build & test jobs for our TypeDB MacOS x86_64 drivers. This is in light of [CircleCI sunsetting MacOS (intel) x86_64 resources in January 2024](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718).

## What are the changes implemented in this PR?
Installing rosetta & using an x86_64 version of bazel was enough for bazel to build & execute targets in x86_64 mode. Additionally, we:
* Make java processes spawned outside of bazel use the same java installation as bazel
* Bump `typedb-common` for a change setting TypeDB runners to use the same java as the test process.
* Replace jobs using the `mac-x86_64` executor to use the `mac-arm64` executor
