### PR TITLE
Node driver package automatic version stamping

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,14 @@
 
 try-import ./.bazel-remote-cache.rc
 
+common --enable_platform_specific_config
+
 build --incompatible_strict_action_env --java_language_version=11 --javacopt='--release 11' --enable_runfiles
 run --incompatible_strict_action_env --java_runtime_version=remotejdk_11
 test --incompatible_strict_action_env --test_env=PATH --cache_test_results=no --java_runtime_version=remotejdk_11
+
+build:linux --stamp --workspace_status_command=$PWD/workspace-status.sh
+build:macos --stamp --workspace_status_command=$PWD/workspace-status.sh
+
+# TODO
+# build:windows --stamp --workspace_status_command=workspace-status.bat

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -984,9 +984,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
 
     deploy-npm-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -1008,9 +1008,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
 
     test-deployment-npm:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       image: vaticle-ubuntu-22.04
       dependencies:
         - deploy-npm-snapshot

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1020,6 +1020,7 @@ build:
         npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
         sudo -H npm install jest --global
         jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        cd -
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
         

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -984,9 +984,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
 
     deploy-npm-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -1008,9 +1008,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
 
     test-deployment-npm:
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       image: vaticle-ubuntu-22.04
       dependencies:
         - deploy-npm-snapshot

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1006,6 +1006,22 @@ build:
         export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+
+    test-deployment-npm:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - deploy-npm-snapshot
+      command: |
+        tool/test/start-core-server.sh
+        cd nodejs/test/deployment/
+        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+        sudo -H npm install jest --global
+        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
         
 # TODO: assembly tests for all drivers to run in factory
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -237,6 +237,9 @@ rules_ts_dependencies(
     ts_version_from = "//nodejs:package.json",
 )
 
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains")
+register_jq_toolchains()
+
 ###############
 # Load @maven #
 ###############

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,10 +43,11 @@ def vaticle_typeql():
     )
 
 def vaticle_typedb_protocol():
+    VATICLE_TYPEDB_PROTOCOL_VERSION = "2.25.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.25.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        tag = VATICLE_TYPEDB_PROTOCOL_VERSION
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,6 +43,7 @@ def vaticle_typeql():
     )
 
 def vaticle_typedb_protocol():
+    # needed for workspace status
     VATICLE_TYPEDB_PROTOCOL_VERSION = "2.25.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     git_repository(
         name = "vaticle_typedb_protocol",

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -34,6 +34,7 @@ load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package", "npm_package")
+load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//nodejs:tool/typedoc/rules.bzl", "typedoc_docs")
 load("//tool/docs:nodejs/rules.bzl", "typedoc_to_adoc")
@@ -89,9 +90,22 @@ ts_project(
     out_dir = "dist",
 )
 
+jq(
+    name = "package",
+    srcs = ["package.json"],
+    filter = "|".join([
+        # Don't directly reference $STAMP as it's only set when stamping
+        # This 'as' syntax results in $stamp being null in unstamped builds.
+        "$ARGS.named.STAMP as $stamp",
+        # Provide a default using the "alternative operator" in case $stamp is null.
+        ".dependencies[\"typedb-protocol\"] = ($stamp.STABLE_PROTOCOL_VERSION // .dependencies[\"typedb-protocol\"])",
+        ".version = ($stamp.STABLE_VERSION // \"0.0.0\")"
+    ]),
+)
+
 npm_package(
     name = "driver-nodejs-npm-package",
-    srcs = [":driver-nodejs", "package.json"],
+    srcs = [":driver-nodejs", ":package"],
     include_runfiles = False,
     package = "typedb-driver",
     replace_prefixes = { "dist/": "" },

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -98,7 +98,7 @@ jq(
         # This 'as' syntax results in $stamp being null in unstamped builds.
         "$ARGS.named.STAMP as $stamp",
         # Provide a default using the "alternative operator" in case $stamp is null.
-        ".dependencies[\"typedb-protocol\"] = ($stamp.STABLE_PROTOCOL_VERSION // .dependencies[\"typedb-protocol\"])",
+        ".dependencies[\"typedb-protocol\"] = $stamp.STABLE_PROTOCOL_VERSION",
         ".version = ($stamp.STABLE_VERSION // \"0.0.0\")"
     ]),
 )

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@grpc/grpc-js": "1.9.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "2.25.2",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/nodejs/pnpm-lock.yaml
+++ b/nodejs/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   google-protobuf:
     specifier: 3.19.3
     version: 3.19.3
-  typedb-protocol:
-    specifier: 2.18.1
-    version: 2.18.1
   uuid:
     specifier: 8.3.2
     version: 8.3.2
@@ -584,32 +581,12 @@ packages:
       - supports-color
     dev: true
 
-  /@grpc/grpc-js@1.5.0:
-    resolution: {integrity: sha512-PDLazk94MFV5hFn/+aSrVj3d5UsOK9HU1xa0ywachvDh1jymBU/Cb+4nGa2NjpfcBoXlHioBC/qIB/XzELednw==}
-    engines: {node: ^8.13.0 || >=10.10.0}
-    dependencies:
-      '@grpc/proto-loader': 0.6.13
-      '@types/node': 20.0.0
-    dev: false
-
   /@grpc/grpc-js@1.9.0:
     resolution: {integrity: sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==}
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.8
       '@types/node': 20.0.0
-    dev: false
-
-  /@grpc/proto-loader@0.6.13:
-    resolution: {integrity: sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      '@types/long': 4.0.2
-      lodash.camelcase: 4.3.0
-      long: 4.0.0
-      protobufjs: 6.11.4
-      yargs: 16.2.0
     dev: false
 
   /@grpc/proto-loader@0.7.8:
@@ -1454,14 +1431,6 @@ packages:
     optionalDependencies:
       '@colors/colors': 1.5.0
     dev: true
-
-  /cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: false
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -3009,6 +2978,7 @@ packages:
       '@types/long': 4.0.2
       '@types/node': 20.0.0
       long: 4.0.0
+    dev: true
 
   /protobufjs@7.2.4:
     resolution: {integrity: sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==}
@@ -3462,12 +3432,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typedb-protocol@2.18.1:
-    resolution: {integrity: sha512-5zkh6040JaIwazELjhwMLUoHzcFXtTNes90YyMKA+6B0UrtBtMsS+aJJr+cRivw+neUd7uFT6sVvUyq7rQ6zOg==}
-    dependencies:
-      '@grpc/grpc-js': 1.5.0
-    dev: false
-
   /typedoc@0.25.1(typescript@4.9.5):
     resolution: {integrity: sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==}
     engines: {node: '>= 16'}
@@ -3622,27 +3586,9 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-    dev: false
-
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
-
-  /yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-    dev: false
 
   /yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}

--- a/workspace-status.sh
+++ b/workspace-status.sh
@@ -36,6 +36,3 @@ elif [[ "$TYPEDB_PROTOCOL_VERSION" =~ ^[0-9a-f]{40}$ ]]; then # SHA
   TYPEDB_PROTOCOL_VERSION=0.0.0-$TYPEDB_PROTOCOL_VERSION
 fi
 echo STABLE_PROTOCOL_VERSION $TYPEDB_PROTOCOL_VERSION
-
-# TODO parse workspace refs (in jq?)
-#echo STABLE_WORKSPACE_REFS $(cat $workspace_refs)

--- a/workspace-status.sh
+++ b/workspace-status.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+tag=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2>/dev/null)
+if [ ! -z "$tag" ]; then
+    echo STABLE_VERSION $tag
+else
+    echo STABLE_VERSION 0.0.0-$(git rev-parse HEAD)
+fi
+
+workspace=$(realpath $(readlink bazel-typedb-driver)/../..)
+workspace_refs=$workspace/external/vaticle_typedb_driver_workspace_refs/refs.json
+typedb_protocol_version=$(grep -o '"vaticle_typedb_protocol":"[^"]*"' $workspace_refs | sed 's/.*:"\(.*\)"/\1/')
+
+echo STABLE_PROTOCOL_VERSION $typedb_protocol_version
+
+# TODO
+#echo STABLE_WORKSPACE_REFS $(cat $workspace_refs)

--- a/workspace-status.sh
+++ b/workspace-status.sh
@@ -20,18 +20,22 @@
 # under the License.
 #
 
-tag=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2>/dev/null)
-if [ ! -z "$tag" ]; then
-    echo STABLE_VERSION $tag
+TAG=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2>/dev/null)
+if [ ! -z "$TAG" ]; then
+    echo STABLE_VERSION $TAG
 else
     echo STABLE_VERSION 0.0.0-$(git rev-parse HEAD)
 fi
 
-workspace=$(realpath $(readlink bazel-typedb-driver)/../..)
-workspace_refs=$workspace/external/vaticle_typedb_driver_workspace_refs/refs.json
-typedb_protocol_version=$(grep -o '"vaticle_typedb_protocol":"[^"]*"' $workspace_refs | sed 's/.*:"\(.*\)"/\1/')
-
-echo STABLE_PROTOCOL_VERSION $typedb_protocol_version
+TYPEDB_PROTOCOL_VERSION=$(grep -o 'VATICLE_TYPEDB_PROTOCOL_VERSION.*"[^"]*"' dependencies/vaticle/repositories.bzl | sed 's/.*"\(.*\)"/\1/')
+if [ -z "$TYPEDB_PROTOCOL_VERSION" ]; then
+  # the following line only prints when the script is run directly
+  echo "VATICLE_TYPEDB_PROTOCOL_VERSION not found in dependencies/vaticle/repositories.bzl, cannot stamp"
+  exit 1
+elif [[ "$TYPEDB_PROTOCOL_VERSION" =~ ^[0-9a-f]{40}$ ]]; then # SHA
+  TYPEDB_PROTOCOL_VERSION=0.0.0-$TYPEDB_PROTOCOL_VERSION
+fi
+echo STABLE_PROTOCOL_VERSION $TYPEDB_PROTOCOL_VERSION
 
 # TODO parse workspace refs (in jq?)
 #echo STABLE_WORKSPACE_REFS $(cat $workspace_refs)

--- a/workspace-status.sh
+++ b/workspace-status.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+#
+# Copyright (C) 2022 Vaticle
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 tag=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2>/dev/null)
 if [ ! -z "$tag" ]; then
     echo STABLE_VERSION $tag
@@ -12,5 +33,5 @@ typedb_protocol_version=$(grep -o '"vaticle_typedb_protocol":"[^"]*"' $workspace
 
 echo STABLE_PROTOCOL_VERSION $typedb_protocol_version
 
-# TODO
+# TODO parse workspace refs (in jq?)
 #echo STABLE_WORKSPACE_REFS $(cat $workspace_refs)


### PR DESCRIPTION
## What is the goal of this PR?

We leverage Bazel's built-in workspace status and stamping capabilities to ensure that the version of TypeDB Protocol depended on by the node package doesn't go out of sync with the bazel dependency. To that end, we also add a snapshot deployment test for the node driver.

## What are the changes implemented in this PR?

Drive-by fix: handshake with core server no longer overrides the user-provided address.