### PR TITLE
Silence send errors in network callbacks when receiver dropped

### DIFF
--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -79,7 +79,7 @@ error_messages! { InternalError
     RecvError() =
         1: "Channel is closed.",
     SendError() =
-        2: "Channel is closed.",
+        2: "Unable to send response over callback channel (receiver dropped).",
     UnexpectedRequestType(String) =
         3: "Unexpected request type for remote procedure call: {}.",
     UnexpectedResponseType(String) =
@@ -215,8 +215,8 @@ impl From<tonic::transport::Error> for Error {
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {
-    fn from(err: tokio::sync::mpsc::error::SendError<T>) -> Self {
-        Self::Other(err.to_string())
+    fn from(_err: tokio::sync::mpsc::error::SendError<T>) -> Self {
+        Self::Internal(InternalError::SendError())
     }
 }
 

--- a/rust/src/connection/network/transmitter/response_sink.rs
+++ b/rust/src/connection/network/transmitter/response_sink.rs
@@ -44,10 +44,8 @@ impl<T> ResponseSink<T> {
             Self::Streamed(sink) => sink.send(response).map_err(Error::from),
         };
         match result {
-            Err(Error::Internal(InternalError::SendError())) => {
-                debug!("Unable to send response over callback channel (receiver dropped)")
-            }
-            Err(err) => error!("{}", err),
+            Err(Error::Internal(err @ InternalError::SendError())) => debug!("{err}"),
+            Err(err) => error!("{err}"),
             Ok(()) => (),
         }
     }
@@ -58,10 +56,8 @@ impl<T> ResponseSink<T> {
             _ => unreachable!("attempted to stream over a one-shot callback"),
         };
         match result {
-            Err(Error::Internal(InternalError::SendError())) => {
-                debug!("Unable to send response over callback channel (receiver dropped)")
-            }
-            Err(err) => error!("{}", err),
+            Err(Error::Internal(err @ InternalError::SendError())) => debug!("{err}"),
+            Err(err) => error!("{err}"),
             Ok(()) => (),
         }
     }


### PR DESCRIPTION
## Release notes: usage and product changes

Downgrade the "channel closed" `SendError` from ERROR to DEBUG when the receiving end of the stream is dropped before the stream is exhausted.

