### PR TITLE
Add untyped value getter for Java values and fix Python type hints

### DIFF
--- a/java/api/concept/value/Value.java
+++ b/java/api/concept/value/Value.java
@@ -115,6 +115,17 @@ public interface Value extends Concept {
     boolean isDateTime();
 
     /**
+     * Returns an untyped <code>Object</code> value of this value concept.
+     * This is useful for value equality or printing without having to switch on the actual contained value.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * value.asUntyped();
+     * </pre>
+     */
+    Object asUntyped();
+
+    /**
      * Returns a <code>boolean</code> value of this value concept.
      * If the value has another type, raises an exception.
      *

--- a/java/concept/value/ValueImpl.java
+++ b/java/concept/value/ValueImpl.java
@@ -114,6 +114,16 @@ public class ValueImpl extends ConceptImpl implements Value {
     }
 
     @Override
+    public Object asUntyped() {
+        if (isBoolean()) return asBoolean();
+        else if (isLong()) return asLong();
+        else if (isDouble()) return asDouble();
+        else if (isString()) return asString();
+        else if (isDateTime()) return asDateTime();
+        throw new TypeDBDriverException(UNEXPECTED_NATIVE_VALUE);
+    }
+
+    @Override
     public boolean asBoolean() {
         if (!isBoolean()) throw new TypeDBDriverException(ILLEGAL_CAST, "boolean");
         return value_get_boolean(nativeObject);
@@ -160,11 +170,6 @@ public class ValueImpl extends ConceptImpl implements Value {
     }
 
     private int computeHash() {
-        if (isBoolean()) return Boolean.hashCode(asBoolean());
-        else if (isLong()) return Long.hashCode(asLong());
-        else if (isDouble()) return Double.hashCode(asDouble());
-        else if (isString()) return asString().hashCode();
-        else if (isDateTime()) return asDateTime().hashCode();
-        return -1;
+        return asUntyped().hashCode();
     }
 }

--- a/java/docs/data/Value.adoc
+++ b/java/docs/data/Value.adoc
@@ -349,6 +349,28 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
+[#_Value_asUntyped_]
+==== asUntyped
+
+[source,java]
+----
+java.lang.Object asUntyped()
+----
+
+Returns an untyped ``Object`` value of this value concept. This is useful for value equality or printing without having to switch on the actual contained value. 
+
+
+[caption=""]
+.Returns
+`java.lang.Object`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+value.asUntyped();
+----
+
 [#_Value_asValue_]
 ==== asValue
 

--- a/python/docs/schema/Type.adoc
+++ b/python/docs/schema/Type.adoc
@@ -217,7 +217,7 @@ type_.is_type()
 
 [source,python]
 ----
-set_label(transaction: TypeDBTransaction, new_label: Label) -> Promise[None]
+set_label(transaction: TypeDBTransaction, new_label: str) -> Promise[None]
 ----
 
 Renames the label of the type. The new label must remain unique.
@@ -229,7 +229,7 @@ Renames the label of the type. The new label must remain unique.
 |===
 |Name |Description |Type |Default Value
 a| `transaction` a| The current transaction a| `TypeDBTransaction` a| 
-a| `new_label` a| The new ``Label`` to be given to the type. a| `Label` a| 
+a| `new_label` a| The new name to be given to the type. a| `str` a| 
 |===
 
 [caption=""]

--- a/python/typedb/api/concept/type/type.py
+++ b/python/typedb/api/concept/type/type.py
@@ -50,12 +50,12 @@ class Type(Concept, ABC):
         pass
 
     @abstractmethod
-    def set_label(self, transaction: TypeDBTransaction, new_label: Label) -> Promise[None]:
+    def set_label(self, transaction: TypeDBTransaction, new_label: str) -> Promise[None]:
         """
         Renames the label of the type. The new label must remain unique.
 
         :param transaction: The current transaction
-        :param new_label: The new ``Label`` to be given to the type.
+        :param new_label: The new name to be given to the type.
         :return:
 
         Examples

--- a/python/typedb/concept/type/thing_type.py
+++ b/python/typedb/concept/type/thing_type.py
@@ -81,7 +81,7 @@ class _ThingType(ThingType, _Type, ABC):
         promise = thing_type_is_deleted(transaction.native_object, self.native_object)
         return Promise(lambda: bool_promise_resolve(promise))
 
-    def set_label(self, transaction: _Transaction, new_label: Label) -> Promise[None]:
+    def set_label(self, transaction: _Transaction, new_label: str) -> Promise[None]:
         promise = thing_type_set_label(transaction.native_object, self.native_object, new_label)
         return Promise(lambda: void_promise_resolve(promise))
 


### PR DESCRIPTION
## Release notes: usage and product changes

We add a simple untyped API to Java's `Value` concepts, which return the value inside of the Value regardless of its type (double/string/etc.). This value is returned as an Object, and useful for equality checks, printing, etc. Additionally, the same API exists in Python and Node already.

We also fix the Python hints for setting the name of a Type, which was incorrectly hinting the type 'Label' when it should have been a simple string.

## Implementation

- Add 'public Object getUntyped()` to `concept.Value`
- Fix python type hintings in `Type.set_label(tx: Transaction, label: Label)` to `Type.set_label(tx: Transaction, label: str)`
- Regenerate documentation
