### PR TITLE
Optimise CI times by retaining server between Java BDD scenarios

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_enterprise_artifact():
         artifact_name = "typedb-enterprise-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "97c3601236b9366784eb476c185577d80be6c2e3",
+        commit = "994220cb44052ba8b66c8e889f94f47ab3b15c0d",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "525ac0f5e072242c1d2f360379e9622397497ef2",
+        tag = "2.25.6",
     )
 
 def vaticle_typedb_enterprise_artifact():

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_enterprise_artifact():
         artifact_name = "typedb-enterprise-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "fc127f880bf85fab134ddcd1e5409142d47a1c32",
+        commit = "97c3601236b9366784eb476c185577d80be6c2e3",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -52,12 +52,8 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-#    git_repository(
-#        name = "vaticle_typedb_behaviour",
-#        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-#        commit = "137adabbba151bbb53885bfbc6079ef09f9b54dc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_behaviour",
-        path = "../typedb-behaviour",
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "b6a1336260a4d11b77750f06abaccba6c9a21f13",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -52,8 +52,12 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_behaviour",
+#        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+#        commit = "137adabbba151bbb53885bfbc6079ef09f9b54dc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+#    )
+    native.local_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "137adabbba151bbb53885bfbc6079ef09f9b54dc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        path = "../typedb-behaviour",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -54,6 +54,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "173c15ec4f15b5f19c2509ecf43f6697efb04247",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "137adabbba151bbb53885bfbc6079ef09f9b54dc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/java/connection/TypeDBDriverImpl.java
+++ b/java/connection/TypeDBDriverImpl.java
@@ -105,6 +105,7 @@ public class TypeDBDriverImpl extends NativeObject<com.vaticle.typedb.driver.jni
 
     @Override
     public void close() {
+        if (!isOpen()) return;
         try {
             connection_force_close(nativeObject);
         } catch (com.vaticle.typedb.driver.jni.Error error) {

--- a/java/test/behaviour/concept/thing/attribute/AttributeTest.java
+++ b/java/test/behaviour/concept/thing/attribute/AttributeTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/concept/thing/attribute.feature",
-        tags = "not @ignore and not @ignore-typedb"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class AttributeTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/concept/thing/entity/EntityTest.java
+++ b/java/test/behaviour/concept/thing/entity/EntityTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/concept/thing/entity.feature",
-        tags = "not @ignore and not @ignore-typedb"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class EntityTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/concept/thing/relation/RelationTest.java
+++ b/java/test/behaviour/concept/thing/relation/RelationTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/concept/thing/relation.feature",
-        tags = "not @ignore and not @ignore-typedb"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class RelationTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/concept/type/attributetype/AttributeTypeTest.java
+++ b/java/test/behaviour/concept/type/attributetype/AttributeTypeTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/concept/type/attributetype.feature",
-        tags = "not @ignore and not @ignore-typedb"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class AttributeTypeTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/concept/type/entitytype/EntityTypeTest.java
+++ b/java/test/behaviour/concept/type/entitytype/EntityTypeTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/concept/type/entitytype.feature",
-        tags = "not @ignore and not @ignore-typedb"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class EntityTypeTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/concept/type/relationtype/RelationTypeTest.java
+++ b/java/test/behaviour/concept/type/relationtype/RelationTypeTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/concept/type/relationtype.feature",
-        tags = "not @ignore and not @ignore-typedb"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class RelationTypeTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -100,6 +100,11 @@ public abstract class ConnectionStepsBase {
         sessionsParallelToTransactionsParallel.clear();
         driver = createTypeDBDriver(TypeDBSingleton.getTypeDBRunner().address());
         driver.databases().all().forEach(Database::delete);
+        driver.users().all().forEach(user -> {
+            if (!user.username().equals("admin")) {
+                driver.users().delete(user.username());
+            }
+        });
         driver.close();
 
         System.out.println("ConnectionSteps.after");

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -100,11 +100,6 @@ public abstract class ConnectionStepsBase {
         sessionsParallelToTransactionsParallel.clear();
         driver = createTypeDBDriver(TypeDBSingleton.getTypeDBRunner().address());
         driver.databases().all().forEach(Database::delete);
-        driver.users().all().forEach(user -> {
-            if (!user.username().equals("admin")) {
-                driver.users().delete(user.username());
-            }
-        });
         driver.close();
 
         System.out.println("ConnectionSteps.after");

--- a/java/test/behaviour/connection/ConnectionStepsCore.java
+++ b/java/test/behaviour/connection/ConnectionStepsCore.java
@@ -21,12 +21,12 @@
 
 package com.vaticle.typedb.driver.test.behaviour.connection;
 
-import com.vaticle.typedb.driver.TypeDB;
-import com.vaticle.typedb.driver.api.TypeDBDriver;
-import com.vaticle.typedb.driver.api.TypeDBOptions;
 import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 import com.vaticle.typedb.common.test.core.TypeDBCoreRunner;
+import com.vaticle.typedb.driver.TypeDB;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBOptions;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
@@ -36,6 +36,13 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
     @Override
     public void beforeAll() {
         super.beforeAll();
+        try {
+            TypeDBCoreRunner typeDBCoreRunner = new TypeDBCoreRunner();
+            TypeDBSingleton.setTypeDBRunner(typeDBCoreRunner);
+            typeDBCoreRunner.start();
+        } catch (InterruptedException | java.util.concurrent.TimeoutException | java.io.IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @Before
@@ -63,20 +70,7 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
         TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
         if (runner != null && runner.isStopped()) {
             runner.start();
-        } else {
-            try {
-                TypeDBCoreRunner typeDBCoreRunner = new TypeDBCoreRunner();
-                TypeDBSingleton.setTypeDBRunner(typeDBCoreRunner);
-                typeDBCoreRunner.start();
-            } catch (InterruptedException | java.util.concurrent.TimeoutException | java.io.IOException e) {
-                e.printStackTrace();
-            }
         }
-    }
-
-    @When("typedb stops")
-    public void typedb_stops() {
-        TypeDBSingleton.getTypeDBRunner().stop();
     }
 
     @Override

--- a/java/test/behaviour/connection/ConnectionStepsEnterprise.java
+++ b/java/test/behaviour/connection/ConnectionStepsEnterprise.java
@@ -28,6 +28,7 @@ import com.vaticle.typedb.driver.api.TypeDBOptions;
 import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
 import com.vaticle.typedb.common.test.enterprise.TypeDBEnterpriseRunner;
+import com.vaticle.typedb.driver.api.database.Database;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
@@ -57,6 +58,13 @@ public class ConnectionStepsEnterprise extends ConnectionStepsBase {
     @After
     public synchronized void after() {
         super.after();
+        driver = createTypeDBDriver(TypeDBSingleton.getTypeDBRunner().address());
+        driver.users().all().forEach(user -> {
+            if (!user.username().equals("admin")) {
+                driver.users().delete(user.username());
+            }
+        });
+        driver.close();
         try {
             // sleep for eventual consistency to catch up with database deletion on all servers
             Thread.sleep(100);

--- a/java/test/behaviour/connection/database/DatabaseTestCore.java
+++ b/java/test/behaviour/connection/database/DatabaseTestCore.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/connection/database.feature",
-        tags = "not @ignore and not @ignore-driver-java and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class DatabaseTestCore extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/connection/database/DatabaseTestEnterprise.java
+++ b/java/test/behaviour/connection/database/DatabaseTestEnterprise.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/connection/database.feature",
-        tags = "not @ignore and not @ignore-driver-java and not @ignore-typedb-enterprise-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class DatabaseTestEnterprise extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/connection/session/SessionTest.java
+++ b/java/test/behaviour/connection/session/SessionTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/connection/session.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class SessionTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/connection/transaction/TransactionTest.java
+++ b/java/test/behaviour/connection/transaction/TransactionTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/connection/transaction.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class TransactionTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/connection/user/UserTestEnterprise.java
+++ b/java/test/behaviour/connection/user/UserTestEnterprise.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/connection/user.feature",
-        tags = "not @ignore and not @ignore-driver-java and not @ignore-typedb-enterprise-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class UserTestEnterprise extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/driver/query/QueryTest.java
+++ b/java/test/behaviour/driver/query/QueryTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/driver/query.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class QueryTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/define/DefineTest.java
+++ b/java/test/behaviour/query/language/define/DefineTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/define.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class DefineTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/delete/DeleteTest.java
+++ b/java/test/behaviour/query/language/delete/DeleteTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/delete.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
 public class DeleteTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/expression/ExpressionTest.java
+++ b/java/test/behaviour/query/language/expression/ExpressionTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/expression.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class ExpressionTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/fetch/FetchTest.java
+++ b/java/test/behaviour/query/language/fetch/FetchTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/fetch.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class FetchTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/get/GetTest.java
+++ b/java/test/behaviour/query/language/get/GetTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/get.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class GetTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/insert/InsertTest.java
+++ b/java/test/behaviour/query/language/insert/InsertTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/insert.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class InsertTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/match/MatchTest.java
+++ b/java/test/behaviour/query/language/match/MatchTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/match.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class MatchTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/modifiers/ModifiersTest.java
+++ b/java/test/behaviour/query/language/modifiers/ModifiersTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/modifiers.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class ModifiersTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/undefine/UndefineTest.java
+++ b/java/test/behaviour/query/language/undefine/UndefineTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/undefine.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class UndefineTest extends BehaviourTest {
     // ATTENTION:

--- a/java/test/behaviour/query/language/update/UpdateTest.java
+++ b/java/test/behaviour/query/language/update/UpdateTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
         plugin = "pretty",
         glue = "com.vaticle.typedb.driver.test.behaviour",
         features = "external/vaticle_typedb_behaviour/query/language/update.feature",
-        tags = "not @ignore and not @ignore-typedb-driver-java"
+        tags = "not @ignore and not @ignore-driver and not @ignore-typedb-driver-java"
 )
 public class UpdateTest extends BehaviourTest {
     // ATTENTION:

--- a/nodejs/common/errors/ErrorMessage.ts
+++ b/nodejs/common/errors/ErrorMessage.ts
@@ -94,14 +94,15 @@ export namespace ErrorMessage {
         export const UNKNOWN_STREAM_STATE = new Driver(11, (args: Stringable[]) => `RPC transaction stream response '${args[0]}' is unknown.`);
         export const MISSING_RESPONSE = new Driver(12, (args: Stringable[]) => `The required field 'res' of type '${args[0]}' was not set.`);
         export const UNKNOWN_REQUEST_ID = new Driver(13, (args: Stringable[]) => `Received a response with unknown request id '${args[0]}'.`);
-        export const ENTPERPRISE_NO_PRIMARY_REPLICA_YET = new Driver(14, (args: Stringable[]) => `No replica has been marked as the primary replica for latest known term '${args[0]}'.`);
-        export const ENTPERPRISE_UNABLE_TO_CONNECT = new Driver(15, (args: Stringable[]) => `Unable to connect to TypeDB Enterprise. Attempted connecting to the enterprise nodes, but none are available: '${args[1]}'.`);
-        export const ENTPERPRISE_REPLICA_NOT_PRIMARY = new Driver(16, () => `The replica is not the primary replica.`);
-        export const ENTPERPRISE_ALL_NODES_FAILED = new Driver(17, (args: Stringable[]) => `Attempted connecting to all enterprise nodes, but the following errors occurred: \n'${args[0]}'`);
-        export const ENTPERPRISE_USER_DOES_NOT_EXIST = new Driver(18, (args: Stringable[]) => `The user '${args[0]}' does not exist.`);
-        export const ENTPERPRISE_TOKEN_CREDENTIAL_INVALID = new Driver(19, (args: Stringable[]) => `Invalid token credential.`);
-        export const ENTERPRISE_INVALID_ROOT_CA_PATH = new Driver(20, (args: Stringable[]) => `The provided Root CA path '${args[0]}' does not exist`);
-        export const UNRECOGNISED_SESSION_TYPE = new Driver(21, (args: Stringable[]) => `Session type '${args[1]}' was not recognised.`);
+        export const ENTERPRISE_NO_PRIMARY_REPLICA_YET = new Driver(14, (args: Stringable[]) => `No replica has been marked as the primary replica for latest known term '${args[0]}'.`);
+        export const ENTERPRISE_UNABLE_TO_CONNECT = new Driver(15, (args: Stringable[]) => `Unable to connect to TypeDB Enterprise. Attempted connecting to the enterprise nodes, but none are available: '${args[1]}'.`);
+        export const ENTERPRISE_REPLICA_NOT_PRIMARY = new Driver(16, () => `The replica is not the primary replica.`);
+        export const ENTERPRISE_ALL_NODES_FAILED = new Driver(17, (args: Stringable[]) => `Attempted connecting to all enterprise nodes, but the following errors occurred: \n'${args[0]}'`);
+        export const USER_MANAGEMENT_ENTERPRISE_ONLY = new Driver(18, (args: Stringable[]) => `User management is only available in TypeDB Enterprise servers.`);
+        export const ENTERPRISE_USER_DOES_NOT_EXIST = new Driver(19, (args: Stringable[]) => `The user '${args[0]}' does not exist.`);
+        export const ENTERPRISE_TOKEN_CREDENTIAL_INVALID = new Driver(20, (args: Stringable[]) => `Invalid token credential.`);
+        export const ENTERPRISE_INVALID_ROOT_CA_PATH = new Driver(21, (args: Stringable[]) => `The provided Root CA path '${args[0]}' does not exist`);
+        export const UNRECOGNISED_SESSION_TYPE = new Driver(22, (args: Stringable[]) => `Session type '${args[1]}' was not recognised.`);
     }
 
     export class Concept extends ErrorMessage {

--- a/nodejs/common/errors/ErrorMessage.ts
+++ b/nodejs/common/errors/ErrorMessage.ts
@@ -76,7 +76,7 @@ export abstract class ErrorMessage {
 export namespace ErrorMessage {
     export class Driver extends ErrorMessage {
         constructor(code: number, message: (args?: Stringable[]) => string) {
-            super("CLI", code, "Driver Error", message)
+            super("DRI", code, "Driver Error", message)
         }
     }
 
@@ -98,7 +98,7 @@ export namespace ErrorMessage {
         export const ENTERPRISE_UNABLE_TO_CONNECT = new Driver(15, (args: Stringable[]) => `Unable to connect to TypeDB Enterprise. Attempted connecting to the enterprise nodes, but none are available: '${args[1]}'.`);
         export const ENTERPRISE_REPLICA_NOT_PRIMARY = new Driver(16, () => `The replica is not the primary replica.`);
         export const ENTERPRISE_ALL_NODES_FAILED = new Driver(17, (args: Stringable[]) => `Attempted connecting to all enterprise nodes, but the following errors occurred: \n'${args[0]}'`);
-        export const USER_MANAGEMENT_ENTERPRISE_ONLY = new Driver(18, (args: Stringable[]) => `User management is only available in TypeDB Enterprise servers.`);
+        export const USER_MANAGEMENT_ENTERPRISE_ONLY = new Driver(18, () => `User management is only available in TypeDB Enterprise servers.`);
         export const ENTERPRISE_USER_DOES_NOT_EXIST = new Driver(19, (args: Stringable[]) => `The user '${args[0]}' does not exist.`);
         export const ENTERPRISE_TOKEN_CREDENTIAL_INVALID = new Driver(20, (args: Stringable[]) => `Invalid token credential.`);
         export const ENTERPRISE_INVALID_ROOT_CA_PATH = new Driver(21, (args: Stringable[]) => `The provided Root CA path '${args[0]}' does not exist`);

--- a/nodejs/common/errors/TypeDBDriverError.ts
+++ b/nodejs/common/errors/TypeDBDriverError.ts
@@ -22,8 +22,8 @@
 import {ServiceError} from "@grpc/grpc-js";
 import {Status} from "@grpc/grpc-js/build/src/constants";
 import {ErrorMessage} from "./ErrorMessage";
-import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTPERPRISE_REPLICA_NOT_PRIMARY;
-import ENTERPRISE_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.ENTPERPRISE_TOKEN_CREDENTIAL_INVALID;
+import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTERPRISE_REPLICA_NOT_PRIMARY;
+import ENTERPRISE_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.ENTERPRISE_TOKEN_CREDENTIAL_INVALID;
 import UNABLE_TO_CONNECT = ErrorMessage.Driver.UNABLE_TO_CONNECT;
 import RPC_METHOD_UNAVAILABLE = ErrorMessage.Driver.RPC_METHOD_UNAVAILABLE;
 

--- a/nodejs/connection/TypeDBDatabaseImpl.ts
+++ b/nodejs/connection/TypeDBDatabaseImpl.ts
@@ -30,7 +30,7 @@ import {RequestBuilder} from "../common/rpc/RequestBuilder";
 import {ErrorMessage} from "../common/errors/ErrorMessage";
 import UNABLE_TO_CONNECT = ErrorMessage.Driver.UNABLE_TO_CONNECT;
 import DATABASE_DOES_NOT_EXIST = ErrorMessage.Driver.DATABASE_DOES_NOT_EXIST;
-import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTPERPRISE_REPLICA_NOT_PRIMARY;
+import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTERPRISE_REPLICA_NOT_PRIMARY;
 
 const PRIMARY_REPLICA_TASK_MAX_RETRIES = 10;
 const FETCH_REPLICAS_MAX_RETRIES = 10;

--- a/nodejs/connection/TypeDBDatabaseManagerImpl.ts
+++ b/nodejs/connection/TypeDBDatabaseManagerImpl.ts
@@ -26,8 +26,8 @@ import {TypeDBDriverError} from "../common/errors/TypeDBDriverError";
 import {RequestBuilder} from "../common/rpc/RequestBuilder";
 import {ServerDriver, TypeDBDriverImpl} from "./TypeDBDriverImpl";
 import {TypeDBDatabaseImpl} from "./TypeDBDatabaseImpl";
-import ENTERPRISE_ALL_NODES_FAILED = ErrorMessage.Driver.ENTPERPRISE_ALL_NODES_FAILED;
-import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTPERPRISE_REPLICA_NOT_PRIMARY;
+import ENTERPRISE_ALL_NODES_FAILED = ErrorMessage.Driver.ENTERPRISE_ALL_NODES_FAILED;
+import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTERPRISE_REPLICA_NOT_PRIMARY;
 import DB_DOES_NOT_EXIST = ErrorMessage.Driver.DATABASE_DOES_NOT_EXIST;
 
 export class TypeDBDatabaseManagerImpl implements DatabaseManager {

--- a/nodejs/connection/TypeDBDriverImpl.ts
+++ b/nodejs/connection/TypeDBDriverImpl.ts
@@ -35,13 +35,13 @@ import {TypeDBDatabaseManagerImpl} from "./TypeDBDatabaseManagerImpl";
 import {TypeDBSessionImpl} from "./TypeDBSessionImpl";
 import {TypeDBStubImpl} from "./TypeDBStubImpl";
 import DRIVER_NOT_OPEN = ErrorMessage.Driver.DRIVER_NOT_OPEN;
-import ENTERPRISE_UNABLE_TO_CONNECT = ErrorMessage.Driver.ENTPERPRISE_UNABLE_TO_CONNECT;
+import ENTERPRISE_UNABLE_TO_CONNECT = ErrorMessage.Driver.ENTERPRISE_UNABLE_TO_CONNECT;
 import SESSION_ID_EXISTS = ErrorMessage.Driver.SESSION_ID_EXISTS;
 import UNABLE_TO_CONNECT = ErrorMessage.Driver.UNABLE_TO_CONNECT;
 
 export class TypeDBDriverImpl implements TypeDBDriver {
     private _isOpen: boolean;
-    private _isEnterprise: boolean;
+    private readonly _isEnterprise: boolean;
 
     private readonly _initAddresses: string[];
     private readonly _credential: TypeDBCredential;
@@ -117,6 +117,10 @@ export class TypeDBDriverImpl implements TypeDBDriver {
 
     isOpen(): boolean {
         return this._isOpen;
+    }
+
+    isEnterprise(): boolean {
+        return this._isEnterprise;
     }
 
     async session(databaseName: string, type: SessionType, options?: TypeDBOptions): Promise<TypeDBSessionImpl> {

--- a/nodejs/connection/TypeDBStubImpl.ts
+++ b/nodejs/connection/TypeDBStubImpl.ts
@@ -27,7 +27,7 @@ import {TypeDBStub} from "../common/rpc/TypeDBStub";
 import {RequestBuilder} from "../common/rpc/RequestBuilder";
 import {ErrorMessage} from "../common/errors/ErrorMessage";
 import {TypeDBClient as GRPCStub} from "typedb-protocol/proto/typedb-service";
-import ENTERPRISE_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.ENTPERPRISE_TOKEN_CREDENTIAL_INVALID;
+import ENTERPRISE_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.ENTERPRISE_TOKEN_CREDENTIAL_INVALID;
 
 function isServiceError(e: any): e is ServiceError {
     return "code" in e;

--- a/nodejs/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/nodejs/test/behaviour/connection/ConnectionStepsBase.ts
@@ -91,14 +91,15 @@ export async function afterBase() {
 }
 
 Given('typedb has configuration', (table: any) => {
+    // empty
 })
 
 Given('typedb starts', async () => {
-
+    // empty
 })
 
 Given('typedb stops', async () => {
-
+    // empty
 })
 
 Given('connection opens with default authentication', async () => {

--- a/nodejs/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/nodejs/test/behaviour/connection/ConnectionStepsBase.ts
@@ -84,7 +84,7 @@ export async function afterBase() {
         await driver.close();
     }
     await createDefaultDriver();
-    for (let db of (await driver.databases.all())) {
+    for (const db of (await driver.databases.all())) {
         await db.delete();
     }
     await driver.close();

--- a/nodejs/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/nodejs/test/behaviour/connection/ConnectionStepsBase.ts
@@ -83,18 +83,22 @@ export async function afterBase() {
     if (driver.isOpen()) {
         await driver.close();
     }
+    await createDefaultDriver();
+    for (let db of (await driver.databases.all())) {
+        await db.delete();
+    }
+    await driver.close();
 }
 
 Given('typedb has configuration', (table: any) => {
-    // TODO: prepare a configuration through the TypeDB runner once it exists
 })
 
 Given('typedb starts', async () => {
-    // TODO: start TypeDB through the TypeDB runner once it exists
+
 })
 
 Given('typedb stops', async () => {
-    // TODO: stop TypeDB through the TypeDB runner once it exists
+
 })
 
 Given('connection opens with default authentication', async () => {

--- a/nodejs/test/behaviour/connection/transaction/BUILD
+++ b/nodejs/test/behaviour/connection/transaction/BUILD
@@ -51,5 +51,6 @@ typedb_behaviour_node_test(
         "//nodejs/test/behaviour/connection/database:steps",
         "//nodejs/test/behaviour/connection/session:steps",
         "//nodejs/test/behaviour/query:steps",
+        "//nodejs/test/behaviour/util:steps"
     ],
 )

--- a/nodejs/test/behaviour/connection/user/BUILD
+++ b/nodejs/test/behaviour/connection/user/BUILD
@@ -47,5 +47,7 @@ node_cucumber_test(
     name = "test-enterprise",
     steps = "@//nodejs/test/behaviour/connection:steps-enterprise",
     features = ["@vaticle_typedb_behaviour//connection:user.feature"],
-    data = [":steps"],
+    data = [
+        ":steps",
+    ],
 )

--- a/nodejs/test/behaviour/rules.bzl
+++ b/nodejs/test/behaviour/rules.bzl
@@ -44,7 +44,7 @@ def node_cucumber_test(name, features, data, steps, **kwargs):
         no_copy_to_bin = features,
         fixed_args = [
             "--publish-quiet", "--strict",
-            "--tags 'not @ignore and not @ignore-typedb and not @ignore-typedb-driver-nodejs and not @ignore-driver-nodejs'",
+            "--tags 'not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-nodejs'",
             "--require", "nodejs/test/**/*.js",
         ] + ["$(location {})".format(feature) for feature in features],
         **kwargs,

--- a/nodejs/test/integration/test-concept.js
+++ b/nodejs/test/integration/test-concept.js
@@ -351,8 +351,8 @@ async function run() {
         const firstPlayer = playersByRoleType.next().value;
         assert(firstPlayer.label.scopedName === "lion-family:lion-cub");
         await firstLionFamily.removeRolePlayer(tx, lionCub, firstLion);
-        const lionFamilyCleanedUp = await firstLionFamily.isDeleted(tx);
-        assert(lionFamilyCleanedUp);
+        const emptyLionFamilyExists = !(await firstLionFamily.isDeleted(tx));
+        assert(emptyLionFamilyExists);
         await tx.rollback();
         await tx.close();
         console.log(`Relation methods - SUCCESS`);

--- a/nodejs/user/UserManagerImpl.ts
+++ b/nodejs/user/UserManagerImpl.ts
@@ -25,6 +25,8 @@ import {RequestBuilder} from "../common/rpc/RequestBuilder";
 import {UserImpl} from "../dependencies_internal";
 import {ServerDriver, TypeDBDriverImpl} from "../connection/TypeDBDriverImpl";
 import {TypeDBDatabaseImpl} from "../connection/TypeDBDatabaseImpl";
+import {TypeDBDriverError} from "../common/errors/TypeDBDriverError";
+import {USER_MANAGEMENT_ENTERPRISE_ONLY} from "../common/errors/ErrorMessage";
 
 export class UserManagerImpl implements UserManager {
     static _SYSTEM_DB = "_system";
@@ -73,6 +75,7 @@ export class UserManagerImpl implements UserManager {
     }
 
     async runFailsafe<T>(task: (driver: ServerDriver) => Promise<T>): Promise<T> {
+        if (!this._driver.isEnterprise()) throw new TypeDBDriverError(USER_MANAGEMENT_ENTERPRISE_ONLY);
         return await (await TypeDBDatabaseImpl.get(UserManagerImpl._SYSTEM_DB, this._driver)).runOnPrimaryReplica(task);
     }
 }

--- a/nodejs/user/UserManagerImpl.ts
+++ b/nodejs/user/UserManagerImpl.ts
@@ -26,7 +26,8 @@ import {UserImpl} from "../dependencies_internal";
 import {ServerDriver, TypeDBDriverImpl} from "../connection/TypeDBDriverImpl";
 import {TypeDBDatabaseImpl} from "../connection/TypeDBDatabaseImpl";
 import {TypeDBDriverError} from "../common/errors/TypeDBDriverError";
-import {USER_MANAGEMENT_ENTERPRISE_ONLY} from "../common/errors/ErrorMessage";
+import {ErrorMessage} from "../common/errors/ErrorMessage";
+import USER_MANAGEMENT_ENTERPRISE_ONLY = ErrorMessage.Driver.USER_MANAGEMENT_ENTERPRISE_ONLY;
 
 export class UserManagerImpl implements UserManager {
     static _SYSTEM_DB = "_system";

--- a/python/tests/behaviour/background/core/environment.py
+++ b/python/tests/behaviour/background/core/environment.py
@@ -24,7 +24,7 @@ from typedb.driver import *
 from tests.behaviour.background import environment_base
 from tests.behaviour.context import Context
 
-IGNORE_TAGS = ["ignore", "ignore-driver-python", "ignore-typedb-driver-python"]
+IGNORE_TAGS = ["ignore", "ignore-typedb-driver", "ignore-typedb-driver-python"]
 
 
 def before_all(context: Context):

--- a/python/tests/behaviour/background/enterprise/environment.py
+++ b/python/tests/behaviour/background/enterprise/environment.py
@@ -25,7 +25,7 @@ from typedb.driver import *
 from tests.behaviour.background import environment_base
 from tests.behaviour.context import Context
 
-IGNORE_TAGS = ["ignore", "ignore-driver-python", "ignore-typedb-driver-python", "ignore-typedb-enterprise-driver-python"]
+IGNORE_TAGS = ["ignore", "ignore-typedb-driver", "ignore-typedb-driver-python"]
 
 
 def before_all(context: Context):

--- a/python/typedb/common/exception.py
+++ b/python/typedb/common/exception.py
@@ -85,7 +85,7 @@ class DriverErrorMessage(ErrorMessage):
     """
 
     def __init__(self, code: int, message: str):
-        super(DriverErrorMessage, self).__init__(code_prefix="CLI", code_number=code, message_prefix="Driver Error",
+        super(DriverErrorMessage, self).__init__(code_prefix="DRI", code_number=code, message_prefix="Driver Error",
                                                  message_body=message)
 
 

--- a/rust/docs/connection/Connection.adoc
+++ b/rust/docs/connection/Connection.adoc
@@ -31,6 +31,30 @@ Result
 connection.force_close()
 ----
 
+[#_struct_Connection_method_is_enterprise]
+==== is_enterprise
+
+[source,rust]
+----
+pub fn is_enterprise(&self) -> bool
+----
+
+Check if the connection is to an Enterprise server.
+
+[caption=""]
+.Returns
+[source,rust]
+----
+bool
+----
+
+[caption=""]
+.Code examples
+[source,rust]
+----
+connection.is_enterprise()
+----
+
 [#_struct_Connection_method_is_open]
 ==== is_open
 

--- a/rust/docs/errors/ConnectionError.adoc
+++ b/rust/docs/errors/ConnectionError.adoc
@@ -17,16 +17,19 @@ a| `EnterpriseEndpointEncrypted()`
 a| `EnterpriseReplicaNotPrimary()`
 a| `EnterpriseSSLCertificateNotValidated()`
 a| `EnterpriseTokenCredentialInvalid()`
-a| `EnterpriseUnableToConnect(String)`
 a| `InvalidResponseField(&'static str)`
 a| `MissingResponseField(&'static str)`
 a| `RPCMethodUnavailable(String)`
+a| `ServerConnectionFailed(String)`
+a| `ServerConnectionFailedStatusError(String)`
+a| `ServerConnectionFailedWithError(String)`
 a| `SessionCloseFailed()`
 a| `SessionIsClosed()`
 a| `TransactionIsClosed()`
 a| `TransactionIsClosedWithErrors(String)`
-a| `UnableToConnect()`
+a| `UnexpectedResponse(String)`
 a| `UnknownRequestId(ID)`
+a| `UserManagementEnterpriseOnly()`
 |===
 // end::enum_constants[]
 

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -48,12 +48,14 @@ error_messages! { ConnectionError
         11: "Received a response with unknown request id '{}'",
     InvalidResponseField(&'static str) =
         12: "Invalid field in message received from server: '{}'.",
+    ServerConnectionError(String) =
+        13: "Unable to connect to the server(s), received errors: \n{}",
     EnterpriseUnableToConnect(String) =
-        13: "Unable to connect to TypeDB Enterprise. Attempted connecting to the enterprise members, but none are available: '{}'.",
+        14: "Unable to connect to TypeDB Enterprise. Attempted connecting to the enterprise members, but none are available: '{}'.",
     EnterpriseReplicaNotPrimary() =
-        14: "The replica is not the primary replica.",
+        15: "The replica is not the primary replica.",
     EnterpriseAllNodesFailed(String) =
-        15: "Attempted connecting to all enterprise members, but the following errors occurred: \n{}.",
+        16: "Attempted connecting to all enterprise members, but the following errors occurred: \n{}.",
     EnterpriseTokenCredentialInvalid() =
         17: "Invalid token credential.",
     SessionCloseFailed() =

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -38,24 +38,28 @@ error_messages! { ConnectionError
         4: "The transaction is closed and no further operation is allowed.",
     TransactionIsClosedWithErrors(String) =
         5: "The transaction is closed because of the error(s):\n{}",
-    UnableToConnect() =
-        6: "Unable to connect to TypeDB server.",
     DatabaseDoesNotExist(String) =
-        9: "The database '{}' does not exist.",
+        6: "The database '{}' does not exist.",
     MissingResponseField(&'static str) =
-        10: "Missing field in message received from server: '{}'.",
+        7: "Missing field in message received from server: '{}'.",
     UnknownRequestId(RequestID) =
-        11: "Received a response with unknown request id '{}'",
+        8: "Received a response with unknown request id '{}'",
     InvalidResponseField(&'static str) =
-        12: "Invalid field in message received from server: '{}'.",
-    ServerConnectionError(String) =
-        13: "Unable to connect to the server(s), received errors: \n{}",
-    EnterpriseUnableToConnect(String) =
-        14: "Unable to connect to TypeDB Enterprise. Attempted connecting to the enterprise members, but none are available: '{}'.",
+        9: "Invalid field in message received from server: '{}'.",
+    UnexpectedResponse(String) =
+        10: "Received unexpected response from server: '{}'.",
+    ServerConnectionFailed(String) =
+        11: "Unable to connect to TypeDB server(s) at: \n{}",
+    ServerConnectionFailedWithError(String) =
+        12: "Unable to connect to TypeDB server(s), received errors: \n{}",
+    ServerConnectionFailedStatusError(String) =
+        13: "Unable to connect to TypeDB server(s), received network error: \n{}",
+    UserManagementEnterpriseOnly() =
+        14: "User management is only available in TypeDB Enterprise servers.",
     EnterpriseReplicaNotPrimary() =
         15: "The replica is not the primary replica.",
     EnterpriseAllNodesFailed(String) =
-        16: "Attempted connecting to all enterprise members, but the following errors occurred: \n{}.",
+        16: "Attempted connecting to all TypeDB Enterprise servers, but the following errors occurred: \n{}.",
     EnterpriseTokenCredentialInvalid() =
         17: "Invalid token credential.",
     SessionCloseFailed() =
@@ -67,7 +71,7 @@ error_messages! { ConnectionError
     BrokenPipe() =
         21: "Stream closed because of a broken pipe. This could happen if you are attempting to connect to an unencrypted enterprise instance using a TLS-enabled credential.",
     ConnectionRefused() =
-        22: "Connection refused. This could happen because of a misconfigured server SSL certificate, or network failures.",
+        22: "Connection refused. This could happen because of a misconfigured server SSL certificate or network failures.",
 }
 
 error_messages! { InternalError
@@ -134,7 +138,7 @@ impl Error {
         } else if status_message.contains("Connection refused") {
             Error::Connection(ConnectionError::ConnectionRefused())
         } else {
-            Error::Connection(ConnectionError::UnableToConnect())
+            Error::Connection(ConnectionError::ServerConnectionFailedStatusError(status_message.to_owned()))
         }
     }
 }
@@ -184,7 +188,7 @@ impl From<Status> for Error {
         if status.code() == Code::Unavailable {
             Self::parse_unavailable(status.message())
         } else if status.code() == Code::Unknown || is_rst_stream(&status) {
-            Self::Connection(ConnectionError::UnableToConnect())
+            Self::Connection(ConnectionError::ServerConnectionFailedStatusError(status.message().to_owned()))
         } else if status.code() == Code::Unimplemented {
             Self::Connection(ConnectionError::RPCMethodUnavailable(status.message().to_owned()))
         } else {

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -71,7 +71,7 @@ error_messages! { ConnectionError
     BrokenPipe() =
         21: "Stream closed because of a broken pipe. This could happen if you are attempting to connect to an unencrypted enterprise instance using a TLS-enabled credential.",
     ConnectionRefused() =
-        22: "Connection refused. This could happen because of a misconfigured server SSL certificate or network failures.",
+        22: "Connection refused. Please check the server is running and the address is accessible. Encrypted Enterprise endpoints may also have misconfigured SSL certificates.",
 }
 
 error_messages! { InternalError

--- a/rust/src/connection/connection.rs
+++ b/rust/src/connection/connection.rs
@@ -139,7 +139,12 @@ impl Connection {
                 errors.into_iter().map(|err| err.to_string()).collect::<Vec<_>>().join("\n"),
             ))?
         } else {
-            Ok(Self { server_connections, background_runtime, username: Some(credential.username().to_string()), is_enterprise: true })
+            Ok(Self {
+                server_connections,
+                background_runtime,
+                username: Some(credential.username().to_string()),
+                is_enterprise: true,
+            })
         }
     }
 
@@ -155,15 +160,20 @@ impl Connection {
                 Ok(server_connection) => match server_connection.servers_all() {
                     Ok(servers) => return Ok(servers.into_iter().collect()),
                     Err(Error::Connection(
-                            ConnectionError::ServerConnectionFailedStatusError(_) | ConnectionError::ConnectionRefused(),
+                        ConnectionError::ServerConnectionFailedStatusError(_) | ConnectionError::ConnectionRefused(),
                     )) => (),
                     Err(err) => Err(err)?,
                 },
-                Err(Error::Connection(ConnectionError::ServerConnectionFailedStatusError(_) | ConnectionError::ConnectionRefused())) => (),
+                Err(Error::Connection(
+                    ConnectionError::ServerConnectionFailedStatusError(_) | ConnectionError::ConnectionRefused(),
+                )) => (),
                 Err(err) => Err(err)?,
             }
         }
-        Err(ConnectionError::ServerConnectionFailed(addresses.into_iter().map(|a| a.to_string()).collect::<Vec<_>>().join(",")).into())
+        Err(ConnectionError::ServerConnectionFailed(
+            addresses.into_iter().map(|a| a.to_string()).collect::<Vec<_>>().join(","),
+        )
+        .into())
     }
 
     /// Checks it this connection is opened.

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -188,7 +188,9 @@ impl Database {
             match task(replica.database.clone(), self.connection.connection(&replica.address)?.clone(), is_first_run)
                 .await
             {
-                Err(Error::Connection(ConnectionError::ServerConnectionFailedStatusError(_) | ConnectionError::ConnectionRefused())) => {
+                Err(Error::Connection(
+                    ConnectionError::ServerConnectionFailedStatusError(_) | ConnectionError::ConnectionRefused(),
+                )) => {
                     debug!("Unable to connect to {}. Attempting next server.", replica.address);
                 }
                 res => return res,

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -188,7 +188,7 @@ impl Database {
             match task(replica.database.clone(), self.connection.connection(&replica.address)?.clone(), is_first_run)
                 .await
             {
-                Err(Error::Connection(ConnectionError::UnableToConnect() | ConnectionError::ConnectionRefused())) => {
+                Err(Error::Connection(ConnectionError::ServerConnectionFailedStatusError(_) | ConnectionError::ConnectionRefused())) => {
                     debug!("Unable to connect to {}. Attempting next server.", replica.address);
                 }
                 res => return res,
@@ -217,7 +217,7 @@ impl Database {
             {
                 Err(Error::Connection(
                     ConnectionError::EnterpriseReplicaNotPrimary()
-                    | ConnectionError::UnableToConnect()
+                    | ConnectionError::ServerConnectionFailedStatusError(_)
                     | ConnectionError::ConnectionRefused(),
                 )) => {
                     debug!("Primary replica error, waiting...");
@@ -323,7 +323,7 @@ impl Replica {
                 }
                 Err(Error::Connection(
                     ConnectionError::DatabaseDoesNotExist(_)
-                    | ConnectionError::UnableToConnect()
+                    | ConnectionError::ServerConnectionFailedStatusError(_)
                     | ConnectionError::ConnectionRefused(),
                 )) => {
                     error!(

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -118,7 +118,7 @@ impl DatabaseManager {
                 Err(err) => error_buffer.push(format!("- {}: {}", server_connection.address(), err)),
             }
         }
-        Err(ConnectionError::EnterpriseAllNodesFailed(error_buffer.join("\n")))?
+        Err(ConnectionError::ServerConnectionError(error_buffer.join("\n")))?
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
@@ -144,6 +144,6 @@ impl DatabaseManager {
                 Err(err) => error_buffer.push(format!("- {}: {}", server_connection.address(), err)),
             }
         }
-        Err(ConnectionError::EnterpriseAllNodesFailed(error_buffer.join("\n")))?
+        Err(ConnectionError::ServerConnectionError(error_buffer.join("\n")))?
     }
 }

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -118,7 +118,7 @@ impl DatabaseManager {
                 Err(err) => error_buffer.push(format!("- {}: {}", server_connection.address(), err)),
             }
         }
-        Err(ConnectionError::ServerConnectionError(error_buffer.join("\n")))?
+        Err(ConnectionError::ServerConnectionFailedWithError(error_buffer.join("\n")))?
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
@@ -144,6 +144,6 @@ impl DatabaseManager {
                 Err(err) => error_buffer.push(format!("- {}: {}", server_connection.address(), err)),
             }
         }
-        Err(ConnectionError::ServerConnectionError(error_buffer.join("\n")))?
+        Err(ConnectionError::ServerConnectionFailedWithError(error_buffer.join("\n")))?
     }
 }

--- a/rust/src/user/user_manager.rs
+++ b/rust/src/user/user_manager.rs
@@ -22,8 +22,9 @@
 #[cfg(not(feature = "sync"))]
 use std::future::Future;
 
-use crate::{common::Result, connection::ServerConnection, Connection, DatabaseManager, User, Error};
-use crate::error::ConnectionError;
+use crate::{
+    common::Result, connection::ServerConnection, error::ConnectionError, Connection, DatabaseManager, Error, User,
+};
 
 /// Provides access to all user management methods.
 #[derive(Clone, Debug)]
@@ -86,7 +87,7 @@ impl UserManager {
             let username = username.clone();
             async move { server_connection.contains_user(username).await }
         })
-            .await
+        .await
     }
 
     /// Create a user with the given name &amp; password.
@@ -110,7 +111,7 @@ impl UserManager {
             let password = password.clone();
             async move { server_connection.create_user(username, password).await }
         })
-            .await
+        .await
     }
 
     /// Deletes a user with the given name.
@@ -131,7 +132,7 @@ impl UserManager {
             let username = username.clone();
             async move { server_connection.delete_user(username).await }
         })
-            .await
+        .await
     }
 
     /// Retrieve a user with the given name.
@@ -152,7 +153,7 @@ impl UserManager {
             let username = username.clone();
             async move { server_connection.get_user(username).await }
         })
-            .await
+        .await
     }
 
     /// Sets a new password for a user. This operation can only be performed by administrators.
@@ -176,14 +177,14 @@ impl UserManager {
             let password = password.clone();
             async move { server_connection.set_user_password(username, password).await }
         })
-            .await
+        .await
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     async fn run_any_node<F, P, R>(&self, task: F) -> Result<R>
-        where
-            F: Fn(ServerConnection) -> P,
-            P: Future<Output=Result<R>>,
+    where
+        F: Fn(ServerConnection) -> P,
+        P: Future<Output = Result<R>>,
     {
         if !self.connection.is_enterprise() {
             Err(Error::Connection(ConnectionError::UserManagementEnterpriseOnly()))

--- a/rust/tests/behaviour/connection/session/steps.rs
+++ b/rust/tests/behaviour/connection/session/steps.rs
@@ -108,9 +108,9 @@ generic_step_impl! {
     }
 
     #[step(expr = "set session option {word} to: {word}")]
-    async fn set_session_option_to(_context: &mut Context, _option: String, _value: String) {
-        if _option == "session_timeout_millis" {
-            _context.options.session_idle_timeout = Some(Duration::from_millis(_value.parse().unwrap()));
+    async fn set_session_option_to(context: &mut Context, option: String, value: String) {
+        if option == "session_timeout_millis" {
+            context.options.session_idle_timeout = Some(Duration::from_millis(value.parse().unwrap()));
         } else {
             todo!();
         }

--- a/rust/tests/behaviour/connection/session/steps.rs
+++ b/rust/tests/behaviour/connection/session/steps.rs
@@ -35,21 +35,21 @@ generic_step_impl! {
     pub async fn connection_open_schema_session_for_database(context: &mut Context, name: String) {
         context
             .session_trackers
-            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options.clone()).await.unwrap().into());
+            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.session_options.clone()).await.unwrap().into());
     }
 
     #[step(expr = "connection open (data )session for database: {word}")]
     pub async fn connection_open_data_session_for_database(context: &mut Context, name: String) {
         context
             .session_trackers
-            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options.clone()).await.unwrap().into());
+            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.session_options.clone()).await.unwrap().into());
     }
 
     #[step(expr = "connection open schema session(s) for database(s):")]
     async fn connection_open_schema_sessions_for_databases(context: &mut Context, step: &Step) {
         for name in util::iter_table(step) {
             context.session_trackers.push(
-                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options.clone()).await.unwrap().into(),
+                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.session_options.clone()).await.unwrap().into(),
             );
         }
     }
@@ -58,7 +58,7 @@ generic_step_impl! {
     async fn connection_open_data_sessions_for_databases(context: &mut Context, step: &Step) {
         for name in util::iter_table(step) {
             context.session_trackers.push(
-                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options.clone()).await.unwrap().into(),
+                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.session_options.clone()).await.unwrap().into(),
             );
         }
     }
@@ -67,7 +67,7 @@ generic_step_impl! {
     async fn connection_open_data_sessions_in_parallel_for_databases(context: &mut Context, step: &Step) {
         let new_sessions = try_join_all(
             util::iter_table(step)
-                .map(|name| context.databases.get(name).and_then(|db| Session::new_with_options(db, SessionType::Data, context.options.clone()))),
+                .map(|name| context.databases.get(name).and_then(|db| Session::new_with_options(db, SessionType::Data, context.session_options.clone()))),
         )
         .await
         .unwrap();
@@ -109,10 +109,10 @@ generic_step_impl! {
 
     #[step(expr = "set session option {word} to: {word}")]
     async fn set_session_option_to(context: &mut Context, option: String, value: String) {
-        if option == "session_timeout_millis" {
-            context.options.session_idle_timeout = Some(Duration::from_millis(value.parse().unwrap()));
+        if option == "session-idle-timeout-millis" {
+            context.session_options.session_idle_timeout = Some(Duration::from_millis(value.parse().unwrap()));
         } else {
-            todo!();
+            todo!("Session option not recognised: {}", option);
         }
     }
 }

--- a/rust/tests/behaviour/connection/session/steps.rs
+++ b/rust/tests/behaviour/connection/session/steps.rs
@@ -22,6 +22,7 @@
 use cucumber::{gherkin::Step, given, then, when};
 use futures::{future::try_join_all, TryFutureExt};
 use typedb_driver::{Session, SessionType};
+use std::time::Duration;
 
 use crate::{
     behaviour::{util, Context},
@@ -33,21 +34,21 @@ generic_step_impl! {
     pub async fn connection_open_schema_session_for_database(context: &mut Context, name: String) {
         context
             .session_trackers
-            .push(Session::new(context.databases.get(name).await.unwrap(), SessionType::Schema).await.unwrap().into());
+            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options).await.unwrap().into());
     }
 
     #[step(expr = "connection open (data )session for database: {word}")]
     pub async fn connection_open_data_session_for_database(context: &mut Context, name: String) {
         context
             .session_trackers
-            .push(Session::new(context.databases.get(name).await.unwrap(), SessionType::Data).await.unwrap().into());
+            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options).await.unwrap().into());
     }
 
     #[step(expr = "connection open schema session(s) for database(s):")]
     async fn connection_open_schema_sessions_for_databases(context: &mut Context, step: &Step) {
         for name in util::iter_table(step) {
             context.session_trackers.push(
-                Session::new(context.databases.get(name).await.unwrap(), SessionType::Schema).await.unwrap().into(),
+                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options).await.unwrap().into(),
             );
         }
     }
@@ -56,7 +57,7 @@ generic_step_impl! {
     async fn connection_open_data_sessions_for_databases(context: &mut Context, step: &Step) {
         for name in util::iter_table(step) {
             context.session_trackers.push(
-                Session::new(context.databases.get(name).await.unwrap(), SessionType::Data).await.unwrap().into(),
+                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options).await.unwrap().into(),
             );
         }
     }
@@ -65,7 +66,7 @@ generic_step_impl! {
     async fn connection_open_data_sessions_in_parallel_for_databases(context: &mut Context, step: &Step) {
         let new_sessions = try_join_all(
             util::iter_table(step)
-                .map(|name| context.databases.get(name).and_then(|db| Session::new(db, SessionType::Data))),
+                .map(|name| context.databases.get(name).and_then(|db| Session::new_with_options(db, SessionType::Data, context.options))),
         )
         .await
         .unwrap();
@@ -107,10 +108,10 @@ generic_step_impl! {
 
     #[step(expr = "set session option {word} to: {word}")]
     async fn set_session_option_to(_context: &mut Context, _option: String, _value: String) {
-        todo!()
-        // if (!optionSetters.containsKey(option)) {
-        //     throw new RuntimeException("Unrecognised option: " + option);
-        // }
-        // optionSetters.get(option).accept(sessionOptions, value);
+        if _option == "session_timeout_millis" {
+            _context.options.session_idle_timeout = Some(Duration::from_millis(_value.parse().unwrap()));
+        } else {
+            todo!();
+        }
     }
 }

--- a/rust/tests/behaviour/connection/session/steps.rs
+++ b/rust/tests/behaviour/connection/session/steps.rs
@@ -19,10 +19,11 @@
  * under the License.
  */
 
+use std::time::Duration;
+
 use cucumber::{gherkin::Step, given, then, when};
 use futures::{future::try_join_all, TryFutureExt};
 use typedb_driver::{Session, SessionType};
-use std::time::Duration;
 
 use crate::{
     behaviour::{util, Context},

--- a/rust/tests/behaviour/connection/session/steps.rs
+++ b/rust/tests/behaviour/connection/session/steps.rs
@@ -34,21 +34,21 @@ generic_step_impl! {
     pub async fn connection_open_schema_session_for_database(context: &mut Context, name: String) {
         context
             .session_trackers
-            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options).await.unwrap().into());
+            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options.clone()).await.unwrap().into());
     }
 
     #[step(expr = "connection open (data )session for database: {word}")]
     pub async fn connection_open_data_session_for_database(context: &mut Context, name: String) {
         context
             .session_trackers
-            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options).await.unwrap().into());
+            .push(Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options.clone()).await.unwrap().into());
     }
 
     #[step(expr = "connection open schema session(s) for database(s):")]
     async fn connection_open_schema_sessions_for_databases(context: &mut Context, step: &Step) {
         for name in util::iter_table(step) {
             context.session_trackers.push(
-                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options).await.unwrap().into(),
+                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Schema, context.options.clone()).await.unwrap().into(),
             );
         }
     }
@@ -57,7 +57,7 @@ generic_step_impl! {
     async fn connection_open_data_sessions_for_databases(context: &mut Context, step: &Step) {
         for name in util::iter_table(step) {
             context.session_trackers.push(
-                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options).await.unwrap().into(),
+                Session::new_with_options(context.databases.get(name).await.unwrap(), SessionType::Data, context.options.clone()).await.unwrap().into(),
             );
         }
     }
@@ -66,7 +66,7 @@ generic_step_impl! {
     async fn connection_open_data_sessions_in_parallel_for_databases(context: &mut Context, step: &Step) {
         let new_sessions = try_join_all(
             util::iter_table(step)
-                .map(|name| context.databases.get(name).and_then(|db| Session::new_with_options(db, SessionType::Data, context.options))),
+                .map(|name| context.databases.get(name).and_then(|db| Session::new_with_options(db, SessionType::Data, context.options.clone()))),
         )
         .await
         .unwrap();

--- a/rust/tests/behaviour/connection/steps.rs
+++ b/rust/tests/behaviour/connection/steps.rs
@@ -36,11 +36,11 @@ generic_step_impl! {
     async fn connection_opens_with_authentication(context: &mut Context, login: String, password: String) {
         let connection = Connection::new_enterprise(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
-            Credential::without_tls(
+            Credential::with_tls(
                 &login,
                 &password,
-                // Some(&context.tls_root_ca),
-            )
+                Some(&context.tls_root_ca),
+            ).unwrap()
         );
         context.set_connection(connection.unwrap());
     }

--- a/rust/tests/behaviour/connection/steps.rs
+++ b/rust/tests/behaviour/connection/steps.rs
@@ -36,11 +36,11 @@ generic_step_impl! {
     async fn connection_opens_with_authentication(context: &mut Context, login: String, password: String) {
         let connection = Connection::new_enterprise(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
-            Credential::with_tls(
+            Credential::without_tls(
                 &login,
                 &password,
-                Some(&context.tls_root_ca),
-            ).unwrap(),
+                // Some(&context.tls_root_ca),
+            )
         );
         context.set_connection(connection.unwrap());
     }

--- a/rust/tests/behaviour/connection/transaction/steps.rs
+++ b/rust/tests/behaviour/connection/transaction/steps.rs
@@ -20,6 +20,7 @@
  */
 
 use std::time::Duration;
+
 use cucumber::{gherkin::Step, given, then, when};
 use typedb_driver::TransactionType;
 

--- a/rust/tests/behaviour/mod.rs
+++ b/rust/tests/behaviour/mod.rs
@@ -47,7 +47,8 @@ use self::session_tracker::SessionTracker;
 #[derive(Debug, World)]
 pub struct Context {
     pub tls_root_ca: PathBuf,
-    pub options: Options,
+    pub session_options: Options,
+    pub transaction_options: Options,
     pub connection: Connection,
     pub databases: DatabaseManager,
     pub users: UserManager,
@@ -97,7 +98,8 @@ impl Context {
 
     pub async fn after_scenario(&mut self) -> TypeDBResult {
         sleep(Context::STEP_REATTEMPT_SLEEP).await;
-        self.options = Options::new();
+        self.session_options = Options::new();
+        self.transaction_options = Options::new();
         self.set_connection(Connection::new_enterprise(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
             Credential::with_tls(Context::ADMIN_USERNAME, Context::ADMIN_PASSWORD, Some(&self.tls_root_ca))?,
@@ -222,7 +224,8 @@ impl Default for Context {
         let tls_root_ca = PathBuf::from(
             std::env::var("ROOT_CA").expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
         );
-        let options = Options::new();
+        let session_options = Options::new();
+        let transaction_options = Options::new();
         let connection = Connection::new_enterprise(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
             Credential::with_tls(Context::ADMIN_USERNAME, Context::ADMIN_PASSWORD, Some(&tls_root_ca)).unwrap(),
@@ -232,7 +235,8 @@ impl Default for Context {
         let users = UserManager::new(connection.clone());
         Self {
             tls_root_ca,
-            options,
+            session_options,
+            transaction_options,
             connection,
             databases,
             users,

--- a/rust/tests/behaviour/mod.rs
+++ b/rust/tests/behaviour/mod.rs
@@ -35,18 +35,14 @@ use std::{
 use cucumber::{StatsWriter, World};
 use futures::future::try_join_all;
 use tokio::time::{sleep, Duration};
-use typedb_driver::{
-    answer::{ConceptMap, ConceptMapGroup, ValueGroup, JSON},
-    concept::{Attribute, AttributeType, Entity, EntityType, Relation, RelationType, Thing, Value},
-    logic::Rule,
-    Connection, Credential, Database, DatabaseManager, Result as TypeDBResult, Transaction, UserManager,
-};
+use typedb_driver::{answer::{ConceptMap, ConceptMapGroup, ValueGroup, JSON}, concept::{Attribute, AttributeType, Entity, EntityType, Relation, RelationType, Thing, Value}, logic::Rule, Connection, Credential, Database, DatabaseManager, Result as TypeDBResult, Transaction, UserManager, Options};
 
 use self::session_tracker::SessionTracker;
 
 #[derive(Debug, World)]
 pub struct Context {
     pub tls_root_ca: PathBuf,
+    pub options: Options,
     pub connection: Connection,
     pub databases: DatabaseManager,
     pub users: UserManager,
@@ -96,6 +92,7 @@ impl Context {
 
     pub async fn after_scenario(&mut self) -> TypeDBResult {
         sleep(Context::STEP_REATTEMPT_SLEEP).await;
+        self.options = Options::new();
         self.set_connection(Connection::new_enterprise(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
             Credential::with_tls(Context::ADMIN_USERNAME, Context::ADMIN_PASSWORD, Some(&self.tls_root_ca))?,
@@ -220,6 +217,7 @@ impl Default for Context {
         let tls_root_ca = PathBuf::from(
             std::env::var("ROOT_CA").expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
         );
+        let options = Options::new();
         let connection = Connection::new_enterprise(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
             Credential::with_tls(Context::ADMIN_USERNAME, Context::ADMIN_PASSWORD, Some(&tls_root_ca)).unwrap(),
@@ -229,6 +227,7 @@ impl Default for Context {
         let users = UserManager::new(connection.clone());
         Self {
             tls_root_ca,
+            options,
             connection,
             databases,
             users,

--- a/rust/tests/behaviour/mod.rs
+++ b/rust/tests/behaviour/mod.rs
@@ -87,7 +87,7 @@ impl Context {
     }
 
     fn is_ignore_tag(t: &String) -> bool {
-        t == "ignore" || t == "ignore-typedb" || t == "ignore-driver-rust" || t == "ignore-typedb-driver-rust"
+        t == "ignore" || t == "ignore-typedb-driver" || t == "ignore-typedb-driver-rust"
     }
 
     pub async fn after_scenario(&mut self) -> TypeDBResult {

--- a/rust/tests/behaviour/mod.rs
+++ b/rust/tests/behaviour/mod.rs
@@ -35,7 +35,12 @@ use std::{
 use cucumber::{StatsWriter, World};
 use futures::future::try_join_all;
 use tokio::time::{sleep, Duration};
-use typedb_driver::{answer::{ConceptMap, ConceptMapGroup, ValueGroup, JSON}, concept::{Attribute, AttributeType, Entity, EntityType, Relation, RelationType, Thing, Value}, logic::Rule, Connection, Credential, Database, DatabaseManager, Result as TypeDBResult, Transaction, UserManager, Options};
+use typedb_driver::{
+    answer::{ConceptMap, ConceptMapGroup, ValueGroup, JSON},
+    concept::{Attribute, AttributeType, Entity, EntityType, Relation, RelationType, Thing, Value},
+    logic::Rule,
+    Connection, Credential, Database, DatabaseManager, Options, Result as TypeDBResult, Transaction, UserManager,
+};
 
 use self::session_tracker::SessionTracker;
 

--- a/rust/tests/behaviour/session_tracker.rs
+++ b/rust/tests/behaviour/session_tracker.rs
@@ -51,7 +51,11 @@ impl SessionTracker {
         &self.session
     }
 
-    pub async fn open_transaction(&mut self, transaction_type: TransactionType, transaction_options: Options) -> typedb_driver::Result {
+    pub async fn open_transaction(
+        &mut self,
+        transaction_type: TransactionType,
+        transaction_options: Options,
+    ) -> typedb_driver::Result {
         unsafe {
             // SAFETY: the transactions tracked by the SessionTracker instance borrow SessionTracker::session.
             // As long as SessionTracker is alive, the transactions are valid.

--- a/rust/tests/behaviour/session_tracker.rs
+++ b/rust/tests/behaviour/session_tracker.rs
@@ -51,15 +51,11 @@ impl SessionTracker {
         &self.session
     }
 
-    pub async fn open_transaction(&mut self, transaction_type: TransactionType) -> typedb_driver::Result {
-        let options = match transaction_type {
-            TransactionType::Write => Options::new(),
-            TransactionType::Read => Options::new().infer(true),
-        };
+    pub async fn open_transaction(&mut self, transaction_type: TransactionType, transaction_options: Options) -> typedb_driver::Result {
         unsafe {
             // SAFETY: the transactions tracked by the SessionTracker instance borrow SessionTracker::session.
             // As long as SessionTracker is alive, the transactions are valid.
-            let transaction = self.session.transaction_with_options(transaction_type, options).await?;
+            let transaction = self.session.transaction_with_options(transaction_type, transaction_options).await?;
             self.transactions.push(std::mem::transmute(transaction));
         }
         Ok(())

--- a/rust/tests/behaviour/util/steps.rs
+++ b/rust/tests/behaviour/util/steps.rs
@@ -21,9 +21,9 @@
 
 use std::env;
 
+use cucumber::{given, then, when};
 use tokio::time::{sleep, Duration};
 
-use cucumber::{given, then, when};
 use crate::{behaviour::Context, generic_step_impl};
 
 generic_step_impl! {

--- a/rust/tests/behaviour/util/steps.rs
+++ b/rust/tests/behaviour/util/steps.rs
@@ -34,6 +34,6 @@ generic_step_impl! {
 
     #[step(expr = "wait {word} seconds")]
     async fn wait_seconds(_context: &mut Context, seconds: String) {
-        sleep(Duration::from_seconds(seconds.parse().unwrap())).await
+        sleep(Duration::from_secs(seconds.parse().unwrap())).await
     }
 }

--- a/rust/tests/behaviour/util/steps.rs
+++ b/rust/tests/behaviour/util/steps.rs
@@ -21,13 +21,19 @@
 
 use std::env;
 
-use cucumber::{given, then, when};
+use tokio::time::{sleep, Duration};
 
+use cucumber::{given, then, when};
 use crate::{behaviour::Context, generic_step_impl};
 
 generic_step_impl! {
     #[step(expr = "set time-zone is: {word}")]
     async fn set_time_zone(_context: &mut Context, timezone: String) {
         env::set_var("TZ", timezone);
+    }
+
+    #[step(expr = "wait {word} seconds")]
+    async fn wait_seconds(_context: &mut Context, seconds: String) {
+        sleep(Duration::from_seconds(seconds.parse().unwrap())).await
     }
 }

--- a/rust/tests/integration/common.rs
+++ b/rust/tests/integration/common.rs
@@ -35,14 +35,14 @@ pub fn new_core_connection() -> typedb_driver::Result<Connection> {
 pub fn new_enterprise_connection() -> typedb_driver::Result<Connection> {
     Connection::new_enterprise(
         &["localhost:11729", "localhost:21729", "localhost:31729"],
-        Credential::without_tls(
+        Credential::with_tls(
             "admin",
             "password",
-            // Some(&PathBuf::from(
-            //     std::env::var("ROOT_CA")
-            //         .expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
-            // )),
-        ),
+            Some(&PathBuf::from(
+                std::env::var("ROOT_CA")
+                    .expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
+            )),
+        )?,
     )
 }
 

--- a/rust/tests/integration/common.rs
+++ b/rust/tests/integration/common.rs
@@ -35,14 +35,14 @@ pub fn new_core_connection() -> typedb_driver::Result<Connection> {
 pub fn new_enterprise_connection() -> typedb_driver::Result<Connection> {
     Connection::new_enterprise(
         &["localhost:11729", "localhost:21729", "localhost:31729"],
-        Credential::with_tls(
+        Credential::without_tls(
             "admin",
             "password",
-            Some(&PathBuf::from(
-                std::env::var("ROOT_CA")
-                    .expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
-            )),
-        )?,
+            // Some(&PathBuf::from(
+            //     std::env::var("ROOT_CA")
+            //         .expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
+            // )),
+        ),
     )
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

We optimise Java CI time by not shutting down the TypeDB server between scenarios. Instead, we delete the existing databases each test, which is much faster. 

During this work, we also discovered some sub-par UX in terms of error messages thrown, and missing BDD steps that needed to be implemented.

## What are the changes implemented in this PR?

* Only boot up TypeDB during the Java BDD Feature setup
* Shut down TypeDB after the last behaviour scenario
* Ignore tests using server configuration - we should only run these from the backend.
* Clean up various Rust and Node error messsages
* Fix `ignore` tags that we parse from BDD
  * This led to new scenarios running that we were missing BDD implementation in Rust.