### PR TITLE
Generate unique documentation anchors

### DIFF
--- a/java/TypeDB.java
+++ b/java/TypeDB.java
@@ -32,14 +32,48 @@ import static com.vaticle.typedb.common.collection.Collections.set;
 public class TypeDB {
     public static final String DEFAULT_ADDRESS = "localhost:1729";
 
+    /**
+     * Open a TypeDB Driver to a TypeDB Core server available at the provided address.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * TypeDB.coreDriver(address);
+     * </pre>
+     *
+     * @param address The address of the TypeDB server
+     */
     public static TypeDBDriver coreDriver(String address) {
         return new TypeDBDriverImpl(address);
     }
 
+    /**
+     * Open a TypeDB Driver to a TypeDB Enterprise server available at the provided address, using
+     * the provided credential.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * TypeDB.enterpriseDriver(address, credential);
+     * </pre>
+     *
+     * @param address The address of the TypeDB server
+     * @param credential The credential to connect with
+     */
     public static TypeDBDriver enterpriseDriver(String address, TypeDBCredential credential) {
         return enterpriseDriver(set(address), credential);
     }
 
+    /**
+     * Open a TypeDB Driver to TypeDB Enterprise server(s) available at the provided addresses, using
+     * the provided credential.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * TypeDB.enterpriseDriver(addresses, credential);
+     * </pre>
+     *
+     * @param addresses The address(es) of the TypeDB server(s)
+     * @param credential The credential to connect with
+     */
     public static TypeDBDriver enterpriseDriver(Set<String> addresses, TypeDBCredential credential) {
         return new TypeDBDriverImpl(addresses, credential);
     }

--- a/java/common/Promise.java
+++ b/java/common/Promise.java
@@ -34,6 +34,16 @@ import java.util.function.Supplier;
 public class Promise<T> {
     private final Supplier<T> inner;
 
+    /**
+     * Promise constructor
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * new Promise(supplier)
+     * </pre>
+     *
+     * @param inner The supplier to function to wrap into the promise
+     */
     public Promise(Supplier<T> inner) {
         this.inner = inner;
     }
@@ -55,7 +65,15 @@ public class Promise<T> {
     }
 
     /**
-     * @hidden
+     * Helper function to map promises.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * Promise.map(supplier, mapper);
+     * </pre>
+     *
+     * @param promise The supplier function to wrap into the promise
+     * @param fn The mapping function
      */
     static public<T, U> Promise<U> map(Supplier<T> promise, Function<T, U> fn) {
         return new Promise<>(() -> {

--- a/java/docs/answer/ConceptMap.Explainable.adoc
+++ b/java/docs/answer/ConceptMap.Explainable.adoc
@@ -1,4 +1,4 @@
-[#_ConceptMap.Explainable]
+[#_ConceptMap_Explainable]
 === ConceptMap.Explainable
 
 *Package*: `com.vaticle.typedb.driver.api.answer`
@@ -6,7 +6,7 @@
 Contains an explainable object.
 
 // tag::methods[]
-[#_ConceptMap.Explainable_conjunction_]
+[#_ConceptMap_Explainable_conjunction__]
 ==== conjunction
 
 [source,java]
@@ -28,7 +28,7 @@ Retrieves the subquery of the original query that is actually being explained.
 explainable.conjunction();
 ----
 
-[#_ConceptMap.Explainable_id_]
+[#_ConceptMap_Explainable_id__]
 ==== id
 
 [source,java]

--- a/java/docs/answer/ConceptMap.Explainables.adoc
+++ b/java/docs/answer/ConceptMap.Explainables.adoc
@@ -1,4 +1,4 @@
-[#_ConceptMap.Explainables]
+[#_ConceptMap_Explainables]
 === ConceptMap.Explainables
 
 *Package*: `com.vaticle.typedb.driver.api.answer`
@@ -6,7 +6,7 @@
 Contains explainable objects.
 
 // tag::methods[]
-[#_ConceptMap.Explainables_attribute_java_lang_String]
+[#_ConceptMap_Explainables_attribute__java_lang_String]
 ==== attribute
 
 [source,java]
@@ -37,7 +37,7 @@ a| `variable` a| The string representation of a variable a| `java.lang.String`
 conceptMap.explainables().attribute(variable);
 ----
 
-[#_ConceptMap.Explainables_attributes_]
+[#_ConceptMap_Explainables_attributes__]
 ==== attributes
 
 [source,java]
@@ -59,7 +59,7 @@ Retrieves all of this ``ConceptMap``’s explainable attributes.
 conceptMap.explainables().attributes();
 ----
 
-[#_ConceptMap.Explainables_ownership_java_lang_String_java_lang_String]
+[#_ConceptMap_Explainables_ownership__java_lang_String__java_lang_String]
 ==== ownership
 
 [source,java]
@@ -92,7 +92,7 @@ a| `attribute` a| The string representation of the attribute variable a| `java.l
 conceptMap.explainables().ownership(owner, attribute);
 ----
 
-[#_ConceptMap.Explainables_ownerships_]
+[#_ConceptMap_Explainables_ownerships__]
 ==== ownerships
 
 [source,java]
@@ -114,7 +114,7 @@ Retrieves all of this ``ConceptMap``’s explainable ownerships.
 conceptMap.explainables().ownerships();
 ----
 
-[#_ConceptMap.Explainables_relation_java_lang_String]
+[#_ConceptMap_Explainables_relation__java_lang_String]
 ==== relation
 
 [source,java]
@@ -145,7 +145,7 @@ a| `variable` a| The string representation of a variable a| `java.lang.String`
 conceptMap.explainables().relation(variable);
 ----
 
-[#_ConceptMap.Explainables_relations_]
+[#_ConceptMap_Explainables_relations__]
 ==== relations
 
 [source,java]

--- a/java/docs/answer/ConceptMap.adoc
+++ b/java/docs/answer/ConceptMap.adoc
@@ -6,7 +6,7 @@
 Contains a mapping of variables to concepts.
 
 // tag::methods[]
-[#_ConceptMap_concepts_]
+[#_ConceptMap_concepts__]
 ==== concepts
 
 [source,java]
@@ -29,7 +29,7 @@ Produces a stream over all concepts in this ``ConceptMap``.
 conceptMap.concepts();
 ----
 
-[#_ConceptMap_explainables_]
+[#_ConceptMap_explainables__]
 ==== explainables
 
 [source,java]
@@ -51,7 +51,7 @@ Gets the ``Explainables`` object for this ``ConceptMap``, exposing which of the 
 conceptMap.explainables();
 ----
 
-[#_ConceptMap_get_java_lang_String]
+[#_ConceptMap_get__java_lang_String]
 ==== get
 
 [source,java]
@@ -83,7 +83,7 @@ a| `variable` a| The string representation of a variable a| `java.lang.String`
 conceptMap.get(variable);
 ----
 
-[#_ConceptMap_variables_]
+[#_ConceptMap_variables__]
 ==== variables
 
 [source,java]

--- a/java/docs/answer/ConceptMapGroup.adoc
+++ b/java/docs/answer/ConceptMapGroup.adoc
@@ -6,7 +6,7 @@
 Contains an element of the group query result.
 
 // tag::methods[]
-[#_ConceptMapGroup_conceptMaps_]
+[#_ConceptMapGroup_conceptMaps__]
 ==== conceptMaps
 
 [source,java]
@@ -29,7 +29,7 @@ Retrieves the ``ConceptMap``s of the group.
 conceptMapGroup.conceptMaps();
 ----
 
-[#_ConceptMapGroup_owner_]
+[#_ConceptMapGroup_owner__]
 ==== owner
 
 [source,java]

--- a/java/docs/answer/Explanation.adoc
+++ b/java/docs/answer/Explanation.adoc
@@ -6,7 +6,7 @@
 An explanation of which rule was used for inferring the explained concept, the condition of the rule, the conclusion of the rule, and the mapping of variables between the query and the rule’s conclusion.
 
 // tag::methods[]
-[#_Explanation_conclusion_]
+[#_Explanation_conclusion__]
 ==== conclusion
 
 [source,java]
@@ -28,7 +28,7 @@ Retrieves the Conclusion for this Explanation.
 explanation.conclusion()
 ----
 
-[#_Explanation_condition_]
+[#_Explanation_condition__]
 ==== condition
 
 [source,java]
@@ -50,7 +50,7 @@ Retrieves the Condition for this Explanation.
 explanation.condition()
 ----
 
-[#_Explanation_queryVariableMapping_java_lang_String]
+[#_Explanation_queryVariableMapping__java_lang_String]
 ==== queryVariableMapping
 
 [source,java]
@@ -81,7 +81,7 @@ a| `var` a| The query variable to map to rule variables. a| `java.lang.String`
 explanation.variableMapping(var)
 ----
 
-[#_Explanation_queryVariables_]
+[#_Explanation_queryVariables__]
 ==== queryVariables
 
 [source,java]
@@ -103,7 +103,7 @@ Retrieves the query variables for this ``Explanation``.
 explanation.queryVariables()
 ----
 
-[#_Explanation_rule_]
+[#_Explanation_rule__]
 ==== rule
 
 [source,java]

--- a/java/docs/answer/JSON.adoc
+++ b/java/docs/answer/JSON.adoc
@@ -4,7 +4,7 @@
 *Package*: `com.vaticle.typedb.driver.api.answer`
 
 // tag::methods[]
-[#_JSON__init__]
+[#_JSON_JSON__]
 ==== JSON
 
 [source,java]
@@ -18,7 +18,7 @@ public JSON()
 .Returns
 `public`
 
-[#_JSON_asArray_]
+[#_JSON_asArray__]
 ==== asArray
 
 [source,java]
@@ -32,7 +32,7 @@ public java.util.List<JSON> asArray()
 .Returns
 `public java.util.List<JSON>`
 
-[#_JSON_asBoolean_]
+[#_JSON_asBoolean__]
 ==== asBoolean
 
 [source,java]
@@ -46,7 +46,7 @@ public boolean asBoolean()
 .Returns
 `public boolean`
 
-[#_JSON_asNumber_]
+[#_JSON_asNumber__]
 ==== asNumber
 
 [source,java]
@@ -60,7 +60,7 @@ public double asNumber()
 .Returns
 `public double`
 
-[#_JSON_asObject_]
+[#_JSON_asObject__]
 ==== asObject
 
 [source,java]
@@ -74,7 +74,7 @@ public java.util.Map<java.lang.String,​JSON> asObject()
 .Returns
 `public java.util.Map<java.lang.String,​JSON>`
 
-[#_JSON_asString_]
+[#_JSON_asString__]
 ==== asString
 
 [source,java]
@@ -88,7 +88,7 @@ public java.lang.String asString()
 .Returns
 `public java.lang.String`
 
-[#_JSON_isArray_]
+[#_JSON_isArray__]
 ==== isArray
 
 [source,java]
@@ -102,7 +102,7 @@ public boolean isArray()
 .Returns
 `public boolean`
 
-[#_JSON_isBoolean_]
+[#_JSON_isBoolean__]
 ==== isBoolean
 
 [source,java]
@@ -116,7 +116,7 @@ public boolean isBoolean()
 .Returns
 `public boolean`
 
-[#_JSON_isNumber_]
+[#_JSON_isNumber__]
 ==== isNumber
 
 [source,java]
@@ -130,7 +130,7 @@ public boolean isNumber()
 .Returns
 `public boolean`
 
-[#_JSON_isObject_]
+[#_JSON_isObject__]
 ==== isObject
 
 [source,java]
@@ -144,7 +144,7 @@ public boolean isObject()
 .Returns
 `public boolean`
 
-[#_JSON_isString_]
+[#_JSON_isString__]
 ==== isString
 
 [source,java]
@@ -158,7 +158,7 @@ public boolean isString()
 .Returns
 `public boolean`
 
-[#_JSON_parse_java_lang_String]
+[#_JSON_parse__java_lang_String]
 ==== parse
 
 [source,java]

--- a/java/docs/answer/Promise_T_.adoc
+++ b/java/docs/answer/Promise_T_.adoc
@@ -1,4 +1,4 @@
-[#_Promise<T>]
+[#_Promise_T]
 === Promise<T>
 
 *Package*: `com.vaticle.typedb.driver.common`
@@ -8,7 +8,7 @@ A ``Promise`` represents an asynchronous network operation.
 The request it represents is performed immediately. The response is only retrieved once the ``Promise`` is ``resolve``d.
 
 // tag::methods[]
-[#_Promise<T>__init__java_util_function_Supplier]
+[#_Promise_T_Promise__java_util_function_Supplier_T_]
 ==== Promise
 
 [source,java]
@@ -16,13 +16,63 @@ The request it represents is performed immediately. The response is only retriev
 public Promise​(java.util.function.Supplier<T> inner)
 ----
 
+Promise constructor 
 
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `inner` a| The supplier to function to wrap into the promise a| `java.util.function.Supplier<T>`
+|===
 
 [caption=""]
 .Returns
 `public`
 
-[#_Promise<T>_resolve_]
+[caption=""]
+.Code examples
+[source,java]
+----
+new Promise(supplier)
+----
+
+[#_Promise_T_map__java_util_function_Supplier_T___java_util_function_Function_T_​U_]
+==== map
+
+[source,java]
+----
+public static <T,​U> Promise<U> map​(java.util.function.Supplier<T> promise,
+                                         java.util.function.Function<T,​U> fn)
+----
+
+Helper function to map promises. 
+
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `promise` a| The supplier function to wrap into the promise a| `java.util.function.Supplier<T>`
+a| `fn` a| The mapping function a| `java.util.function.Function<T,​U>`
+|===
+
+[caption=""]
+.Returns
+`public static <T,​U> Promise<U>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+Promise.map(supplier, mapper);
+----
+
+[#_Promise_T_resolve__]
 ==== resolve
 
 [source,java]

--- a/java/docs/answer/ValueGroup.adoc
+++ b/java/docs/answer/ValueGroup.adoc
@@ -6,7 +6,7 @@
 Contains an element of the group aggregate query result.
 
 // tag::methods[]
-[#_ValueGroup_owner_]
+[#_ValueGroup_owner__]
 ==== owner
 
 [source,java]
@@ -29,7 +29,7 @@ Retrieves the concept that is the group owner.
 conceptMapGroup.owner()
 ----
 
-[#_ValueGroup_value_]
+[#_ValueGroup_value__]
 ==== value
 
 [source,java]

--- a/java/docs/concept/Concept.adoc
+++ b/java/docs/concept/Concept.adoc
@@ -4,7 +4,7 @@
 *Package*: `com.vaticle.typedb.driver.api.concept`
 
 // tag::methods[]
-[#_Concept_asAttribute_]
+[#_Concept_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -26,7 +26,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_Concept_asAttributeType_]
+[#_Concept_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -48,7 +48,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_Concept_asEntity_]
+[#_Concept_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -70,7 +70,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_Concept_asEntityType_]
+[#_Concept_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -92,7 +92,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_Concept_asRelation_]
+[#_Concept_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -114,7 +114,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_Concept_asRelationType_]
+[#_Concept_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -136,7 +136,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_Concept_asRoleType_]
+[#_Concept_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -158,7 +158,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_Concept_asThing_]
+[#_Concept_asThing__]
 ==== asThing
 
 [source,java]
@@ -180,7 +180,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_Concept_asThingType_]
+[#_Concept_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -202,7 +202,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_Concept_asType_]
+[#_Concept_asType__]
 ==== asType
 
 [source,java]
@@ -224,7 +224,7 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
-[#_Concept_asValue_]
+[#_Concept_asValue__]
 ==== asValue
 
 [source,java]
@@ -246,7 +246,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_Concept_isAttribute_]
+[#_Concept_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -269,7 +269,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_Concept_isAttributeType_]
+[#_Concept_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -292,7 +292,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_Concept_isEntity_]
+[#_Concept_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -315,7 +315,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_Concept_isEntityType_]
+[#_Concept_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -338,7 +338,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Concept_isRelation_]
+[#_Concept_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -361,7 +361,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_Concept_isRelationType_]
+[#_Concept_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -384,7 +384,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_Concept_isRoleType_]
+[#_Concept_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -407,7 +407,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_Concept_isThing_]
+[#_Concept_isThing__]
 ==== isThing
 
 [source,java]
@@ -430,7 +430,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_Concept_isThingType_]
+[#_Concept_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -453,7 +453,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_Concept_isType_]
+[#_Concept_isType__]
 ==== isType
 
 [source,java]
@@ -476,7 +476,7 @@ Checks if the concept is a ``Type``.
 concept.isType();
 ----
 
-[#_Concept_isValue_]
+[#_Concept_isValue__]
 ==== isValue
 
 [source,java]

--- a/java/docs/concept/ConceptManager.adoc
+++ b/java/docs/concept/ConceptManager.adoc
@@ -6,7 +6,7 @@
 Provides access for all Concept API methods.
 
 // tag::methods[]
-[#_ConceptManager_getAttribute_java_lang_String]
+[#_ConceptManager_getAttribute__java_lang_String]
 ==== getAttribute
 
 [source,java]
@@ -38,7 +38,7 @@ a| `iid` a| The iid of the ``Attribute`` to retrieve a| `java.lang.String`
 transaction.concepts().getAttribute(iid).resolve();
 ----
 
-[#_ConceptManager_getAttributeType_java_lang_String]
+[#_ConceptManager_getAttributeType__java_lang_String]
 ==== getAttributeType
 
 [source,java]
@@ -70,7 +70,7 @@ a| `label` a| The label of the ``AttributeType`` to retrieve a| `java.lang.Strin
 transaction.concepts().getAttributeType(label).resolve();
 ----
 
-[#_ConceptManager_getEntity_java_lang_String]
+[#_ConceptManager_getEntity__java_lang_String]
 ==== getEntity
 
 [source,java]
@@ -102,7 +102,7 @@ a| `iid` a| The iid of the ``Entity`` to retrieve a| `java.lang.String`
 transaction.concepts().getEntity(iid).resolve();
 ----
 
-[#_ConceptManager_getEntityType_java_lang_String]
+[#_ConceptManager_getEntityType__java_lang_String]
 ==== getEntityType
 
 [source,java]
@@ -134,7 +134,7 @@ a| `label` a| The label of the ``EntityType`` to retrieve a| `java.lang.String`
 transaction.concepts().getEntityType(label).resolve();
 ----
 
-[#_ConceptManager_getRelation_java_lang_String]
+[#_ConceptManager_getRelation__java_lang_String]
 ==== getRelation
 
 [source,java]
@@ -166,7 +166,7 @@ a| `iid` a| The iid of the ``Relation`` to retrieve a| `java.lang.String`
 transaction.concepts().getRelation(iid).resolve();
 ----
 
-[#_ConceptManager_getRelationType_java_lang_String]
+[#_ConceptManager_getRelationType__java_lang_String]
 ==== getRelationType
 
 [source,java]
@@ -198,7 +198,7 @@ a| `label` a| The label of the ``RelationType`` to retrieve a| `java.lang.String
 transaction.concepts().getRelationType(label).resolve();
 ----
 
-[#_ConceptManager_getRootAttributeType_]
+[#_ConceptManager_getRootAttributeType__]
 ==== getRootAttributeType
 
 [source,java]
@@ -221,7 +221,7 @@ Retrieve the root ``AttributeType``, “attribute”.
 transaction.concepts().getRootAttributeType();
 ----
 
-[#_ConceptManager_getRootEntityType_]
+[#_ConceptManager_getRootEntityType__]
 ==== getRootEntityType
 
 [source,java]
@@ -244,7 +244,7 @@ Retrieves the root ``EntityType``, “entity”.
 transaction.concepts().getRootEntityType();
 ----
 
-[#_ConceptManager_getRootRelationType_]
+[#_ConceptManager_getRootRelationType__]
 ==== getRootRelationType
 
 [source,java]
@@ -267,7 +267,7 @@ Retrieve the root ``RelationType``, “relation”.
 transaction.concepts().getRootRelationType();
 ----
 
-[#_ConceptManager_getSchemaExceptions_]
+[#_ConceptManager_getSchemaExceptions__]
 ==== getSchemaExceptions
 
 [source,java]
@@ -290,7 +290,7 @@ Retrieves a list of all schema exceptions for the current transaction.
 transaction.concepts().getSchemaException();
 ----
 
-[#_ConceptManager_putAttributeType_java_lang_String_com_vaticle_typedb_driver_api_concept_value_Value_Type]
+[#_ConceptManager_putAttributeType__java_lang_String__Value_Type]
 ==== putAttributeType
 
 [source,java]
@@ -324,7 +324,7 @@ a| `valueType` a| The value type of the ``AttributeType`` to create a| `Value.Ty
 await transaction.concepts().putAttributeType(label, valueType).resolve();
 ----
 
-[#_ConceptManager_putEntityType_java_lang_String]
+[#_ConceptManager_putEntityType__java_lang_String]
 ==== putEntityType
 
 [source,java]
@@ -356,7 +356,7 @@ a| `label` a| The label of the ``EntityType`` to create or retrieve a| `java.lan
 transaction.concepts().putEntityType(label).resolve();
 ----
 
-[#_ConceptManager_putRelationType_java_lang_String]
+[#_ConceptManager_putRelationType__java_lang_String]
 ==== putRelationType
 
 [source,java]

--- a/java/docs/connection/Database.Replica.adoc
+++ b/java/docs/connection/Database.Replica.adoc
@@ -1,4 +1,4 @@
-[#_Database.Replica]
+[#_Database_Replica]
 === Database.Replica
 
 *Package*: `com.vaticle.typedb.driver.api.database`
@@ -6,7 +6,7 @@
 The metadata and state of an individual raft replica of a database.
 
 // tag::methods[]
-[#_Database.Replica_address_]
+[#_Database_Replica_address__]
 ==== address
 
 [source,java]
@@ -21,7 +21,7 @@ Retrieves the address of the server hosting this replica
 .Returns
 `java.lang.String`
 
-[#_Database.Replica_isPreferred_]
+[#_Database_Replica_isPreferred__]
 ==== isPreferred
 
 [source,java]
@@ -36,7 +36,7 @@ Checks whether this is the preferred replica of the raft cluster. If true, Opera
 .Returns
 `boolean`
 
-[#_Database.Replica_isPrimary_]
+[#_Database_Replica_isPrimary__]
 ==== isPrimary
 
 [source,java]
@@ -51,7 +51,7 @@ Checks whether this is the primary replica of the raft cluster.
 .Returns
 `boolean`
 
-[#_Database.Replica_term_]
+[#_Database_Replica_term__]
 ==== term
 
 [source,java]

--- a/java/docs/connection/Database.adoc
+++ b/java/docs/connection/Database.adoc
@@ -4,7 +4,7 @@
 *Package*: `com.vaticle.typedb.driver.api.database`
 
 // tag::methods[]
-[#_Database_delete_]
+[#_Database_delete__]
 ==== delete
 
 [source,java]
@@ -26,7 +26,7 @@ Deletes this database.
 database.delete()
 ----
 
-[#_Database_name_]
+[#_Database_name__]
 ==== name
 
 [source,java]
@@ -41,7 +41,7 @@ The database name as a string.
 .Returns
 `java.lang.String`
 
-[#_Database_preferredReplica_]
+[#_Database_preferredReplica__]
 ==== preferredReplica
 
 [source,java]
@@ -64,7 +64,7 @@ Returns the preferred replica for this database. Operations which can be run on 
 database.preferredReplica()
 ----
 
-[#_Database_primaryReplica_]
+[#_Database_primaryReplica__]
 ==== primaryReplica
 
 [source,java]
@@ -87,7 +87,7 @@ Returns the primary replica for this database. _Only works in TypeDB Enterprise_
 database.primaryReplica()
 ----
 
-[#_Database_replicas_]
+[#_Database_replicas__]
 ==== replicas
 
 [source,java]
@@ -110,7 +110,7 @@ Set of ``Replica`` instances for this database. Only works in TypeDB Enterprise
 database.replicas()
 ----
 
-[#_Database_ruleSchema_]
+[#_Database_ruleSchema__]
 ==== ruleSchema
 
 [source,java]
@@ -133,7 +133,7 @@ The rules in the schema as a valid TypeQL define query string.
 database.ruleSchema()
 ----
 
-[#_Database_schema_]
+[#_Database_schema__]
 ==== schema
 
 [source,java]
@@ -156,7 +156,7 @@ A full schema text as a valid TypeQL define query string.
 database.schema()
 ----
 
-[#_Database_typeSchema_]
+[#_Database_typeSchema__]
 ==== typeSchema
 
 [source,java]

--- a/java/docs/connection/DatabaseManager.adoc
+++ b/java/docs/connection/DatabaseManager.adoc
@@ -6,7 +6,7 @@
 Provides access to all database management methods.
 
 // tag::methods[]
-[#_DatabaseManager_all_]
+[#_DatabaseManager_all__]
 ==== all
 
 [source,java]
@@ -29,7 +29,7 @@ Retrieves all databases present on the TypeDB server
 driver.databases().all()
 ----
 
-[#_DatabaseManager_contains_java_lang_String]
+[#_DatabaseManager_contains__java_lang_String]
 ==== contains
 
 [source,java]
@@ -61,7 +61,7 @@ a| `name` a| The database name to be checked a| `java.lang.String`
 driver.databases().contains(name)
 ----
 
-[#_DatabaseManager_create_java_lang_String]
+[#_DatabaseManager_create__java_lang_String]
 ==== create
 
 [source,java]
@@ -92,7 +92,7 @@ a| `name` a| The name of the database to be created a| `java.lang.String`
 driver.databases().create(name)
 ----
 
-[#_DatabaseManager_get_java_lang_String]
+[#_DatabaseManager_get__java_lang_String]
 ==== get
 
 [source,java]

--- a/java/docs/connection/TypeDB.adoc
+++ b/java/docs/connection/TypeDB.adoc
@@ -15,7 +15,7 @@ a| `DEFAULT_ADDRESS` a| `static java.lang.String` a|
 // end::properties[]
 
 // tag::methods[]
-[#_TypeDB__init__]
+[#_TypeDB_TypeDB__]
 ==== TypeDB
 
 [source,java]
@@ -29,7 +29,7 @@ public TypeDB()
 .Returns
 `public`
 
-[#_TypeDB_coreDriver_java_lang_String]
+[#_TypeDB_coreDriver__java_lang_String]
 ==== coreDriver
 
 [source,java]
@@ -37,13 +37,30 @@ public TypeDB()
 public static TypeDBDriver coreDriver​(java.lang.String address)
 ----
 
+Open a TypeDB Driver to a TypeDB Core server available at the provided address. 
 
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `address` a| The address of the TypeDB server a| `java.lang.String`
+|===
 
 [caption=""]
 .Returns
 `public static TypeDBDriver`
 
-[#_TypeDB_enterpriseDriver_java_lang_String_com_vaticle_typedb_driver_api_TypeDBCredential]
+[caption=""]
+.Code examples
+[source,java]
+----
+TypeDB.coreDriver(address);
+----
+
+[#_TypeDB_enterpriseDriver__java_lang_String__TypeDBCredential]
 ==== enterpriseDriver
 
 [source,java]
@@ -52,13 +69,31 @@ public static TypeDBDriver enterpriseDriver​(java.lang.String address,
                                             TypeDBCredential credential)
 ----
 
+Open a TypeDB Driver to a TypeDB Enterprise server available at the provided address, using the provided credential. 
 
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `address` a| The address of the TypeDB server a| `java.lang.String`
+a| `credential` a| The credential to connect with a| `TypeDBCredential`
+|===
 
 [caption=""]
 .Returns
 `public static TypeDBDriver`
 
-[#_TypeDB_enterpriseDriver_java_util_Set_com_vaticle_typedb_driver_api_TypeDBCredential]
+[caption=""]
+.Code examples
+[source,java]
+----
+TypeDB.enterpriseDriver(address, credential);
+----
+
+[#_TypeDB_enterpriseDriver__java_util_Set_java_lang_String___TypeDBCredential]
 ==== enterpriseDriver
 
 [source,java]
@@ -67,11 +102,29 @@ public static TypeDBDriver enterpriseDriver​(java.util.Set<java.lang.String> a
                                             TypeDBCredential credential)
 ----
 
+Open a TypeDB Driver to TypeDB Enterprise server(s) available at the provided addresses, using the provided credential. 
 
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `addresses` a| The address(es) of the TypeDB server(s) a| `java.util.Set<java.lang.String>`
+a| `credential` a| The credential to connect with a| `TypeDBCredential`
+|===
 
 [caption=""]
 .Returns
 `public static TypeDBDriver`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+TypeDB.enterpriseDriver(addresses, credential);
+----
 
 // end::methods[]
 

--- a/java/docs/connection/TypeDBCredential.adoc
+++ b/java/docs/connection/TypeDBCredential.adoc
@@ -22,7 +22,7 @@ User credentials and TLS encryption settings for connecting to TypeDB Enterprise
 ====
 
 // tag::methods[]
-[#_TypeDBCredential__init__java_lang_String_java_lang_String_boolean]
+[#_TypeDBCredential_TypeDBCredential__java_lang_String__java_lang_String__boolean]
 ==== TypeDBCredential
 
 [source,java]
@@ -49,7 +49,7 @@ a| `tlsEnabled` a| Specify whether the connection to TypeDB Enterprise must be d
 .Returns
 `public`
 
-[#_TypeDBCredential__init__java_lang_String_java_lang_String_java_nio_file_Path]
+[#_TypeDBCredential_TypeDBCredential__java_lang_String__java_lang_String__java_nio_file_Path]
 ==== TypeDBCredential
 
 [source,java]

--- a/java/docs/connection/TypeDBDriver.adoc
+++ b/java/docs/connection/TypeDBDriver.adoc
@@ -8,7 +8,7 @@
 * `java.lang.AutoCloseable`
 
 // tag::methods[]
-[#_TypeDBDriver_close_]
+[#_TypeDBDriver_close__]
 ==== close
 
 [source,java]
@@ -30,7 +30,7 @@ Closes the driver. Before instantiating a new driver, the driver that’s curren
 driver.close()
 ----
 
-[#_TypeDBDriver_databases_]
+[#_TypeDBDriver_databases__]
 ==== databases
 
 [source,java]
@@ -45,7 +45,7 @@ The ``DatabaseManager`` for this connection, providing access to database manage
 .Returns
 `DatabaseManager`
 
-[#_TypeDBDriver_isOpen_]
+[#_TypeDBDriver_isOpen__]
 ==== isOpen
 
 [source,java]
@@ -68,7 +68,7 @@ Checks whether this connection is presently open.
 driver.isOpen();
 ----
 
-[#_TypeDBDriver_session_java_lang_String_com_vaticle_typedb_driver_api_TypeDBSession_Type]
+[#_TypeDBDriver_session__java_lang_String__TypeDBSession_Type]
 ==== session
 
 [source,java]
@@ -88,7 +88,7 @@ See also: <<#_session_java_lang_String_com_vaticle_typedb_driver_api_TypeDBSessi
 .Returns
 `TypeDBSession`
 
-[#_TypeDBDriver_session_java_lang_String_com_vaticle_typedb_driver_api_TypeDBSession_Type_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_TypeDBDriver_session__java_lang_String__TypeDBSession_Type__TypeDBOptions]
 ==== session
 
 [source,java]
@@ -124,7 +124,7 @@ a| `options` a| ``TypeDBOptions`` for the session a| `TypeDBOptions`
 driver.session(database, sessionType, options);
 ----
 
-[#_TypeDBDriver_user_]
+[#_TypeDBDriver_user__]
 ==== user
 
 [source,java]
@@ -139,7 +139,7 @@ The ``UserManager`` instance for this connection, providing access to user manag
 .Returns
 `User`
 
-[#_TypeDBDriver_users_]
+[#_TypeDBDriver_users__]
 ==== users
 
 [source,java]

--- a/java/docs/connection/User.adoc
+++ b/java/docs/connection/User.adoc
@@ -6,7 +6,7 @@
 TypeDB user information
 
 // tag::methods[]
-[#_User_passwordExpirySeconds_]
+[#_User_passwordExpirySeconds__]
 ==== passwordExpirySeconds
 
 [source,java]
@@ -20,7 +20,7 @@ Returns the number of seconds remaining till this user’s current password expi
 .Returns
 `java.util.Optional<java.lang.Long>`
 
-[#_User_passwordUpdate_java_lang_String_java_lang_String]
+[#_User_passwordUpdate__java_lang_String__java_lang_String]
 ==== passwordUpdate
 
 [source,java]
@@ -45,7 +45,7 @@ a| `passwordNew` a| The new password a| `java.lang.String`
 .Returns
 `void`
 
-[#_User_username_]
+[#_User_username__]
 ==== username
 
 [source,java]

--- a/java/docs/connection/UserManager.adoc
+++ b/java/docs/connection/UserManager.adoc
@@ -6,7 +6,7 @@
 Provides access to all user management methods.
 
 // tag::methods[]
-[#_UserManager_all_]
+[#_UserManager_all__]
 ==== all
 
 [source,java]
@@ -28,7 +28,7 @@ Retrieves all users which exist on the TypeDB server.
 driver.users().all();
 ----
 
-[#_UserManager_contains_java_lang_String]
+[#_UserManager_contains__java_lang_String]
 ==== contains
 
 [source,java]
@@ -60,7 +60,7 @@ a| `username` a| The user name to be checked a| `java.lang.String`
 driver.users().contains(username);
 ----
 
-[#_UserManager_create_java_lang_String_java_lang_String]
+[#_UserManager_create__java_lang_String__java_lang_String]
 ==== create
 
 [source,java]
@@ -93,7 +93,7 @@ a| `password` a| The password of the user to be created a| `java.lang.String`
 driver.users().create(username, password);
 ----
 
-[#_UserManager_delete_java_lang_String]
+[#_UserManager_delete__java_lang_String]
 ==== delete
 
 [source,java]
@@ -124,7 +124,7 @@ a| `username` a| The name of the user to be deleted a| `java.lang.String`
 driver.users().delete(username);
 ----
 
-[#_UserManager_get_java_lang_String]
+[#_UserManager_get__java_lang_String]
 ==== get
 
 [source,java]
@@ -156,7 +156,7 @@ a| `username` a| The name of the user to retrieve a| `java.lang.String`
 driver.users().get(username);
 ----
 
-[#_UserManager_passwordSet_java_lang_String_java_lang_String]
+[#_UserManager_passwordSet__java_lang_String__java_lang_String]
 ==== passwordSet
 
 [source,java]

--- a/java/docs/data/Attribute.adoc
+++ b/java/docs/data/Attribute.adoc
@@ -15,7 +15,7 @@ Attribute is an instance of the attribute type and has a value. This value is fi
 Attributes can be uniquely addressed by their type and value.
 
 // tag::methods[]
-[#_Attribute_asAttribute_]
+[#_Attribute_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -38,7 +38,7 @@ Casts the concept to ``Attribute``.
 attribute.asAttribute();
 ----
 
-[#_Attribute_asAttributeType_]
+[#_Attribute_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -60,7 +60,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_Attribute_asEntity_]
+[#_Attribute_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -82,7 +82,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_Attribute_asEntityType_]
+[#_Attribute_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -104,7 +104,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_Attribute_asRelation_]
+[#_Attribute_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -126,7 +126,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_Attribute_asRelationType_]
+[#_Attribute_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -148,7 +148,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_Attribute_asRoleType_]
+[#_Attribute_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -170,7 +170,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_Attribute_asThingType_]
+[#_Attribute_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -192,7 +192,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_Attribute_asType_]
+[#_Attribute_asType__]
 ==== asType
 
 [source,java]
@@ -214,7 +214,7 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
-[#_Attribute_asValue_]
+[#_Attribute_asValue__]
 ==== asValue
 
 [source,java]
@@ -236,7 +236,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_Attribute_getOwners_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Attribute_getOwners__TypeDBTransaction]
 ==== getOwners
 
 [source,java]
@@ -268,7 +268,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 attribute.getOwners(transaction);
 ----
 
-[#_Attribute_getOwners_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_ThingType]
+[#_Attribute_getOwners__TypeDBTransaction__ThingType]
 ==== getOwners
 
 [source,java]
@@ -302,7 +302,7 @@ a| `ownerType` a| Filter results for only owners of the given type a| `ThingType
 attribute.getOwners(transaction, ownerType);
 ----
 
-[#_Attribute_getType_]
+[#_Attribute_getType__]
 ==== getType
 
 [source,java]
@@ -325,7 +325,7 @@ Retrieves the type which this ``Attribute`` belongs to.
 attribute.getType();
 ----
 
-[#_Attribute_getValue_]
+[#_Attribute_getValue__]
 ==== getValue
 
 [source,java]
@@ -347,7 +347,7 @@ Retrieves the value which the ``Attribute`` instance holds.
 attribute.getValue();
 ----
 
-[#_Attribute_isAttribute_]
+[#_Attribute_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -370,7 +370,7 @@ Checks if the concept is an ``Attribute``.
 attribute.isAttribute();
 ----
 
-[#_Attribute_isAttributeType_]
+[#_Attribute_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -393,7 +393,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_Attribute_isEntity_]
+[#_Attribute_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -416,7 +416,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_Attribute_isEntityType_]
+[#_Attribute_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -439,7 +439,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Attribute_isRelation_]
+[#_Attribute_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -462,7 +462,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_Attribute_isRelationType_]
+[#_Attribute_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -485,7 +485,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_Attribute_isRoleType_]
+[#_Attribute_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -508,7 +508,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_Attribute_isThingType_]
+[#_Attribute_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -531,7 +531,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_Attribute_isType_]
+[#_Attribute_isType__]
 ==== isType
 
 [source,java]
@@ -554,7 +554,7 @@ Checks if the concept is a ``Type``.
 concept.isType();
 ----
 
-[#_Attribute_isValue_]
+[#_Attribute_isValue__]
 ==== isValue
 
 [source,java]

--- a/java/docs/data/Entity.adoc
+++ b/java/docs/data/Entity.adoc
@@ -11,7 +11,7 @@
 Instance of data of an entity type, representing a standalone object that exists in the data model independently. Entity does not have a value. It is usually addressed by its ownership over attribute instances and/or roles played in relation instances.
 
 // tag::methods[]
-[#_Entity_asAttribute_]
+[#_Entity_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -33,7 +33,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_Entity_asAttributeType_]
+[#_Entity_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -55,7 +55,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_Entity_asEntity_]
+[#_Entity_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -78,7 +78,7 @@ Casts the concept to ``Entity``.
 entity.asEntity();
 ----
 
-[#_Entity_asEntityType_]
+[#_Entity_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -100,7 +100,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_Entity_asRelation_]
+[#_Entity_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -122,7 +122,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_Entity_asRelationType_]
+[#_Entity_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -144,7 +144,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_Entity_asRoleType_]
+[#_Entity_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -166,7 +166,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_Entity_asThingType_]
+[#_Entity_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -188,7 +188,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_Entity_asType_]
+[#_Entity_asType__]
 ==== asType
 
 [source,java]
@@ -210,7 +210,7 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
-[#_Entity_asValue_]
+[#_Entity_asValue__]
 ==== asValue
 
 [source,java]
@@ -232,7 +232,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_Entity_getType_]
+[#_Entity_getType__]
 ==== getType
 
 [source,java]
@@ -255,7 +255,7 @@ Retrieves the type which this ``Entity`` belongs to.
 entity.getType();
 ----
 
-[#_Entity_isAttribute_]
+[#_Entity_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -278,7 +278,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_Entity_isAttributeType_]
+[#_Entity_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -301,7 +301,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_Entity_isEntity_]
+[#_Entity_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -324,7 +324,7 @@ Checks if the concept is an ``Entity``.
 entity.isEntity();
 ----
 
-[#_Entity_isEntityType_]
+[#_Entity_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -347,7 +347,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Entity_isRelation_]
+[#_Entity_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -370,7 +370,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_Entity_isRelationType_]
+[#_Entity_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -393,7 +393,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_Entity_isRoleType_]
+[#_Entity_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -416,7 +416,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_Entity_isThingType_]
+[#_Entity_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -439,7 +439,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_Entity_isType_]
+[#_Entity_isType__]
 ==== isType
 
 [source,java]
@@ -462,7 +462,7 @@ Checks if the concept is a ``Type``.
 concept.isType();
 ----
 
-[#_Entity_isValue_]
+[#_Entity_isValue__]
 ==== isValue
 
 [source,java]

--- a/java/docs/data/Relation.adoc
+++ b/java/docs/data/Relation.adoc
@@ -11,7 +11,7 @@
 Relation is an instance of a relation type and can be uniquely addressed by a combination of its type, owned attributes and role players.
 
 // tag::methods[]
-[#_Relation_addPlayer_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType_com_vaticle_typedb_driver_api_concept_thing_Thing]
+[#_Relation_addPlayer__TypeDBTransaction__RoleType__Thing]
 ==== addPlayer
 
 [source,java]
@@ -47,7 +47,7 @@ a| `player` a| The thing to play the role a| `Thing`
 relation.addPlayer(transaction, roleType, player).resolve();
 ----
 
-[#_Relation_asAttribute_]
+[#_Relation_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -69,7 +69,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_Relation_asAttributeType_]
+[#_Relation_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -91,7 +91,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_Relation_asEntity_]
+[#_Relation_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -113,7 +113,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_Relation_asEntityType_]
+[#_Relation_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -135,7 +135,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_Relation_asRelation_]
+[#_Relation_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -158,7 +158,7 @@ Casts the concept to ``Relation``.
 relation.asRelation();
 ----
 
-[#_Relation_asRelationType_]
+[#_Relation_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -180,7 +180,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_Relation_asRoleType_]
+[#_Relation_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -202,7 +202,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_Relation_asThingType_]
+[#_Relation_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -224,7 +224,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_Relation_asType_]
+[#_Relation_asType__]
 ==== asType
 
 [source,java]
@@ -246,7 +246,7 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
-[#_Relation_asValue_]
+[#_Relation_asValue__]
 ==== asValue
 
 [source,java]
@@ -268,7 +268,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_Relation_getPlayers_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Relation_getPlayers__TypeDBTransaction]
 ==== getPlayers
 
 [source,java]
@@ -300,7 +300,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 relation.getPlayers(transaction)
 ----
 
-[#_Relation_getPlayersByRoleType_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType___]
+[#_Relation_getPlayersByRoleType__TypeDBTransaction__RoleType___]
 ==== getPlayersByRoleType
 
 [source,java]
@@ -334,7 +334,7 @@ a| `roleTypes` a| 0 or more role types a| `RoleType[]`
 relation.getPlayersByRoleType(transaction, roleTypes);
 ----
 
-[#_Relation_getRelating_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Relation_getRelating__TypeDBTransaction]
 ==== getRelating
 
 [source,java]
@@ -366,7 +366,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 relation.getRelating(transaction);
 ----
 
-[#_Relation_getType_]
+[#_Relation_getType__]
 ==== getType
 
 [source,java]
@@ -389,7 +389,7 @@ Retrieves the type which this ``Relation`` belongs to.
 relation.getType();
 ----
 
-[#_Relation_isAttribute_]
+[#_Relation_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -412,7 +412,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_Relation_isAttributeType_]
+[#_Relation_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -435,7 +435,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_Relation_isEntity_]
+[#_Relation_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -458,7 +458,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_Relation_isEntityType_]
+[#_Relation_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -481,7 +481,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Relation_isRelation_]
+[#_Relation_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -504,7 +504,7 @@ Checks if the concept is a ``Relation``.
 relation.isRelation();
 ----
 
-[#_Relation_isRelationType_]
+[#_Relation_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -527,7 +527,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_Relation_isRoleType_]
+[#_Relation_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -550,7 +550,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_Relation_isThingType_]
+[#_Relation_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -573,7 +573,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_Relation_isType_]
+[#_Relation_isType__]
 ==== isType
 
 [source,java]
@@ -596,7 +596,7 @@ Checks if the concept is a ``Type``.
 concept.isType();
 ----
 
-[#_Relation_isValue_]
+[#_Relation_isValue__]
 ==== isValue
 
 [source,java]
@@ -619,7 +619,7 @@ Checks if the concept is a ``Value``.
 concept.isValue();
 ----
 
-[#_Relation_removePlayer_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType_com_vaticle_typedb_driver_api_concept_thing_Thing]
+[#_Relation_removePlayer__TypeDBTransaction__RoleType__Thing]
 ==== removePlayer
 
 [source,java]

--- a/java/docs/data/Thing.adoc
+++ b/java/docs/data/Thing.adoc
@@ -8,7 +8,7 @@
 * `Concept`
 
 // tag::methods[]
-[#_Thing_asAttribute_]
+[#_Thing_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -30,7 +30,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_Thing_asAttributeType_]
+[#_Thing_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -52,7 +52,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_Thing_asEntity_]
+[#_Thing_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -74,7 +74,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_Thing_asEntityType_]
+[#_Thing_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -96,7 +96,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_Thing_asRelation_]
+[#_Thing_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -118,7 +118,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_Thing_asRelationType_]
+[#_Thing_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -140,7 +140,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_Thing_asRoleType_]
+[#_Thing_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -162,7 +162,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_Thing_asThing_]
+[#_Thing_asThing__]
 ==== asThing
 
 [source,java]
@@ -185,7 +185,7 @@ Casts the concept to ``Thing``.
 thing.asThing();
 ----
 
-[#_Thing_asThingType_]
+[#_Thing_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -207,7 +207,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_Thing_asType_]
+[#_Thing_asType__]
 ==== asType
 
 [source,java]
@@ -229,7 +229,7 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
-[#_Thing_asValue_]
+[#_Thing_asValue__]
 ==== asValue
 
 [source,java]
@@ -251,7 +251,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_Thing_delete_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Thing_delete__TypeDBTransaction]
 ==== delete
 
 [source,java]
@@ -283,7 +283,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.delete(transaction).resolve();
 ----
 
-[#_Thing_getHas_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType___]
+[#_Thing_getHas__TypeDBTransaction__AttributeType___]
 ==== getHas
 
 [source,java]
@@ -318,7 +318,7 @@ thing.getHas(transaction);
  thing.getHas(transaction, attributeType);
 ----
 
-[#_Thing_getHas_com_vaticle_typedb_driver_api_TypeDBTransaction_java_util_Set]
+[#_Thing_getHas__TypeDBTransaction__java_util_Set_ThingType_Annotation_]
 ==== getHas
 
 [source,java]
@@ -353,7 +353,7 @@ thing.getHas(transaction);
  thing.getHas(transaction, set(Annotation.key()));
 ----
 
-[#_Thing_getIID_]
+[#_Thing_getIID__]
 ==== getIID
 
 [source,java]
@@ -376,7 +376,7 @@ Retrieves the unique id of the ``Thing``.
 thing.getIID();
 ----
 
-[#_Thing_getPlaying_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Thing_getPlaying__TypeDBTransaction]
 ==== getPlaying
 
 [source,java]
@@ -408,7 +408,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getPlaying(transaction);
 ----
 
-[#_Thing_getRelations_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType___]
+[#_Thing_getRelations__TypeDBTransaction__RoleType___]
 ==== getRelations
 
 [source,java]
@@ -442,7 +442,7 @@ a| `roleTypes` a| The array of roles to filter the relations by. a| `RoleType[]`
 thing.getRelations(transaction, roleTypes);
 ----
 
-[#_Thing_getType_]
+[#_Thing_getType__]
 ==== getType
 
 [source,java]
@@ -465,7 +465,7 @@ Retrieves the type which this ``Thing`` belongs to.
 thing.getType();
 ----
 
-[#_Thing_isAttribute_]
+[#_Thing_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -488,7 +488,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_Thing_isAttributeType_]
+[#_Thing_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -511,7 +511,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_Thing_isDeleted_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Thing_isDeleted__TypeDBTransaction]
 ==== isDeleted
 
 [source,java]
@@ -543,7 +543,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.isDeleted(transaction).resolve();
 ----
 
-[#_Thing_isEntity_]
+[#_Thing_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -566,7 +566,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_Thing_isEntityType_]
+[#_Thing_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -589,7 +589,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Thing_isInferred_]
+[#_Thing_isInferred__]
 ==== isInferred
 
 [source,java]
@@ -612,7 +612,7 @@ Checks if this ``Thing`` is inferred by a [Reasoning Rule].
 thing.isInferred();
 ----
 
-[#_Thing_isRelation_]
+[#_Thing_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -635,7 +635,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_Thing_isRelationType_]
+[#_Thing_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -658,7 +658,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_Thing_isRoleType_]
+[#_Thing_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -681,7 +681,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_Thing_isThing_]
+[#_Thing_isThing__]
 ==== isThing
 
 [source,java]
@@ -704,7 +704,7 @@ Checks if the concept is a ``Thing``.
 thing.isThing();
 ----
 
-[#_Thing_isThingType_]
+[#_Thing_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -727,7 +727,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_Thing_isType_]
+[#_Thing_isType__]
 ==== isType
 
 [source,java]
@@ -750,7 +750,7 @@ Checks if the concept is a ``Type``.
 concept.isType();
 ----
 
-[#_Thing_isValue_]
+[#_Thing_isValue__]
 ==== isValue
 
 [source,java]
@@ -773,7 +773,7 @@ Checks if the concept is a ``Value``.
 concept.isValue();
 ----
 
-[#_Thing_setHas_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_thing_Attribute]
+[#_Thing_setHas__TypeDBTransaction__Attribute]
 ==== setHas
 
 [source,java]
@@ -807,7 +807,7 @@ a| `attribute` a| The ``Attribute`` to be owned by this ``Thing``. a| `Attribute
 thing.setHas(transaction, attribute).resolve();
 ----
 
-[#_Thing_unsetHas_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_thing_Attribute]
+[#_Thing_unsetHas__TypeDBTransaction__Attribute]
 ==== unsetHas
 
 [source,java]

--- a/java/docs/data/Value.adoc
+++ b/java/docs/data/Value.adoc
@@ -19,7 +19,7 @@ a| `ISO_LOCAL_DATE_TIME_MILLIS` a| `static java.time.format.DateTimeFormatter` a
 // end::properties[]
 
 // tag::methods[]
-[#_Value_asAttribute_]
+[#_Value_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -41,7 +41,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_Value_asAttributeType_]
+[#_Value_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -63,7 +63,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_Value_asBoolean_]
+[#_Value_asBoolean__]
 ==== asBoolean
 
 [source,java]
@@ -85,7 +85,7 @@ Returns a ``boolean`` value of this value concept. If the value has another type
 value.asBoolean();
 ----
 
-[#_Value_asDateTime_]
+[#_Value_asDateTime__]
 ==== asDateTime
 
 [source,java]
@@ -107,7 +107,7 @@ Returns a ``datetime`` value of this value concept. If the value has another typ
 value.asDatetime();
 ----
 
-[#_Value_asDouble_]
+[#_Value_asDouble__]
 ==== asDouble
 
 [source,java]
@@ -129,7 +129,7 @@ Returns a ``double`` value of this value concept. If the value has another type,
 value.asDouble();
 ----
 
-[#_Value_asEntity_]
+[#_Value_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -151,7 +151,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_Value_asEntityType_]
+[#_Value_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -173,7 +173,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_Value_asLong_]
+[#_Value_asLong__]
 ==== asLong
 
 [source,java]
@@ -195,7 +195,7 @@ Returns a ``long`` value of this value concept. If the value has another type, r
 value.asLong();
 ----
 
-[#_Value_asRelation_]
+[#_Value_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -217,7 +217,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_Value_asRelationType_]
+[#_Value_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -239,7 +239,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_Value_asRoleType_]
+[#_Value_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -261,7 +261,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_Value_asString_]
+[#_Value_asString__]
 ==== asString
 
 [source,java]
@@ -283,7 +283,7 @@ Returns a ``string`` value of this value concept. If the value has another type,
 value.asString();
 ----
 
-[#_Value_asThing_]
+[#_Value_asThing__]
 ==== asThing
 
 [source,java]
@@ -305,7 +305,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_Value_asThingType_]
+[#_Value_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -327,7 +327,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_Value_asType_]
+[#_Value_asType__]
 ==== asType
 
 [source,java]
@@ -349,7 +349,7 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
-[#_Value_asUntyped_]
+[#_Value_asUntyped__]
 ==== asUntyped
 
 [source,java]
@@ -371,7 +371,7 @@ Returns an untyped ``Object`` value of this value concept. This is useful for va
 value.asUntyped();
 ----
 
-[#_Value_asValue_]
+[#_Value_asValue__]
 ==== asValue
 
 [source,java]
@@ -393,7 +393,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_Value_getType_]
+[#_Value_getType__]
 ==== getType
 
 [source,java]
@@ -415,7 +415,7 @@ Retrieves the ``Value.Type`` of this value concept.
 value.getType()
 ----
 
-[#_Value_isAttribute_]
+[#_Value_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -438,7 +438,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_Value_isAttributeType_]
+[#_Value_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -461,7 +461,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_Value_isBoolean_]
+[#_Value_isBoolean__]
 ==== isBoolean
 
 [source,java]
@@ -483,7 +483,7 @@ Returns ``True`` if the value which this value concept holds is of type ``boolea
 value.isBoolean()
 ----
 
-[#_Value_isDateTime_]
+[#_Value_isDateTime__]
 ==== isDateTime
 
 [source,java]
@@ -505,7 +505,7 @@ Returns ``True`` if the value which this value concept holds is of type ``dateti
 value.isDatetime();
 ----
 
-[#_Value_isDouble_]
+[#_Value_isDouble__]
 ==== isDouble
 
 [source,java]
@@ -527,7 +527,7 @@ Returns ``True`` if the value which this value concept holds is of type ``double
 value.isDouble();
 ----
 
-[#_Value_isEntity_]
+[#_Value_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -550,7 +550,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_Value_isEntityType_]
+[#_Value_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -573,7 +573,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Value_isLong_]
+[#_Value_isLong__]
 ==== isLong
 
 [source,java]
@@ -595,7 +595,7 @@ Returns ``True`` if the value which this value concept holds is of type ``long``
 value.isLong();
 ----
 
-[#_Value_isRelation_]
+[#_Value_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -618,7 +618,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_Value_isRelationType_]
+[#_Value_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -641,7 +641,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_Value_isRoleType_]
+[#_Value_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -664,7 +664,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_Value_isString_]
+[#_Value_isString__]
 ==== isString
 
 [source,java]
@@ -686,7 +686,7 @@ Returns ``True`` if the value which this value concept holds is of type ``string
 value.isString();
 ----
 
-[#_Value_isThing_]
+[#_Value_isThing__]
 ==== isThing
 
 [source,java]
@@ -709,7 +709,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_Value_isThingType_]
+[#_Value_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -732,7 +732,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_Value_isType_]
+[#_Value_isType__]
 ==== isType
 
 [source,java]
@@ -755,7 +755,7 @@ Checks if the concept is a ``Type``.
 concept.isType();
 ----
 
-[#_Value_isValue_]
+[#_Value_isValue__]
 ==== isValue
 
 [source,java]

--- a/java/docs/errors/TypeDBDriverException.adoc
+++ b/java/docs/errors/TypeDBDriverException.adoc
@@ -6,7 +6,7 @@
 Exceptions raised by the driver.
 
 // tag::methods[]
-[#_TypeDBDriverException_getErrorMessage_]
+[#_TypeDBDriverException_getErrorMessage__]
 ==== getErrorMessage
 
 [source,java]
@@ -21,7 +21,7 @@ public com.vaticle.typedb.driver.common.exception.ErrorMessage getErrorMessage()
 .Returns
 `public com.vaticle.typedb.driver.common.exception.ErrorMessage`
 
-[#_TypeDBDriverException_getName_]
+[#_TypeDBDriverException_getName__]
 ==== getName
 
 [source,java]

--- a/java/docs/logic/LogicManager.adoc
+++ b/java/docs/logic/LogicManager.adoc
@@ -6,7 +6,7 @@
 Provides methods for manipulating rules in the database.
 
 // tag::methods[]
-[#_LogicManager_getRule_java_lang_String]
+[#_LogicManager_getRule__java_lang_String]
 ==== getRule
 
 [source,java]
@@ -38,7 +38,7 @@ a| `label` a| The label of the Rule to create or retrieve a| `java.lang.String`
 transaction.logic().getRule(label).resolve();
 ----
 
-[#_LogicManager_getRules_]
+[#_LogicManager_getRules__]
 ==== getRules
 
 [source,java]
@@ -61,7 +61,7 @@ Retrieves all rules.
 transaction.logic().getRules()
 ----
 
-[#_LogicManager_putRule_java_lang_String_com_vaticle_typeql_lang_pattern_Pattern_com_vaticle_typeql_lang_pattern_Pattern]
+[#_LogicManager_putRule__java_lang_String__com_vaticle_typeql_lang_pattern_Pattern__com_vaticle_typeql_lang_pattern_Pattern]
 ==== putRule
 
 [source,java]

--- a/java/docs/logic/Rule.adoc
+++ b/java/docs/logic/Rule.adoc
@@ -6,7 +6,7 @@
 Rules are a part of schema and define embedded logic. The reasoning engine uses rules as a set of logic to infer new data. A rule consists of a condition and a conclusion, and is uniquely identified by a label.
 
 // tag::methods[]
-[#_Rule_delete_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Rule_delete__TypeDBTransaction]
 ==== delete
 
 [source,java]
@@ -38,7 +38,7 @@ a| `transaction` a| The current ``Transaction`` a| `TypeDBTransaction`
 rule.delete(transaction).resolve();
 ----
 
-[#_Rule_getLabel_]
+[#_Rule_getLabel__]
 ==== getLabel
 
 [source,java]
@@ -53,7 +53,7 @@ Retrieves the unique label of the rule.
 .Returns
 `java.lang.String`
 
-[#_Rule_getThen_]
+[#_Rule_getThen__]
 ==== getThen
 
 [source,java]
@@ -68,7 +68,7 @@ The single statement that constitutes the ‘then’ of the rule.
 .Returns
 `com.vaticle.typeql.lang.pattern.Pattern`
 
-[#_Rule_getWhen_]
+[#_Rule_getWhen__]
 ==== getWhen
 
 [source,java]
@@ -83,7 +83,7 @@ The statements that constitute the ‘when’ of the rule.
 .Returns
 `com.vaticle.typeql.lang.pattern.Pattern`
 
-[#_Rule_isDeleted_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Rule_isDeleted__TypeDBTransaction]
 ==== isDeleted
 
 [source,java]
@@ -115,7 +115,7 @@ a| `transaction` a| The current ``Transaction`` a| `TypeDBTransaction`
 rule.isDeleted(transaction).resolve();
 ----
 
-[#_Rule_setLabel_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_Rule_setLabel__TypeDBTransaction__java_lang_String]
 ==== setLabel
 
 [source,java]

--- a/java/docs/schema/AttributeType.adoc
+++ b/java/docs/schema/AttributeType.adoc
@@ -18,7 +18,7 @@ Other types can own an attribute type. That means that instances of these other 
 Multiple types can own the same attribute type, and different instances of the same type or different types can share ownership of the same attribute instance.
 
 // tag::methods[]
-[#_AttributeType_asAttribute_]
+[#_AttributeType_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -40,7 +40,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_AttributeType_asAttributeType_]
+[#_AttributeType_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -63,7 +63,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_AttributeType_asEntity_]
+[#_AttributeType_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -85,7 +85,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_AttributeType_asEntityType_]
+[#_AttributeType_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -107,7 +107,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_AttributeType_asRelation_]
+[#_AttributeType_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -129,7 +129,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_AttributeType_asRelationType_]
+[#_AttributeType_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -151,7 +151,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_AttributeType_asRoleType_]
+[#_AttributeType_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -173,7 +173,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_AttributeType_asThing_]
+[#_AttributeType_asThing__]
 ==== asThing
 
 [source,java]
@@ -195,7 +195,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_AttributeType_asValue_]
+[#_AttributeType_asValue__]
 ==== asValue
 
 [source,java]
@@ -217,7 +217,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_AttributeType_get_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value]
+[#_AttributeType_get__TypeDBTransaction__Value]
 ==== get
 
 [source,java]
@@ -251,7 +251,7 @@ a| `value` a| ``Attribute``’s value a| `Value`
 attributeType.get(transaction, value).resolve();
 ----
 
-[#_AttributeType_get_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_AttributeType_get__TypeDBTransaction__java_lang_String]
 ==== get
 
 [source,java]
@@ -285,7 +285,7 @@ a| `value` a| ``Attribute``’s value a| `java.lang.String`
 attributeType.get(transaction, value).resolve();
 ----
 
-[#_AttributeType_get_com_vaticle_typedb_driver_api_TypeDBTransaction_long]
+[#_AttributeType_get__TypeDBTransaction__long]
 ==== get
 
 [source,java]
@@ -319,7 +319,7 @@ a| `value` a| ``Attribute``’s value a| `long`
 attributeType.get(transaction, value).resolve();
 ----
 
-[#_AttributeType_get_com_vaticle_typedb_driver_api_TypeDBTransaction_double]
+[#_AttributeType_get__TypeDBTransaction__double]
 ==== get
 
 [source,java]
@@ -353,7 +353,7 @@ a| `value` a| ``Attribute``’s value a| `double`
 attributeType.get(transaction, value).resolve();
 ----
 
-[#_AttributeType_get_com_vaticle_typedb_driver_api_TypeDBTransaction_boolean]
+[#_AttributeType_get__TypeDBTransaction__boolean]
 ==== get
 
 [source,java]
@@ -387,7 +387,7 @@ a| `value` a| ``Attribute``’s value a| `boolean`
 attributeType.get(transaction, value).resolve();
 ----
 
-[#_AttributeType_get_com_vaticle_typedb_driver_api_TypeDBTransaction_java_time_LocalDateTime]
+[#_AttributeType_get__TypeDBTransaction__java_time_LocalDateTime]
 ==== get
 
 [source,java]
@@ -421,7 +421,7 @@ a| `value` a| ``Attribute``’s value a| `java.time.LocalDateTime`
 attributeType.get(transaction, value).resolve();
 ----
 
-[#_AttributeType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_AttributeType_getInstances__TypeDBTransaction]
 ==== getInstances
 
 [source,java]
@@ -457,7 +457,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 attributeType.getInstances(transaction);
 ----
 
-[#_AttributeType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_AttributeType_getInstances__TypeDBTransaction__Concept_Transitivity]
 ==== getInstances
 
 [source,java]
@@ -491,7 +491,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 attributeType.getInstances(transaction, transitivity);
 ----
 
-[#_AttributeType_getOwners_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_AttributeType_getOwners__TypeDBTransaction]
 ==== getOwners
 
 [source,java]
@@ -523,7 +523,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 attributeType.getOwners(transaction);
 ----
 
-[#_AttributeType_getOwners_com_vaticle_typedb_driver_api_TypeDBTransaction_java_util_Set]
+[#_AttributeType_getOwners__TypeDBTransaction__java_util_Set_ThingType_Annotation_]
 ==== getOwners
 
 [source,java]
@@ -557,7 +557,7 @@ a| `annotations` a| Only retrieve ``ThingTypes`` that have an attribute of this 
 attributeType.getOwners(transaction, annotations);
 ----
 
-[#_AttributeType_getOwners_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_AttributeType_getOwners__TypeDBTransaction__Concept_Transitivity]
 ==== getOwners
 
 [source,java]
@@ -591,7 +591,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited owners
 attributeType.getOwners(transaction, transitivity);
 ----
 
-[#_AttributeType_getOwners_com_vaticle_typedb_driver_api_TypeDBTransaction_java_util_Set_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_AttributeType_getOwners__TypeDBTransaction__java_util_Set_ThingType_Annotation___Concept_Transitivity]
 ==== getOwners
 
 [source,java]
@@ -627,7 +627,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited owners
 attributeType.getOwners(transaction, annotations, transitivity);
 ----
 
-[#_AttributeType_getRegex_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_AttributeType_getRegex__TypeDBTransaction]
 ==== getRegex
 
 [source,java]
@@ -659,7 +659,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 attributeType.getRegex(transaction).resolve();
 ----
 
-[#_AttributeType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_AttributeType_getSubtypes__TypeDBTransaction]
 ==== getSubtypes
 
 [source,java]
@@ -695,7 +695,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 attributeType.getSubtypes(transaction);
 ----
 
-[#_AttributeType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value_Type]
+[#_AttributeType_getSubtypes__TypeDBTransaction__Value_Type]
 ==== getSubtypes
 
 [source,java]
@@ -729,7 +729,7 @@ a| `valueType` a| ``Value.Type`` for retrieving subtypes a| `Value.Type`
 attributeType.getSubtypes(transaction, valueType);
 ----
 
-[#_AttributeType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value_Type_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_AttributeType_getSubtypes__TypeDBTransaction__Value_Type__Concept_Transitivity]
 ==== getSubtypes
 
 [source,java]
@@ -765,7 +765,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 attributeType.getSubtypes(transaction, valueType, transitivity);
 ----
 
-[#_AttributeType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_AttributeType_getSubtypes__TypeDBTransaction__Concept_Transitivity]
 ==== getSubtypes
 
 [source,java]
@@ -799,7 +799,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 attributeType.getSubtypes(transaction, transitivity);
 ----
 
-[#_AttributeType_getValueType_]
+[#_AttributeType_getValueType__]
 ==== getValueType
 
 [source,java]
@@ -822,7 +822,7 @@ Retrieves the ``Value.Type`` of this ``AttributeType``.
 attributeType.getValueType();
 ----
 
-[#_AttributeType_isAttribute_]
+[#_AttributeType_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -845,7 +845,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_AttributeType_isAttributeType_]
+[#_AttributeType_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -868,7 +868,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_AttributeType_isBoolean_]
+[#_AttributeType_isBoolean__]
 ==== isBoolean
 
 [source,java]
@@ -891,7 +891,7 @@ Returns ``True`` if the value for attributes of this type is of type ``boolean``
 attributeType.isBoolean();
 ----
 
-[#_AttributeType_isDateTime_]
+[#_AttributeType_isDateTime__]
 ==== isDateTime
 
 [source,java]
@@ -914,7 +914,7 @@ Returns ``True`` if the value for attributes of this type is of type ``datetime`
 attributeType.isDatetime();
 ----
 
-[#_AttributeType_isDouble_]
+[#_AttributeType_isDouble__]
 ==== isDouble
 
 [source,java]
@@ -937,7 +937,7 @@ Returns ``True`` if the value for attributes of this type is of type ``double``.
 attributeType.isDouble();
 ----
 
-[#_AttributeType_isEntity_]
+[#_AttributeType_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -960,7 +960,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_AttributeType_isEntityType_]
+[#_AttributeType_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -983,7 +983,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_AttributeType_isLong_]
+[#_AttributeType_isLong__]
 ==== isLong
 
 [source,java]
@@ -1006,7 +1006,7 @@ Returns ``True`` if the value for attributes of this type is of type ``long``. O
 attributeType.isLong();
 ----
 
-[#_AttributeType_isRelation_]
+[#_AttributeType_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -1029,7 +1029,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_AttributeType_isRelationType_]
+[#_AttributeType_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -1052,7 +1052,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_AttributeType_isRoleType_]
+[#_AttributeType_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -1075,7 +1075,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_AttributeType_isString_]
+[#_AttributeType_isString__]
 ==== isString
 
 [source,java]
@@ -1098,7 +1098,7 @@ Returns ``True`` if the value for attributes of this type is of type ``string``.
 attributeType.isString();
 ----
 
-[#_AttributeType_isThing_]
+[#_AttributeType_isThing__]
 ==== isThing
 
 [source,java]
@@ -1121,7 +1121,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_AttributeType_isValue_]
+[#_AttributeType_isValue__]
 ==== isValue
 
 [source,java]
@@ -1144,7 +1144,7 @@ Checks if the concept is a ``Value``.
 concept.isValue();
 ----
 
-[#_AttributeType_put_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value]
+[#_AttributeType_put__TypeDBTransaction__Value]
 ==== put
 
 [source,java]
@@ -1178,7 +1178,7 @@ a| `value` a| New ``Attribute``’s value a| `Value`
 attributeType.put(transaction, value).resolve();
 ----
 
-[#_AttributeType_put_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_AttributeType_put__TypeDBTransaction__java_lang_String]
 ==== put
 
 [source,java]
@@ -1212,7 +1212,7 @@ a| `value` a| New ``Attribute``’s value a| `java.lang.String`
 attributeType.put(transaction, value).resolve();
 ----
 
-[#_AttributeType_put_com_vaticle_typedb_driver_api_TypeDBTransaction_long]
+[#_AttributeType_put__TypeDBTransaction__long]
 ==== put
 
 [source,java]
@@ -1246,7 +1246,7 @@ a| `value` a| New ``Attribute``’s value a| `long`
 attributeType.put(transaction, value).resolve();
 ----
 
-[#_AttributeType_put_com_vaticle_typedb_driver_api_TypeDBTransaction_double]
+[#_AttributeType_put__TypeDBTransaction__double]
 ==== put
 
 [source,java]
@@ -1280,7 +1280,7 @@ a| `value` a| New ``Attribute``’s value a| `double`
 attributeType.put(transaction, value).resolve();
 ----
 
-[#_AttributeType_put_com_vaticle_typedb_driver_api_TypeDBTransaction_boolean]
+[#_AttributeType_put__TypeDBTransaction__boolean]
 ==== put
 
 [source,java]
@@ -1314,7 +1314,7 @@ a| `value` a| New ``Attribute``’s value a| `boolean`
 attributeType.put(transaction, value).resolve();
 ----
 
-[#_AttributeType_put_com_vaticle_typedb_driver_api_TypeDBTransaction_java_time_LocalDateTime]
+[#_AttributeType_put__TypeDBTransaction__java_time_LocalDateTime]
 ==== put
 
 [source,java]
@@ -1348,7 +1348,7 @@ a| `value` a| New ``Attribute``’s value a| `java.time.LocalDateTime`
 attributeType.put(transaction, value).resolve();
 ----
 
-[#_AttributeType_setRegex_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_AttributeType_setRegex__TypeDBTransaction__java_lang_String]
 ==== setRegex
 
 [source,java]
@@ -1384,7 +1384,7 @@ a| `regex` a| Regular expression a| `java.lang.String`
 attributeType.setRegex(transaction, regex).resolve();
 ----
 
-[#_AttributeType_setSupertype_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType]
+[#_AttributeType_setSupertype__TypeDBTransaction__AttributeType]
 ==== setSupertype
 
 [source,java]
@@ -1418,7 +1418,7 @@ a| `attributeType` a| The ``AttributeType`` to set as the supertype of this ``At
 attributeType.setSupertype(transaction, superType).resolve();
 ----
 
-[#_AttributeType_unsetRegex_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_AttributeType_unsetRegex__TypeDBTransaction]
 ==== unsetRegex
 
 [source,java]

--- a/java/docs/schema/Concept.Transitivity.adoc
+++ b/java/docs/schema/Concept.Transitivity.adoc
@@ -1,4 +1,4 @@
-[#_Concept.Transitivity]
+[#_Concept_Transitivity]
 === Concept.Transitivity
 
 *Package*: `com.vaticle.typedb.driver.api.concept`
@@ -30,7 +30,7 @@ a| `TRANSITIVE`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_Concept.Transitivity_of_com_vaticle_typedb_driver_jni_Transitivity]
+[#_Concept_Transitivity_of__com_vaticle_typedb_driver_jni_Transitivity]
 ==== of
 
 [source,java]
@@ -44,7 +44,7 @@ public static Concept.Transitivity of​(com.vaticle.typedb.driver.jni.Transitiv
 .Returns
 `public static Concept.Transitivity`
 
-[#_Concept.Transitivity_valueOf_java_lang_String]
+[#_Concept_Transitivity_valueOf__java_lang_String]
 ==== valueOf
 
 [source,java]
@@ -67,7 +67,7 @@ a| `name` a| the name of the enum constant to be returned. a| `java.lang.String`
 .Returns
 `public static Concept.Transitivity`
 
-[#_Concept.Transitivity_values_]
+[#_Concept_Transitivity_values__]
 ==== values
 
 [source,java]

--- a/java/docs/schema/EntityType.adoc
+++ b/java/docs/schema/EntityType.adoc
@@ -12,7 +12,7 @@
 Entity types represent the classification of independent objects in the data model of the business domain.
 
 // tag::methods[]
-[#_EntityType_asAttribute_]
+[#_EntityType_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -34,7 +34,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_EntityType_asAttributeType_]
+[#_EntityType_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -56,7 +56,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_EntityType_asEntity_]
+[#_EntityType_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -78,7 +78,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_EntityType_asEntityType_]
+[#_EntityType_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -101,7 +101,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_EntityType_asRelation_]
+[#_EntityType_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -123,7 +123,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_EntityType_asRelationType_]
+[#_EntityType_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -145,7 +145,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_EntityType_asRoleType_]
+[#_EntityType_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -167,7 +167,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_EntityType_asThing_]
+[#_EntityType_asThing__]
 ==== asThing
 
 [source,java]
@@ -189,7 +189,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_EntityType_asValue_]
+[#_EntityType_asValue__]
 ==== asValue
 
 [source,java]
@@ -211,7 +211,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_EntityType_create_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_EntityType_create__TypeDBTransaction]
 ==== create
 
 [source,java]
@@ -243,7 +243,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 entityType.create(transaction).resolve();
 ----
 
-[#_EntityType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_EntityType_getInstances__TypeDBTransaction]
 ==== getInstances
 
 [source,java]
@@ -262,7 +262,7 @@ See also: <<#_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_v
 .Returns
 `java.util.stream.Stream<? extends Entity>`
 
-[#_EntityType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_EntityType_getInstances__TypeDBTransaction__Concept_Transitivity]
 ==== getInstances
 
 [source,java]
@@ -296,7 +296,7 @@ a| `transitivity` a| ``Transitivity.EXPLICIT`` for direct instances only, ``Tran
 entityType.getInstances(transaction, transitivity);
 ----
 
-[#_EntityType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_EntityType_getSubtypes__TypeDBTransaction]
 ==== getSubtypes
 
 [source,java]
@@ -315,7 +315,7 @@ See also: <<#_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_va
 .Returns
 `java.util.stream.Stream<? extends EntityType>`
 
-[#_EntityType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_EntityType_getSubtypes__TypeDBTransaction__Concept_Transitivity]
 ==== getSubtypes
 
 [source,java]
@@ -349,7 +349,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 entityType.getSubtypes(transaction, transitivity);
 ----
 
-[#_EntityType_isAttribute_]
+[#_EntityType_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -372,7 +372,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_EntityType_isAttributeType_]
+[#_EntityType_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -395,7 +395,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_EntityType_isEntity_]
+[#_EntityType_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -418,7 +418,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_EntityType_isEntityType_]
+[#_EntityType_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -441,7 +441,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_EntityType_isRelation_]
+[#_EntityType_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -464,7 +464,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_EntityType_isRelationType_]
+[#_EntityType_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -487,7 +487,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_EntityType_isRoleType_]
+[#_EntityType_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -510,7 +510,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_EntityType_isThing_]
+[#_EntityType_isThing__]
 ==== isThing
 
 [source,java]
@@ -533,7 +533,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_EntityType_isValue_]
+[#_EntityType_isValue__]
 ==== isValue
 
 [source,java]
@@ -556,7 +556,7 @@ Checks if the concept is a ``Value``.
 concept.isValue();
 ----
 
-[#_EntityType_setSupertype_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_EntityType]
+[#_EntityType_setSupertype__TypeDBTransaction__EntityType]
 ==== setSupertype
 
 [source,java]

--- a/java/docs/schema/Label.adoc
+++ b/java/docs/schema/Label.adoc
@@ -8,7 +8,7 @@ A ``Label`` holds the uniquely identifying name of a type.
 It consists of an optional ``scope``, and a ``name``, represented ``scope:name``. The scope is used only used to distinguish between role-types of the same name declared in different relation types.
 
 // tag::methods[]
-[#_Label_equals_java_lang_Object]
+[#_Label_equals__java_lang_Object]
 ==== equals
 
 [source,java]
@@ -39,7 +39,7 @@ a| `obj` a| Object to compare with a| `java.lang.Object`
 label.equals(obj);
 ----
 
-[#_Label_name_]
+[#_Label_name__]
 ==== name
 
 [source,java]
@@ -61,7 +61,7 @@ Returns the name of this Label.
 label.name();
 ----
 
-[#_Label_of_java_lang_String]
+[#_Label_of__java_lang_String]
 ==== of
 
 [source,java]
@@ -92,7 +92,7 @@ a| `name` a| Label name a| `java.lang.String`
 Label.of("entity");
 ----
 
-[#_Label_of_java_lang_String_java_lang_String]
+[#_Label_of__java_lang_String__java_lang_String]
 ==== of
 
 [source,java]
@@ -125,7 +125,7 @@ a| `name` a| Label name a| `java.lang.String`
 Label.of("relation", "role");
 ----
 
-[#_Label_scope_]
+[#_Label_scope__]
 ==== scope
 
 [source,java]
@@ -147,7 +147,7 @@ Returns the scope of this Label.
 label.scope();
 ----
 
-[#_Label_scopedName_]
+[#_Label_scopedName__]
 ==== scopedName
 
 [source,java]
@@ -169,7 +169,7 @@ Returns the string representation of the scoped name.
 label.scoped_name();
 ----
 
-[#_Label_toString_]
+[#_Label_toString__]
 ==== toString
 
 [source,java]

--- a/java/docs/schema/RelationType.adoc
+++ b/java/docs/schema/RelationType.adoc
@@ -12,7 +12,7 @@
 Relation types (or subtypes of the relation root type) represent relationships between types. Relation types have roles. Other types can play roles in relations if it’s mentioned in their definition. A relation type must specify at least one role.
 
 // tag::methods[]
-[#_RelationType_asAttribute_]
+[#_RelationType_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -34,7 +34,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_RelationType_asAttributeType_]
+[#_RelationType_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -56,7 +56,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_RelationType_asEntity_]
+[#_RelationType_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -78,7 +78,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_RelationType_asEntityType_]
+[#_RelationType_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -100,7 +100,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_RelationType_asRelation_]
+[#_RelationType_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -122,7 +122,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_RelationType_asRelationType_]
+[#_RelationType_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -145,7 +145,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_RelationType_asRoleType_]
+[#_RelationType_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -167,7 +167,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_RelationType_asThing_]
+[#_RelationType_asThing__]
 ==== asThing
 
 [source,java]
@@ -189,7 +189,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_RelationType_asValue_]
+[#_RelationType_asValue__]
 ==== asValue
 
 [source,java]
@@ -211,7 +211,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_RelationType_create_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RelationType_create__TypeDBTransaction]
 ==== create
 
 [source,java]
@@ -243,7 +243,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 relationType.create(transaction).resolve();
 ----
 
-[#_RelationType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RelationType_getInstances__TypeDBTransaction]
 ==== getInstances
 
 [source,java]
@@ -262,7 +262,7 @@ See also: <<#_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_v
 .Returns
 `java.util.stream.Stream<? extends Relation>`
 
-[#_RelationType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_RelationType_getInstances__TypeDBTransaction__Concept_Transitivity]
 ==== getInstances
 
 [source,java]
@@ -296,7 +296,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect instanc
 relationType.getInstances(transaction, transitivity)
 ----
 
-[#_RelationType_getRelates_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RelationType_getRelates__TypeDBTransaction]
 ==== getRelates
 
 [source,java]
@@ -315,7 +315,7 @@ See also: <<#_getRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vat
 .Returns
 `java.util.stream.Stream<? extends RoleType>`
 
-[#_RelationType_getRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_RelationType_getRelates__TypeDBTransaction__Concept_Transitivity]
 ==== getRelates
 
 [source,java]
@@ -349,7 +349,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited relate
 relationType.getRelates(transaction, transitivity);
 ----
 
-[#_RelationType_getRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_RelationType_getRelates__TypeDBTransaction__java_lang_String]
 ==== getRelates
 
 [source,java]
@@ -383,7 +383,7 @@ a| `roleLabel` a| Label of the role we wish to retrieve a| `java.lang.String`
 relationType.getRelates(transaction, roleLabel).resolve();
 ----
 
-[#_RelationType_getRelatesOverridden_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType]
+[#_RelationType_getRelatesOverridden__TypeDBTransaction__RoleType]
 ==== getRelatesOverridden
 
 [source,java]
@@ -399,7 +399,7 @@ Promise<? extends RoleType> getRelatesOverridden​(TypeDBTransaction transactio
 .Returns
 `Promise<? extends RoleType>`
 
-[#_RelationType_getRelatesOverridden_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_RelationType_getRelatesOverridden__TypeDBTransaction__java_lang_String]
 ==== getRelatesOverridden
 
 [source,java]
@@ -433,7 +433,7 @@ a| `roleLabel` a| Label of the role that overrides an inherited role a| `java.la
 relationType.getRelatesOverridden(transaction, roleLabel).resolve();
 ----
 
-[#_RelationType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RelationType_getSubtypes__TypeDBTransaction]
 ==== getSubtypes
 
 [source,java]
@@ -452,7 +452,7 @@ See also: <<#_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_va
 .Returns
 `java.util.stream.Stream<? extends RelationType>`
 
-[#_RelationType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_RelationType_getSubtypes__TypeDBTransaction__Concept_Transitivity]
 ==== getSubtypes
 
 [source,java]
@@ -486,7 +486,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 relationType.getSubtypes(transaction, transitivity).resolve();
 ----
 
-[#_RelationType_isAttribute_]
+[#_RelationType_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -509,7 +509,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_RelationType_isAttributeType_]
+[#_RelationType_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -532,7 +532,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_RelationType_isEntity_]
+[#_RelationType_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -555,7 +555,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_RelationType_isEntityType_]
+[#_RelationType_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -578,7 +578,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_RelationType_isRelation_]
+[#_RelationType_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -601,7 +601,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_RelationType_isRelationType_]
+[#_RelationType_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -624,7 +624,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_RelationType_isRoleType_]
+[#_RelationType_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -647,7 +647,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_RelationType_isThing_]
+[#_RelationType_isThing__]
 ==== isThing
 
 [source,java]
@@ -670,7 +670,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_RelationType_isValue_]
+[#_RelationType_isValue__]
 ==== isValue
 
 [source,java]
@@ -693,7 +693,7 @@ Checks if the concept is a ``Value``.
 concept.isValue();
 ----
 
-[#_RelationType_setRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_RelationType_setRelates__TypeDBTransaction__java_lang_String]
 ==== setRelates
 
 [source,java]
@@ -713,7 +713,7 @@ See also: <<#_setRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_la
 .Returns
 `Promise<java.lang.Void>`
 
-[#_RelationType_setRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String_com_vaticle_typedb_driver_api_concept_type_RoleType]
+[#_RelationType_setRelates__TypeDBTransaction__java_lang_String__RoleType]
 ==== setRelates
 
 [source,java]
@@ -734,7 +734,7 @@ See also: <<#_setRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_la
 .Returns
 `Promise<java.lang.Void>`
 
-[#_RelationType_setRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String_java_lang_String]
+[#_RelationType_setRelates__TypeDBTransaction__java_lang_String__java_lang_String]
 ==== setRelates
 
 [source,java]
@@ -771,7 +771,7 @@ relationType.setRelates(transaction, roleLabel).resolve();
  relationType.setRelates(transaction, roleLabel, overriddenLabel).resolve();
 ----
 
-[#_RelationType_setSupertype_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RelationType]
+[#_RelationType_setSupertype__TypeDBTransaction__RelationType]
 ==== setSupertype
 
 [source,java]
@@ -805,7 +805,7 @@ a| `superRelationType` a| The ``RelationType`` to set as the supertype of this `
 relationType.setSupertype(transaction, superRelationType).resolve();
 ----
 
-[#_RelationType_unsetRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType]
+[#_RelationType_unsetRelates__TypeDBTransaction__RoleType]
 ==== unsetRelates
 
 [source,java]
@@ -825,7 +825,7 @@ See also: <<#_unsetRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_
 .Returns
 `Promise<java.lang.Void>`
 
-[#_RelationType_unsetRelates_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_RelationType_unsetRelates__TypeDBTransaction__java_lang_String]
 ==== unsetRelates
 
 [source,java]

--- a/java/docs/schema/RoleType.adoc
+++ b/java/docs/schema/RoleType.adoc
@@ -11,7 +11,7 @@
 Roles are special internal types used by relations. We can not create an instance of a role in a database. But we can set an instance of another type (role player) to play a role in a particular instance of a relation type. Roles allow a schema to enforce logical constraints on types of role players.
 
 // tag::methods[]
-[#_RoleType_asAttribute_]
+[#_RoleType_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -33,7 +33,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_RoleType_asAttributeType_]
+[#_RoleType_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -55,7 +55,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_RoleType_asEntity_]
+[#_RoleType_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -77,7 +77,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_RoleType_asEntityType_]
+[#_RoleType_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -99,7 +99,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_RoleType_asRelation_]
+[#_RoleType_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -121,7 +121,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_RoleType_asRelationType_]
+[#_RoleType_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -143,7 +143,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_RoleType_asRoleType_]
+[#_RoleType_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -166,7 +166,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_RoleType_asThing_]
+[#_RoleType_asThing__]
 ==== asThing
 
 [source,java]
@@ -188,7 +188,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_RoleType_asThingType_]
+[#_RoleType_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -210,7 +210,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_RoleType_asValue_]
+[#_RoleType_asValue__]
 ==== asValue
 
 [source,java]
@@ -232,7 +232,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_RoleType_getPlayerInstances_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getPlayerInstances__TypeDBTransaction]
 ==== getPlayerInstances
 
 [source,java]
@@ -251,7 +251,7 @@ See also: <<#_getPlayerTypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com
 .Returns
 `java.util.stream.Stream<? extends Thing>`
 
-[#_RoleType_getPlayerInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_RoleType_getPlayerInstances__TypeDBTransaction__Concept_Transitivity]
 ==== getPlayerInstances
 
 [source,java]
@@ -285,7 +285,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 roleType.getPlayerInstances(transaction, transitivity);
 ----
 
-[#_RoleType_getPlayerTypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getPlayerTypes__TypeDBTransaction]
 ==== getPlayerTypes
 
 [source,java]
@@ -304,7 +304,7 @@ See also: <<#_getPlayerTypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com
 .Returns
 `java.util.stream.Stream<? extends ThingType>`
 
-[#_RoleType_getPlayerTypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_RoleType_getPlayerTypes__TypeDBTransaction__Concept_Transitivity]
 ==== getPlayerTypes
 
 [source,java]
@@ -338,7 +338,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 roleType.getPlayerTypes(transaction, transitivity)
 ----
 
-[#_RoleType_getRelationInstances_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getRelationInstances__TypeDBTransaction]
 ==== getRelationInstances
 
 [source,java]
@@ -357,7 +357,7 @@ See also: <<#_getRelationInstances_com_vaticle_typedb_driver_api_TypeDBTransacti
 .Returns
 `java.util.stream.Stream<? extends Relation>`
 
-[#_RoleType_getRelationInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_RoleType_getRelationInstances__TypeDBTransaction__Concept_Transitivity]
 ==== getRelationInstances
 
 [source,java]
@@ -391,7 +391,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect relatio
 roleType.getRelationInstances(transaction, transitivity)
 ----
 
-[#_RoleType_getRelationType_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getRelationType__TypeDBTransaction]
 ==== getRelationType
 
 [source,java]
@@ -423,7 +423,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getRelationType(transaction).resolve();
 ----
 
-[#_RoleType_getRelationTypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getRelationTypes__TypeDBTransaction]
 ==== getRelationTypes
 
 [source,java]
@@ -455,7 +455,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getRelationTypes(transaction);
 ----
 
-[#_RoleType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getSubtypes__TypeDBTransaction]
 ==== getSubtypes
 
 [source,java]
@@ -474,7 +474,7 @@ See also: <<#_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_va
 .Returns
 `java.util.stream.Stream<? extends RoleType>`
 
-[#_RoleType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_RoleType_getSubtypes__TypeDBTransaction__Concept_Transitivity]
 ==== getSubtypes
 
 [source,java]
@@ -508,7 +508,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 roleType.getSubtypes(transaction, transitivity);
 ----
 
-[#_RoleType_getSupertype_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getSupertype__TypeDBTransaction]
 ==== getSupertype
 
 [source,java]
@@ -540,7 +540,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getSupertype(transaction).resolve();
 ----
 
-[#_RoleType_getSupertypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_RoleType_getSupertypes__TypeDBTransaction]
 ==== getSupertypes
 
 [source,java]
@@ -572,7 +572,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getSupertypes(transaction);
 ----
 
-[#_RoleType_isAttribute_]
+[#_RoleType_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -595,7 +595,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_RoleType_isAttributeType_]
+[#_RoleType_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -618,7 +618,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_RoleType_isEntity_]
+[#_RoleType_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -641,7 +641,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_RoleType_isEntityType_]
+[#_RoleType_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -664,7 +664,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_RoleType_isRelation_]
+[#_RoleType_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -687,7 +687,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_RoleType_isRelationType_]
+[#_RoleType_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -710,7 +710,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_RoleType_isRoleType_]
+[#_RoleType_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -733,7 +733,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_RoleType_isThing_]
+[#_RoleType_isThing__]
 ==== isThing
 
 [source,java]
@@ -756,7 +756,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_RoleType_isThingType_]
+[#_RoleType_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -779,7 +779,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_RoleType_isValue_]
+[#_RoleType_isValue__]
 ==== isValue
 
 [source,java]

--- a/java/docs/schema/ThingType.Annotation.adoc
+++ b/java/docs/schema/ThingType.Annotation.adoc
@@ -1,4 +1,4 @@
-[#_ThingType.Annotation]
+[#_ThingType_Annotation]
 === ThingType.Annotation
 
 *Package*: `com.vaticle.typedb.driver.api.concept.type`
@@ -6,7 +6,7 @@
 Annotation
 
 // tag::methods[]
-[#_ThingType.Annotation_equals_java_lang_Object]
+[#_ThingType_Annotation_equals__java_lang_Object]
 ==== equals
 
 [source,java]
@@ -37,7 +37,7 @@ a| `obj` a| Object to compare with a| `java.lang.Object`
 annotation.equals(obj);
 ----
 
-[#_ThingType.Annotation_hashCode_]
+[#_ThingType_Annotation_hashCode__]
 ==== hashCode
 
 [source,java]
@@ -51,7 +51,7 @@ public int hashCode()
 .Returns
 `public int`
 
-[#_ThingType.Annotation_isKey_]
+[#_ThingType_Annotation_isKey__]
 ==== isKey
 
 [source,java]
@@ -73,7 +73,7 @@ Checks if this ``Annotation`` is a ``@key`` annotation.
 annotation.isKey();
 ----
 
-[#_ThingType.Annotation_isUnique_]
+[#_ThingType_Annotation_isUnique__]
 ==== isUnique
 
 [source,java]
@@ -95,7 +95,7 @@ Checks if this ``Annotation`` is a ``@unique`` annotation.
 annotation.isUnique();
 ----
 
-[#_ThingType.Annotation_key_]
+[#_ThingType_Annotation_key__]
 ==== key
 
 [source,java]
@@ -117,7 +117,7 @@ Produces a ``@key`` annotation.
 ThingType.Annotation.key();
 ----
 
-[#_ThingType.Annotation_toString_]
+[#_ThingType_Annotation_toString__]
 ==== toString
 
 [source,java]
@@ -139,7 +139,7 @@ Retrieves a string representation of this ``Annotation``.
 annotation.toString();
 ----
 
-[#_ThingType.Annotation_unique_]
+[#_ThingType_Annotation_unique__]
 ==== unique
 
 [source,java]

--- a/java/docs/schema/ThingType.adoc
+++ b/java/docs/schema/ThingType.adoc
@@ -9,7 +9,7 @@
 * `Type`
 
 // tag::methods[]
-[#_ThingType_asAttribute_]
+[#_ThingType_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -31,7 +31,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_ThingType_asAttributeType_]
+[#_ThingType_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -53,7 +53,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_ThingType_asEntity_]
+[#_ThingType_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -75,7 +75,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_ThingType_asEntityType_]
+[#_ThingType_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -97,7 +97,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_ThingType_asRelation_]
+[#_ThingType_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -119,7 +119,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_ThingType_asRelationType_]
+[#_ThingType_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -141,7 +141,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_ThingType_asRoleType_]
+[#_ThingType_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -163,7 +163,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_ThingType_asThing_]
+[#_ThingType_asThing__]
 ==== asThing
 
 [source,java]
@@ -185,7 +185,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_ThingType_asThingType_]
+[#_ThingType_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -208,7 +208,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_ThingType_asValue_]
+[#_ThingType_asValue__]
 ==== asValue
 
 [source,java]
@@ -230,7 +230,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_ThingType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_getInstances__TypeDBTransaction]
 ==== getInstances
 
 [source,java]
@@ -249,7 +249,7 @@ See also: <<#_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_v
 .Returns
 `java.util.stream.Stream<? extends Thing>`
 
-[#_ThingType_getInstances_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_ThingType_getInstances__TypeDBTransaction__Concept_Transitivity]
 ==== getInstances
 
 [source,java]
@@ -284,7 +284,7 @@ thingType.getInstances(transaction);
  thingType.getInstances(transaction, Transitivity.EXPLICIT);
 ----
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_getOwns__TypeDBTransaction]
 ==== getOwns
 
 [source,java]
@@ -303,7 +303,7 @@ See also: <<#_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `java.util.stream.Stream<? extends AttributeType>`
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value_Type]
+[#_ThingType_getOwns__TypeDBTransaction__Value_Type]
 ==== getOwns
 
 [source,java]
@@ -323,7 +323,7 @@ See also: <<#_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `java.util.stream.Stream<? extends AttributeType>`
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_java_util_Set]
+[#_ThingType_getOwns__TypeDBTransaction__java_util_Set_ThingType_Annotation_]
 ==== getOwns
 
 [source,java]
@@ -343,7 +343,7 @@ See also: <<#_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `java.util.stream.Stream<? extends AttributeType>`
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value_Type_java_util_Set]
+[#_ThingType_getOwns__TypeDBTransaction__Value_Type__java_util_Set_ThingType_Annotation_]
 ==== getOwns
 
 [source,java]
@@ -364,7 +364,7 @@ See also: <<#_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `java.util.stream.Stream<? extends AttributeType>`
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_ThingType_getOwns__TypeDBTransaction__Concept_Transitivity]
 ==== getOwns
 
 [source,java]
@@ -384,7 +384,7 @@ See also: <<#_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `java.util.stream.Stream<? extends AttributeType>`
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value_Type_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_ThingType_getOwns__TypeDBTransaction__Value_Type__Concept_Transitivity]
 ==== getOwns
 
 [source,java]
@@ -405,7 +405,7 @@ See also: <<#_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `java.util.stream.Stream<? extends AttributeType>`
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_java_util_Set_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_ThingType_getOwns__TypeDBTransaction__java_util_Set_ThingType_Annotation___Concept_Transitivity]
 ==== getOwns
 
 [source,java]
@@ -426,7 +426,7 @@ See also: <<#_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `java.util.stream.Stream<? extends AttributeType>`
 
-[#_ThingType_getOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_value_Value_Type_java_util_Set_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_ThingType_getOwns__TypeDBTransaction__Value_Type__java_util_Set_ThingType_Annotation___Concept_Transitivity]
 ==== getOwns
 
 [source,java]
@@ -465,7 +465,7 @@ thingType.getOwns(transaction);
  thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT, Collections.singleton(Annotation.key()));
 ----
 
-[#_ThingType_getOwnsOverridden_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType]
+[#_ThingType_getOwnsOverridden__TypeDBTransaction__AttributeType]
 ==== getOwnsOverridden
 
 [source,java]
@@ -499,7 +499,7 @@ a| `attributeType` a| The ``AttributeType`` that overrides requested ``Attribute
 thingType.getOwnsOverridden(transaction, attributeType).resolve();
 ----
 
-[#_ThingType_getPlays_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_getPlays__TypeDBTransaction]
 ==== getPlays
 
 [source,java]
@@ -518,7 +518,7 @@ See also: <<#_getPlays_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vatic
 .Returns
 `java.util.stream.Stream<? extends RoleType>`
 
-[#_ThingType_getPlays_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_ThingType_getPlays__TypeDBTransaction__Concept_Transitivity]
 ==== getPlays
 
 [source,java]
@@ -553,7 +553,7 @@ thingType.getPlays(transaction).resolve();
  thingType.getPlays(transaction, Transitivity.EXPLICIT).resolve();
 ----
 
-[#_ThingType_getPlaysOverridden_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType]
+[#_ThingType_getPlaysOverridden__TypeDBTransaction__RoleType]
 ==== getPlaysOverridden
 
 [source,java]
@@ -587,7 +587,7 @@ a| `roleType` a| The ``RoleType`` that overrides an inherited role a| `RoleType`
 thingType.getPlaysOverridden(transaction, roleType).resolve();
 ----
 
-[#_ThingType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_getSubtypes__TypeDBTransaction]
 ==== getSubtypes
 
 [source,java]
@@ -606,7 +606,7 @@ See also: ``Type.getSubtypes(TypeDBTransaction, Transitivity)``
 .Returns
 `java.util.stream.Stream<? extends ThingType>`
 
-[#_ThingType_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_ThingType_getSubtypes__TypeDBTransaction__Concept_Transitivity]
 ==== getSubtypes
 
 [source,java]
@@ -641,7 +641,7 @@ type.getSubtypes(transaction);
  type.getSubtypes(transaction, Transitivity.EXPLICIT);
 ----
 
-[#_ThingType_getSupertype_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_getSupertype__TypeDBTransaction]
 ==== getSupertype
 
 [source,java]
@@ -673,7 +673,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertype(transaction).resolve();
 ----
 
-[#_ThingType_getSupertypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_getSupertypes__TypeDBTransaction]
 ==== getSupertypes
 
 [source,java]
@@ -705,7 +705,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertypes(transaction);
 ----
 
-[#_ThingType_getSyntax_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_getSyntax__TypeDBTransaction]
 ==== getSyntax
 
 [source,java]
@@ -737,7 +737,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSyntax(transaction).resolve();
 ----
 
-[#_ThingType_isAttribute_]
+[#_ThingType_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -760,7 +760,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_ThingType_isAttributeType_]
+[#_ThingType_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -783,7 +783,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_ThingType_isEntity_]
+[#_ThingType_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -806,7 +806,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_ThingType_isEntityType_]
+[#_ThingType_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -829,7 +829,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_ThingType_isRelation_]
+[#_ThingType_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -852,7 +852,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_ThingType_isRelationType_]
+[#_ThingType_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -875,7 +875,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_ThingType_isRoleType_]
+[#_ThingType_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -898,7 +898,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_ThingType_isThing_]
+[#_ThingType_isThing__]
 ==== isThing
 
 [source,java]
@@ -921,7 +921,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_ThingType_isThingType_]
+[#_ThingType_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -944,7 +944,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_ThingType_isValue_]
+[#_ThingType_isValue__]
 ==== isValue
 
 [source,java]
@@ -967,7 +967,7 @@ Checks if the concept is a ``Value``.
 concept.isValue();
 ----
 
-[#_ThingType_setAbstract_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_setAbstract__TypeDBTransaction]
 ==== setAbstract
 
 [source,java]
@@ -999,7 +999,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.setAbstract(transaction).resolve();
 ----
 
-[#_ThingType_setOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType_com_vaticle_typedb_driver_api_concept_type_AttributeType_java_util_Set]
+[#_ThingType_setOwns__TypeDBTransaction__AttributeType__AttributeType__java_util_Set_ThingType_Annotation_]
 ==== setOwns
 
 [source,java]
@@ -1038,7 +1038,7 @@ thingType.setOwns(transaction, attributeType).resolve();
  thingType.setOwns(transaction, attributeType, overriddenType, Collections.singleton(Annotation.key())).resolve();
 ----
 
-[#_ThingType_setOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType_com_vaticle_typedb_driver_api_concept_type_AttributeType]
+[#_ThingType_setOwns__TypeDBTransaction__AttributeType__AttributeType]
 ==== setOwns
 
 [source,java]
@@ -1059,7 +1059,7 @@ See also: <<#_setOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `Promise<java.lang.Void>`
 
-[#_ThingType_setOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType_java_util_Set]
+[#_ThingType_setOwns__TypeDBTransaction__AttributeType__java_util_Set_ThingType_Annotation_]
 ==== setOwns
 
 [source,java]
@@ -1080,7 +1080,7 @@ See also: <<#_setOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `Promise<java.lang.Void>`
 
-[#_ThingType_setOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType]
+[#_ThingType_setOwns__TypeDBTransaction__AttributeType]
 ==== setOwns
 
 [source,java]
@@ -1100,7 +1100,7 @@ See also: <<#_setOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticl
 .Returns
 `Promise<java.lang.Void>`
 
-[#_ThingType_setPlays_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType]
+[#_ThingType_setPlays__TypeDBTransaction__RoleType]
 ==== setPlays
 
 [source,java]
@@ -1120,7 +1120,7 @@ See also: <<#_setPlays_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vatic
 .Returns
 `Promise<java.lang.Void>`
 
-[#_ThingType_setPlays_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType_com_vaticle_typedb_driver_api_concept_type_RoleType]
+[#_ThingType_setPlays__TypeDBTransaction__RoleType__RoleType]
 ==== setPlays
 
 [source,java]
@@ -1157,7 +1157,7 @@ thingType.setPlays(transaction, roleType).resolve();
  thingType.setPlays(transaction, roleType, overriddenType).resolve();
 ----
 
-[#_ThingType_unsetAbstract_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_ThingType_unsetAbstract__TypeDBTransaction]
 ==== unsetAbstract
 
 [source,java]
@@ -1189,7 +1189,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.unsetAbstract(transaction).resolve();
 ----
 
-[#_ThingType_unsetOwns_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_AttributeType]
+[#_ThingType_unsetOwns__TypeDBTransaction__AttributeType]
 ==== unsetOwns
 
 [source,java]
@@ -1223,7 +1223,7 @@ a| `attributeType` a| The ``AttributeType`` to not be owned by the type. a| `Att
 thingType.unsetOwns(transaction, attributeType).resolve();
 ----
 
-[#_ThingType_unsetPlays_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_type_RoleType]
+[#_ThingType_unsetPlays__TypeDBTransaction__RoleType]
 ==== unsetPlays
 
 [source,java]

--- a/java/docs/schema/Type.adoc
+++ b/java/docs/schema/Type.adoc
@@ -8,7 +8,7 @@
 * `Concept`
 
 // tag::methods[]
-[#_Type_asAttribute_]
+[#_Type_asAttribute__]
 ==== asAttribute
 
 [source,java]
@@ -30,7 +30,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute();
 ----
 
-[#_Type_asAttributeType_]
+[#_Type_asAttributeType__]
 ==== asAttributeType
 
 [source,java]
@@ -52,7 +52,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType();
 ----
 
-[#_Type_asEntity_]
+[#_Type_asEntity__]
 ==== asEntity
 
 [source,java]
@@ -74,7 +74,7 @@ Casts the concept to ``Entity``.
 concept.asEntity();
 ----
 
-[#_Type_asEntityType_]
+[#_Type_asEntityType__]
 ==== asEntityType
 
 [source,java]
@@ -96,7 +96,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType();
 ----
 
-[#_Type_asRelation_]
+[#_Type_asRelation__]
 ==== asRelation
 
 [source,java]
@@ -118,7 +118,7 @@ Casts the concept to ``Relation``.
 concept.asRelation();
 ----
 
-[#_Type_asRelationType_]
+[#_Type_asRelationType__]
 ==== asRelationType
 
 [source,java]
@@ -140,7 +140,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType();
 ----
 
-[#_Type_asRoleType_]
+[#_Type_asRoleType__]
 ==== asRoleType
 
 [source,java]
@@ -162,7 +162,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType();
 ----
 
-[#_Type_asThing_]
+[#_Type_asThing__]
 ==== asThing
 
 [source,java]
@@ -184,7 +184,7 @@ Casts the concept to ``Thing``.
 concept.asThing();
 ----
 
-[#_Type_asThingType_]
+[#_Type_asThingType__]
 ==== asThingType
 
 [source,java]
@@ -206,7 +206,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType();
 ----
 
-[#_Type_asType_]
+[#_Type_asType__]
 ==== asType
 
 [source,java]
@@ -229,7 +229,7 @@ Casts the concept to ``Type``.
 concept.asType();
 ----
 
-[#_Type_asValue_]
+[#_Type_asValue__]
 ==== asValue
 
 [source,java]
@@ -251,7 +251,7 @@ Casts the concept to ``Value``.
 concept.asValue();
 ----
 
-[#_Type_delete_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Type_delete__TypeDBTransaction]
 ==== delete
 
 [source,java]
@@ -283,7 +283,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.delete(transaction).resolve();
 ----
 
-[#_Type_getLabel_]
+[#_Type_getLabel__]
 ==== getLabel
 
 [source,java]
@@ -306,7 +306,7 @@ Retrieves the unique label of the type.
 type.getLabel();
 ----
 
-[#_Type_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Type_getSubtypes__TypeDBTransaction]
 ==== getSubtypes
 
 [source,java]
@@ -325,7 +325,7 @@ See also: <<#_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_va
 .Returns
 `java.util.stream.Stream<? extends Type>`
 
-[#_Type_getSubtypes_com_vaticle_typedb_driver_api_TypeDBTransaction_com_vaticle_typedb_driver_api_concept_Concept_Transitivity]
+[#_Type_getSubtypes__TypeDBTransaction__Concept_Transitivity]
 ==== getSubtypes
 
 [source,java]
@@ -360,7 +360,7 @@ type.getSubtypes(transaction);
  type.getSubtypes(transaction, Transitivity.EXPLICIT);
 ----
 
-[#_Type_getSupertype_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Type_getSupertype__TypeDBTransaction]
 ==== getSupertype
 
 [source,java]
@@ -392,7 +392,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertype(transaction).resolve();
 ----
 
-[#_Type_getSupertypes_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Type_getSupertypes__TypeDBTransaction]
 ==== getSupertypes
 
 [source,java]
@@ -424,7 +424,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertypes(transaction);
 ----
 
-[#_Type_isAbstract_]
+[#_Type_isAbstract__]
 ==== isAbstract
 
 [source,java]
@@ -447,7 +447,7 @@ Checks if the type is prevented from having data instances (i.e., ``abstract``).
 type.isAbstract();
 ----
 
-[#_Type_isAttribute_]
+[#_Type_isAttribute__]
 ==== isAttribute
 
 [source,java]
@@ -470,7 +470,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute();
 ----
 
-[#_Type_isAttributeType_]
+[#_Type_isAttributeType__]
 ==== isAttributeType
 
 [source,java]
@@ -493,7 +493,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType();
 ----
 
-[#_Type_isDeleted_com_vaticle_typedb_driver_api_TypeDBTransaction]
+[#_Type_isDeleted__TypeDBTransaction]
 ==== isDeleted
 
 [source,java]
@@ -525,7 +525,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.isDeleted(transaction).resolve();
 ----
 
-[#_Type_isEntity_]
+[#_Type_isEntity__]
 ==== isEntity
 
 [source,java]
@@ -548,7 +548,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity();
 ----
 
-[#_Type_isEntityType_]
+[#_Type_isEntityType__]
 ==== isEntityType
 
 [source,java]
@@ -571,7 +571,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Type_isRelation_]
+[#_Type_isRelation__]
 ==== isRelation
 
 [source,java]
@@ -594,7 +594,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation();
 ----
 
-[#_Type_isRelationType_]
+[#_Type_isRelationType__]
 ==== isRelationType
 
 [source,java]
@@ -617,7 +617,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType();
 ----
 
-[#_Type_isRoleType_]
+[#_Type_isRoleType__]
 ==== isRoleType
 
 [source,java]
@@ -640,7 +640,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType();
 ----
 
-[#_Type_isRoot_]
+[#_Type_isRoot__]
 ==== isRoot
 
 [source,java]
@@ -663,7 +663,7 @@ Checks if the type is a root type.
 type.isRoot();
 ----
 
-[#_Type_isThing_]
+[#_Type_isThing__]
 ==== isThing
 
 [source,java]
@@ -686,7 +686,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing();
 ----
 
-[#_Type_isThingType_]
+[#_Type_isThingType__]
 ==== isThingType
 
 [source,java]
@@ -709,7 +709,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType();
 ----
 
-[#_Type_isType_]
+[#_Type_isType__]
 ==== isType
 
 [source,java]
@@ -732,7 +732,7 @@ Checks if the concept is a ``Type``.
 concept.isType();
 ----
 
-[#_Type_isValue_]
+[#_Type_isValue__]
 ==== isValue
 
 [source,java]
@@ -755,7 +755,7 @@ Checks if the concept is a ``Value``.
 concept.isValue();
 ----
 
-[#_Type_setLabel_com_vaticle_typedb_driver_api_TypeDBTransaction_java_lang_String]
+[#_Type_setLabel__TypeDBTransaction__java_lang_String]
 ==== setLabel
 
 [source,java]

--- a/java/docs/schema/Value.Type.adoc
+++ b/java/docs/schema/Value.Type.adoc
@@ -1,4 +1,4 @@
-[#_Value.Type]
+[#_Value_Type]
 === Value.Type
 
 *Package*: `com.vaticle.typedb.driver.api.concept.value`
@@ -20,7 +20,7 @@ a| `STRING`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_Value.Type_isKeyable_]
+[#_Value_Type_isKeyable__]
 ==== isKeyable
 
 [source,java]
@@ -35,7 +35,7 @@ public boolean isKeyable()
 .Returns
 `public boolean`
 
-[#_Value.Type_isWritable_]
+[#_Value_Type_isWritable__]
 ==== isWritable
 
 [source,java]
@@ -50,7 +50,7 @@ public boolean isWritable()
 .Returns
 `public boolean`
 
-[#_Value.Type_of_com_vaticle_typedb_driver_jni_ValueType]
+[#_Value_Type_of__com_vaticle_typedb_driver_jni_ValueType]
 ==== of
 
 [source,java]
@@ -65,7 +65,7 @@ public static Value.Type of​(com.vaticle.typedb.driver.jni.ValueType valueType
 .Returns
 `public static Value.Type`
 
-[#_Value.Type_valueClass_]
+[#_Value_Type_valueClass__]
 ==== valueClass
 
 [source,java]
@@ -80,7 +80,7 @@ public java.lang.Class<?> valueClass()
 .Returns
 `public java.lang.Class<?>`
 
-[#_Value.Type_valueOf_java_lang_String]
+[#_Value_Type_valueOf__java_lang_String]
 ==== valueOf
 
 [source,java]
@@ -103,7 +103,7 @@ a| `name` a| the name of the enum constant to be returned. a| `java.lang.String`
 .Returns
 `public static Value.Type`
 
-[#_Value.Type_values_]
+[#_Value_Type_values__]
 ==== values
 
 [source,java]

--- a/java/docs/session/TypeDBOptions.adoc
+++ b/java/docs/session/TypeDBOptions.adoc
@@ -6,7 +6,7 @@
 TypeDB session and transaction options. ``TypeDBOptions`` object can be used to override the default server behaviour.
 
 // tag::methods[]
-[#_TypeDBOptions__init__]
+[#_TypeDBOptions_TypeDBOptions__]
 ==== TypeDBOptions
 
 [source,java]
@@ -28,7 +28,7 @@ Produces a new ``TypeDBOptions`` object.
 TypeDBOptions options = TypeDBOptions();
 ----
 
-[#_TypeDBOptions_explain_]
+[#_TypeDBOptions_explain__]
 ==== explain
 
 [source,java]
@@ -51,7 +51,7 @@ Returns the value set for the explanation in this ``TypeDBOptions`` object. If s
 options.explain();
 ----
 
-[#_TypeDBOptions_explain_boolean]
+[#_TypeDBOptions_explain__boolean]
 ==== explain
 
 [source,java]
@@ -82,7 +82,7 @@ a| `explain` a| Explicitly enable or disable explanations a| `boolean`
 options.explain(explain);
 ----
 
-[#_TypeDBOptions_infer_]
+[#_TypeDBOptions_infer__]
 ==== infer
 
 [source,java]
@@ -105,7 +105,7 @@ Returns the value set for the inference in this ``TypeDBOptions`` object.
 options.infer();
 ----
 
-[#_TypeDBOptions_infer_boolean]
+[#_TypeDBOptions_infer__boolean]
 ==== infer
 
 [source,java]
@@ -136,7 +136,7 @@ a| `infer` a| Explicitly enable or disable inference a| `boolean`
 options.infer(infer);
 ----
 
-[#_TypeDBOptions_parallel_]
+[#_TypeDBOptions_parallel__]
 ==== parallel
 
 [source,java]
@@ -159,7 +159,7 @@ Returns the value set for the parallel execution in this ``TypeDBOptions`` objec
 options.parallel();
 ----
 
-[#_TypeDBOptions_parallel_boolean]
+[#_TypeDBOptions_parallel__boolean]
 ==== parallel
 
 [source,java]
@@ -190,7 +190,7 @@ a| `parallel` a| Explicitly enable or disable parallel execution a| `boolean`
 options.parallel(parallel);
 ----
 
-[#_TypeDBOptions_prefetch_]
+[#_TypeDBOptions_prefetch__]
 ==== prefetch
 
 [source,java]
@@ -213,7 +213,7 @@ Returns the value set for the prefetching in this ``TypeDBOptions`` object. If s
 options.prefetch();
 ----
 
-[#_TypeDBOptions_prefetch_boolean]
+[#_TypeDBOptions_prefetch__boolean]
 ==== prefetch
 
 [source,java]
@@ -244,7 +244,7 @@ a| `prefetch` a| Explicitly enable or disable prefetching a| `boolean`
 options.prefetch(prefetch);
 ----
 
-[#_TypeDBOptions_prefetchSize_]
+[#_TypeDBOptions_prefetchSize__]
 ==== prefetchSize
 
 [source,java]
@@ -267,7 +267,7 @@ Returns the value set for the prefetch size in this ``TypeDBOptions`` object. If
 options.prefetchSize();
 ----
 
-[#_TypeDBOptions_prefetchSize_int]
+[#_TypeDBOptions_prefetchSize__int]
 ==== prefetchSize
 
 [source,java]
@@ -298,7 +298,7 @@ a| `prefetchSize` a| Number of answers that the server should send before the dr
 options.prefetchSize(prefetchSize);
 ----
 
-[#_TypeDBOptions_readAnyReplica_]
+[#_TypeDBOptions_readAnyReplica__]
 ==== readAnyReplica
 
 [source,java]
@@ -321,7 +321,7 @@ Returns the value set for reading data from any replica in this ``TypeDBOptions`
 options.readAnyReplica();
 ----
 
-[#_TypeDBOptions_readAnyReplica_boolean]
+[#_TypeDBOptions_readAnyReplica__boolean]
 ==== readAnyReplica
 
 [source,java]
@@ -352,7 +352,7 @@ a| `readAnyReplica` a| Explicitly enable or disable reading data from any replic
 options.readAnyReplica(readAnyReplica);
 ----
 
-[#_TypeDBOptions_schemaLockAcquireTimeoutMillis_]
+[#_TypeDBOptions_schemaLockAcquireTimeoutMillis__]
 ==== schemaLockAcquireTimeoutMillis
 
 [source,java]
@@ -374,7 +374,7 @@ Returns the value set for the schema lock acquire timeout in this ``TypeDBOption
 options.schemaLockAcquireTimeoutMillis();
 ----
 
-[#_TypeDBOptions_schemaLockAcquireTimeoutMillis_int]
+[#_TypeDBOptions_schemaLockAcquireTimeoutMillis__int]
 ==== schemaLockAcquireTimeoutMillis
 
 [source,java]
@@ -405,7 +405,7 @@ a| `schemaLockAcquireTimeoutMillis` a| How long the driver should wait if openin
 options.schemaLockAcquireTimeoutMillis(schemaLockAcquireTimeoutMillis);
 ----
 
-[#_TypeDBOptions_sessionIdleTimeoutMillis_]
+[#_TypeDBOptions_sessionIdleTimeoutMillis__]
 ==== sessionIdleTimeoutMillis
 
 [source,java]
@@ -428,7 +428,7 @@ Returns the value set for the session idle timeout in this ``TypeDBOptions`` obj
 options.sessionIdleTimeoutMillis();
 ----
 
-[#_TypeDBOptions_sessionIdleTimeoutMillis_int]
+[#_TypeDBOptions_sessionIdleTimeoutMillis__int]
 ==== sessionIdleTimeoutMillis
 
 [source,java]
@@ -459,7 +459,7 @@ a| `sessionIdleTimeoutMillis` a| timeout that allows the server to close session
 options.sessionIdleTimeoutMillis(sessionIdleTimeoutMillis);
 ----
 
-[#_TypeDBOptions_traceInference_]
+[#_TypeDBOptions_traceInference__]
 ==== traceInference
 
 [source,java]
@@ -482,7 +482,7 @@ Returns the value set for reasoning tracing in this ``TypeDBOptions`` object. If
 options.traceInference();
 ----
 
-[#_TypeDBOptions_traceInference_boolean]
+[#_TypeDBOptions_traceInference__boolean]
 ==== traceInference
 
 [source,java]
@@ -513,7 +513,7 @@ a| `traceInference` a| Explicitly enable or disable reasoning tracing a| `boolea
 options.traceInference(traceInference);
 ----
 
-[#_TypeDBOptions_transactionTimeoutMillis_]
+[#_TypeDBOptions_transactionTimeoutMillis__]
 ==== transactionTimeoutMillis
 
 [source,java]
@@ -536,7 +536,7 @@ Returns the value set for the transaction timeout in this ``TypeDBOptions`` obje
 options.transactionTimeoutMillis();
 ----
 
-[#_TypeDBOptions_transactionTimeoutMillis_int]
+[#_TypeDBOptions_transactionTimeoutMillis__int]
 ==== transactionTimeoutMillis
 
 [source,java]

--- a/java/docs/session/TypeDBSession.Type.adoc
+++ b/java/docs/session/TypeDBSession.Type.adoc
@@ -1,4 +1,4 @@
-[#_TypeDBSession.Type]
+[#_TypeDBSession_Type]
 === TypeDBSession.Type
 
 *Package*: `com.vaticle.typedb.driver.api`
@@ -30,7 +30,7 @@ a| `SCHEMA`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_TypeDBSession.Type_id_]
+[#_TypeDBSession_Type_id__]
 ==== id
 
 [source,java]
@@ -44,7 +44,7 @@ public int id()
 .Returns
 `public int`
 
-[#_TypeDBSession.Type_isData_]
+[#_TypeDBSession_Type_isData__]
 ==== isData
 
 [source,java]
@@ -58,7 +58,7 @@ public boolean isData()
 .Returns
 `public boolean`
 
-[#_TypeDBSession.Type_isSchema_]
+[#_TypeDBSession_Type_isSchema__]
 ==== isSchema
 
 [source,java]
@@ -72,7 +72,7 @@ public boolean isSchema()
 .Returns
 `public boolean`
 
-[#_TypeDBSession.Type_of_com_vaticle_typedb_driver_jni_SessionType]
+[#_TypeDBSession_Type_of__com_vaticle_typedb_driver_jni_SessionType]
 ==== of
 
 [source,java]
@@ -86,7 +86,7 @@ public static TypeDBSession.Type of​(com.vaticle.typedb.driver.jni.SessionType
 .Returns
 `public static TypeDBSession.Type`
 
-[#_TypeDBSession.Type_valueOf_java_lang_String]
+[#_TypeDBSession_Type_valueOf__java_lang_String]
 ==== valueOf
 
 [source,java]
@@ -109,7 +109,7 @@ a| `name` a| the name of the enum constant to be returned. a| `java.lang.String`
 .Returns
 `public static TypeDBSession.Type`
 
-[#_TypeDBSession.Type_values_]
+[#_TypeDBSession_Type_values__]
 ==== values
 
 [source,java]

--- a/java/docs/session/TypeDBSession.adoc
+++ b/java/docs/session/TypeDBSession.adoc
@@ -8,7 +8,7 @@
 * `java.lang.AutoCloseable`
 
 // tag::methods[]
-[#_TypeDBSession_close_]
+[#_TypeDBSession_close__]
 ==== close
 
 [source,java]
@@ -30,7 +30,7 @@ Closes the session. Before opening a new session, the session currently open sho
 session.close();
 ----
 
-[#_TypeDBSession_database_name_]
+[#_TypeDBSession_database_name__]
 ==== database_name
 
 [source,java]
@@ -53,7 +53,7 @@ Returns the name of the database of the session.
 session.databaseName();
 ----
 
-[#_TypeDBSession_isOpen_]
+[#_TypeDBSession_isOpen__]
 ==== isOpen
 
 [source,java]
@@ -76,7 +76,7 @@ Checks whether this session is open.
 session.isOpen();
 ----
 
-[#_TypeDBSession_onClose_java_lang_Runnable]
+[#_TypeDBSession_onClose__java_lang_Runnable]
 ==== onClose
 
 [source,java]
@@ -107,7 +107,7 @@ a| `function` a| The callback function. a| `java.lang.Runnable`
 session.onClose(function)
 ----
 
-[#_TypeDBSession_options_]
+[#_TypeDBSession_options__]
 ==== options
 
 [source,java]
@@ -122,7 +122,7 @@ Gets the options for the session
 .Returns
 `TypeDBOptions`
 
-[#_TypeDBSession_transaction_com_vaticle_typedb_driver_api_TypeDBTransaction_Type]
+[#_TypeDBSession_transaction__TypeDBTransaction_Type]
 ==== transaction
 
 [source,java]
@@ -141,7 +141,7 @@ See also: <<#_transaction_com_vaticle_typedb_driver_api_TypeDBTransaction_Type_c
 .Returns
 `TypeDBTransaction`
 
-[#_TypeDBSession_transaction_com_vaticle_typedb_driver_api_TypeDBTransaction_Type_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_TypeDBSession_transaction__TypeDBTransaction_Type__TypeDBOptions]
 ==== transaction
 
 [source,java]
@@ -175,7 +175,7 @@ a| `options` a| Options for the session a| `TypeDBOptions`
 session.transaction(transactionType, options);
 ----
 
-[#_TypeDBSession_type_]
+[#_TypeDBSession_type__]
 ==== type
 
 [source,java]

--- a/java/docs/transaction/QueryManager.adoc
+++ b/java/docs/transaction/QueryManager.adoc
@@ -6,7 +6,7 @@
 Provides methods for executing TypeQL queries in the transaction.
 
 // tag::methods[]
-[#_QueryManager_define_com_vaticle_typeql_lang_query_TypeQLDefine]
+[#_QueryManager_define__com_vaticle_typeql_lang_query_TypeQLDefine]
 ==== define
 
 [source,java]
@@ -25,7 +25,7 @@ See also: <<#_define_com_vaticle_typeql_lang_query_TypeQLDefine_com_vaticle_type
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_define_com_vaticle_typeql_lang_query_TypeQLDefine_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_define__com_vaticle_typeql_lang_query_TypeQLDefine__TypeDBOptions]
 ==== define
 
 [source,java]
@@ -59,7 +59,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().define(query, options).resolve()
 ----
 
-[#_QueryManager_define_java_lang_String]
+[#_QueryManager_define__java_lang_String]
 ==== define
 
 [source,java]
@@ -78,7 +78,7 @@ See also: <<#_define_com_vaticle_typeql_lang_query_TypeQLDefine_com_vaticle_type
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_define_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_define__java_lang_String__TypeDBOptions]
 ==== define
 
 [source,java]
@@ -96,7 +96,7 @@ See also: <<#_define_com_vaticle_typeql_lang_query_TypeQLDefine_com_vaticle_type
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_delete_com_vaticle_typeql_lang_query_TypeQLDelete]
+[#_QueryManager_delete__com_vaticle_typeql_lang_query_TypeQLDelete]
 ==== delete
 
 [source,java]
@@ -115,7 +115,7 @@ See also: <<#_delete_com_vaticle_typeql_lang_query_TypeQLDelete_com_vaticle_type
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_delete_com_vaticle_typeql_lang_query_TypeQLDelete_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_delete__com_vaticle_typeql_lang_query_TypeQLDelete__TypeDBOptions]
 ==== delete
 
 [source,java]
@@ -149,7 +149,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().delete(query, options).resolve()
 ----
 
-[#_QueryManager_delete_java_lang_String]
+[#_QueryManager_delete__java_lang_String]
 ==== delete
 
 [source,java]
@@ -168,7 +168,7 @@ See also: <<#_delete_com_vaticle_typeql_lang_query_TypeQLDelete_com_vaticle_type
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_delete_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_delete__java_lang_String__TypeDBOptions]
 ==== delete
 
 [source,java]
@@ -186,7 +186,7 @@ See also: <<#_delete_com_vaticle_typeql_lang_query_TypeQLDelete_com_vaticle_type
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_explain_com_vaticle_typedb_driver_api_answer_ConceptMap_Explainable]
+[#_QueryManager_explain__ConceptMap_Explainable]
 ==== explain
 
 [source,java]
@@ -205,7 +205,7 @@ See also: <<#_explain_com_vaticle_typedb_driver_api_answer_ConceptMap_Explainabl
 .Returns
 `java.util.stream.Stream<Explanation>`
 
-[#_QueryManager_explain_com_vaticle_typedb_driver_api_answer_ConceptMap_Explainable_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_explain__ConceptMap_Explainable__TypeDBOptions]
 ==== explain
 
 [source,java]
@@ -239,7 +239,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().explain(explainable, options)
 ----
 
-[#_QueryManager_fetch_com_vaticle_typeql_lang_query_TypeQLFetch]
+[#_QueryManager_fetch__com_vaticle_typeql_lang_query_TypeQLFetch]
 ==== fetch
 
 [source,java]
@@ -258,7 +258,7 @@ See also: <<#_fetch_com_vaticle_typeql_lang_query_TypeQLFetch_com_vaticle_typedb
 .Returns
 `java.util.stream.Stream<JSON>`
 
-[#_QueryManager_fetch_com_vaticle_typeql_lang_query_TypeQLFetch_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_fetch__com_vaticle_typeql_lang_query_TypeQLFetch__TypeDBOptions]
 ==== fetch
 
 [source,java]
@@ -292,7 +292,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().fetch(query, options)
 ----
 
-[#_QueryManager_fetch_java_lang_String]
+[#_QueryManager_fetch__java_lang_String]
 ==== fetch
 
 [source,java]
@@ -311,7 +311,7 @@ See also: <<#_fetch_com_vaticle_typeql_lang_query_TypeQLFetch_com_vaticle_typedb
 .Returns
 `java.util.stream.Stream<JSON>`
 
-[#_QueryManager_fetch_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_fetch__java_lang_String__TypeDBOptions]
 ==== fetch
 
 [source,java]
@@ -329,7 +329,7 @@ See also: <<#_fetch_com_vaticle_typeql_lang_query_TypeQLFetch_com_vaticle_typedb
 .Returns
 `java.util.stream.Stream<JSON>`
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet]
 ==== get
 
 [source,java]
@@ -348,7 +348,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_com_vaticle_typedb_dri
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet__TypeDBOptions]
 ==== get
 
 [source,java]
@@ -382,7 +382,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().get(query, options)
 ----
 
-[#_QueryManager_get_java_lang_String]
+[#_QueryManager_get__java_lang_String]
 ==== get
 
 [source,java]
@@ -401,7 +401,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_com_vaticle_typedb_dri
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_get_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_get__java_lang_String__TypeDBOptions]
 ==== get
 
 [source,java]
@@ -419,7 +419,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_com_vaticle_typedb_dri
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet_Aggregate]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet_Aggregate]
 ==== get
 
 [source,java]
@@ -438,7 +438,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Aggregate_com_vaticle_
 .Returns
 `Promise<java.util.Optional<Value>>`
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet_Aggregate_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet_Aggregate__TypeDBOptions]
 ==== get
 
 [source,java]
@@ -472,7 +472,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().getAggregate(query, options).resolve()
 ----
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet_Group]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet_Group]
 ==== get
 
 [source,java]
@@ -491,7 +491,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMapGroup>`
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet_Group__TypeDBOptions]
 ==== get
 
 [source,java]
@@ -525,7 +525,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().getGroup(query, options)
 ----
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_Aggregate]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet_Group_Aggregate]
 ==== get
 
 [source,java]
@@ -544,7 +544,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_Aggregate_com_va
 .Returns
 `java.util.stream.Stream<ValueGroup>`
 
-[#_QueryManager_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_Aggregate_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_get__com_vaticle_typeql_lang_query_TypeQLGet_Group_Aggregate__TypeDBOptions]
 ==== get
 
 [source,java]
@@ -578,7 +578,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().getGroupAggregate(query, options)
 ----
 
-[#_QueryManager_getAggregate_java_lang_String]
+[#_QueryManager_getAggregate__java_lang_String]
 ==== getAggregate
 
 [source,java]
@@ -597,7 +597,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Aggregate_com_vaticle_
 .Returns
 `Promise<java.util.Optional<Value>>`
 
-[#_QueryManager_getAggregate_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_getAggregate__java_lang_String__TypeDBOptions]
 ==== getAggregate
 
 [source,java]
@@ -615,7 +615,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Aggregate_com_vaticle_
 .Returns
 `Promise<java.util.Optional<Value>>`
 
-[#_QueryManager_getGroup_java_lang_String]
+[#_QueryManager_getGroup__java_lang_String]
 ==== getGroup
 
 [source,java]
@@ -634,7 +634,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMapGroup>`
 
-[#_QueryManager_getGroup_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_getGroup__java_lang_String__TypeDBOptions]
 ==== getGroup
 
 [source,java]
@@ -652,7 +652,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMapGroup>`
 
-[#_QueryManager_getGroupAggregate_java_lang_String]
+[#_QueryManager_getGroupAggregate__java_lang_String]
 ==== getGroupAggregate
 
 [source,java]
@@ -671,7 +671,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_Aggregate_com_va
 .Returns
 `java.util.stream.Stream<ValueGroup>`
 
-[#_QueryManager_getGroupAggregate_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_getGroupAggregate__java_lang_String__TypeDBOptions]
 ==== getGroupAggregate
 
 [source,java]
@@ -689,7 +689,7 @@ See also: <<#_get_com_vaticle_typeql_lang_query_TypeQLGet_Group_Aggregate_com_va
 .Returns
 `java.util.stream.Stream<ValueGroup>`
 
-[#_QueryManager_insert_com_vaticle_typeql_lang_query_TypeQLInsert]
+[#_QueryManager_insert__com_vaticle_typeql_lang_query_TypeQLInsert]
 ==== insert
 
 [source,java]
@@ -707,7 +707,7 @@ See also: <<#_insert_com_vaticle_typeql_lang_query_TypeQLInsert_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_insert_com_vaticle_typeql_lang_query_TypeQLInsert_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_insert__com_vaticle_typeql_lang_query_TypeQLInsert__TypeDBOptions]
 ==== insert
 
 [source,java]
@@ -740,7 +740,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().insert(query, options)
 ----
 
-[#_QueryManager_insert_java_lang_String]
+[#_QueryManager_insert__java_lang_String]
 ==== insert
 
 [source,java]
@@ -758,7 +758,7 @@ See also: <<#_insert_com_vaticle_typeql_lang_query_TypeQLInsert_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_insert_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_insert__java_lang_String__TypeDBOptions]
 ==== insert
 
 [source,java]
@@ -775,7 +775,7 @@ See also: <<#_insert_com_vaticle_typeql_lang_query_TypeQLInsert_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_undefine_com_vaticle_typeql_lang_query_TypeQLUndefine]
+[#_QueryManager_undefine__com_vaticle_typeql_lang_query_TypeQLUndefine]
 ==== undefine
 
 [source,java]
@@ -794,7 +794,7 @@ See also: <<#_undefine_com_vaticle_typeql_lang_query_TypeQLUndefine_com_vaticle_
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_undefine_com_vaticle_typeql_lang_query_TypeQLUndefine_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_undefine__com_vaticle_typeql_lang_query_TypeQLUndefine__TypeDBOptions]
 ==== undefine
 
 [source,java]
@@ -828,7 +828,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().undefine(query, options).resolve()
 ----
 
-[#_QueryManager_undefine_java_lang_String]
+[#_QueryManager_undefine__java_lang_String]
 ==== undefine
 
 [source,java]
@@ -847,7 +847,7 @@ See also: <<#_undefine_com_vaticle_typeql_lang_query_TypeQLUndefine_com_vaticle_
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_undefine_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_undefine__java_lang_String__TypeDBOptions]
 ==== undefine
 
 [source,java]
@@ -865,7 +865,7 @@ See also: <<#_undefine_com_vaticle_typeql_lang_query_TypeQLUndefine_com_vaticle_
 .Returns
 `Promise<java.lang.Void>`
 
-[#_QueryManager_update_com_vaticle_typeql_lang_query_TypeQLUpdate]
+[#_QueryManager_update__com_vaticle_typeql_lang_query_TypeQLUpdate]
 ==== update
 
 [source,java]
@@ -883,7 +883,7 @@ See also: <<#_update_com_vaticle_typeql_lang_query_TypeQLUpdate_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_update_com_vaticle_typeql_lang_query_TypeQLUpdate_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_update__com_vaticle_typeql_lang_query_TypeQLUpdate__TypeDBOptions]
 ==== update
 
 [source,java]
@@ -916,7 +916,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query().update(query, options)
 ----
 
-[#_QueryManager_update_java_lang_String]
+[#_QueryManager_update__java_lang_String]
 ==== update
 
 [source,java]
@@ -934,7 +934,7 @@ See also: <<#_update_com_vaticle_typeql_lang_query_TypeQLUpdate_com_vaticle_type
 .Returns
 `java.util.stream.Stream<ConceptMap>`
 
-[#_QueryManager_update_java_lang_String_com_vaticle_typedb_driver_api_TypeDBOptions]
+[#_QueryManager_update__java_lang_String__TypeDBOptions]
 ==== update
 
 [source,java]

--- a/java/docs/transaction/TypeDBTransaction.Type.adoc
+++ b/java/docs/transaction/TypeDBTransaction.Type.adoc
@@ -1,4 +1,4 @@
-[#_TypeDBTransaction.Type]
+[#_TypeDBTransaction_Type]
 === TypeDBTransaction.Type
 
 *Package*: `com.vaticle.typedb.driver.api`
@@ -30,7 +30,7 @@ a| `WRITE`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_TypeDBTransaction.Type_id_]
+[#_TypeDBTransaction_Type_id__]
 ==== id
 
 [source,java]
@@ -44,7 +44,7 @@ public int id()
 .Returns
 `public int`
 
-[#_TypeDBTransaction.Type_isRead_]
+[#_TypeDBTransaction_Type_isRead__]
 ==== isRead
 
 [source,java]
@@ -58,7 +58,7 @@ public boolean isRead()
 .Returns
 `public boolean`
 
-[#_TypeDBTransaction.Type_isWrite_]
+[#_TypeDBTransaction_Type_isWrite__]
 ==== isWrite
 
 [source,java]
@@ -72,7 +72,7 @@ public boolean isWrite()
 .Returns
 `public boolean`
 
-[#_TypeDBTransaction.Type_of_com_vaticle_typedb_driver_jni_TransactionType]
+[#_TypeDBTransaction_Type_of__com_vaticle_typedb_driver_jni_TransactionType]
 ==== of
 
 [source,java]
@@ -86,7 +86,7 @@ public static TypeDBTransaction.Type of​(com.vaticle.typedb.driver.jni.Transac
 .Returns
 `public static TypeDBTransaction.Type`
 
-[#_TypeDBTransaction.Type_valueOf_java_lang_String]
+[#_TypeDBTransaction_Type_valueOf__java_lang_String]
 ==== valueOf
 
 [source,java]
@@ -109,7 +109,7 @@ a| `name` a| the name of the enum constant to be returned. a| `java.lang.String`
 .Returns
 `public static TypeDBTransaction.Type`
 
-[#_TypeDBTransaction.Type_values_]
+[#_TypeDBTransaction_Type_values__]
 ==== values
 
 [source,java]

--- a/java/docs/transaction/TypeDBTransaction.adoc
+++ b/java/docs/transaction/TypeDBTransaction.adoc
@@ -8,7 +8,7 @@
 * `java.lang.AutoCloseable`
 
 // tag::methods[]
-[#_TypeDBTransaction_close_]
+[#_TypeDBTransaction_close__]
 ==== close
 
 [source,java]
@@ -30,7 +30,7 @@ Closes the transaction.
 transaction.close()
 ----
 
-[#_TypeDBTransaction_commit_]
+[#_TypeDBTransaction_commit__]
 ==== commit
 
 [source,java]
@@ -52,7 +52,7 @@ Commits the changes made via this transaction to the TypeDB database. Whether or
 transaction.commit()
 ----
 
-[#_TypeDBTransaction_concepts_]
+[#_TypeDBTransaction_concepts__]
 ==== concepts
 
 [source,java]
@@ -67,7 +67,7 @@ The ``ConceptManager`` for this transaction, providing access to all Concept API
 .Returns
 `ConceptManager`
 
-[#_TypeDBTransaction_isOpen_]
+[#_TypeDBTransaction_isOpen__]
 ==== isOpen
 
 [source,java]
@@ -90,7 +90,7 @@ Checks whether this transaction is open.
 transaction.isOpen();
 ----
 
-[#_TypeDBTransaction_logic_]
+[#_TypeDBTransaction_logic__]
 ==== logic
 
 [source,java]
@@ -105,7 +105,7 @@ The ``LogicManager`` for this Transaction, providing access to all Concept API -
 .Returns
 `LogicManager`
 
-[#_TypeDBTransaction_onClose_java_util_function_Consumer]
+[#_TypeDBTransaction_onClose__java_util_function_Consumer_java_lang_Throwable_]
 ==== onClose
 
 [source,java]
@@ -136,7 +136,7 @@ a| `function` a| The callback function. a| `java.util.function.Consumer<java.lan
 transaction.onClose(function);
 ----
 
-[#_TypeDBTransaction_options_]
+[#_TypeDBTransaction_options__]
 ==== options
 
 [source,java]
@@ -151,7 +151,7 @@ The options for the transaction
 .Returns
 `TypeDBOptions`
 
-[#_TypeDBTransaction_query_]
+[#_TypeDBTransaction_query__]
 ==== query
 
 [source,java]
@@ -166,7 +166,7 @@ The````QueryManager```` for this Transaction, from which any TypeQL query can be
 .Returns
 `QueryManager`
 
-[#_TypeDBTransaction_rollback_]
+[#_TypeDBTransaction_rollback__]
 ==== rollback
 
 [source,java]
@@ -188,7 +188,7 @@ Rolls back the uncommitted changes made via this transaction.
 transaction.rollback()
 ----
 
-[#_TypeDBTransaction_type_]
+[#_TypeDBTransaction_type__]
 ==== type
 
 [source,java]

--- a/nodejs/docs/answer/ConceptMap.adoc
+++ b/nodejs/docs/answer/ConceptMap.adoc
@@ -15,7 +15,7 @@ a| `explainables` a| `Explainables` a| The Explainables object for this ConceptM
 // end::properties[]
 
 // tag::methods[]
-[#_ConceptMap_conceptsconcepts__:_IterableIterator_Concept]
+[#_ConceptMap_concepts__]
 ==== concepts
 
 [source,nodejs]
@@ -36,7 +36,7 @@ Produces an iterator over all concepts in this ``ConceptMap``.
 conceptMap.concepts()
 ----
 
-[#_ConceptMap_getget_variable_:_Concept]
+[#_ConceptMap_get__variable_string]
 ==== get
 
 [source,nodejs]
@@ -66,7 +66,7 @@ a| `variable` a| The string representation of a variable a| `string`
 conceptMap.get(variable)
 ----
 
-[#_ConceptMap_variablesvariables__:_IterableIterator_string]
+[#_ConceptMap_variables__]
 ==== variables
 
 [source,nodejs]

--- a/nodejs/docs/answer/Explainables.adoc
+++ b/nodejs/docs/answer/Explainables.adoc
@@ -17,7 +17,7 @@ a| `relations` a| `Map` a| All of this ConceptMap’s explainable relations.
 // end::properties[]
 
 // tag::methods[]
-[#_Explainables_attributeattribute_variable_:_Explainable]
+[#_Explainables_attribute__variable_string]
 ==== attribute
 
 [source,nodejs]
@@ -47,7 +47,7 @@ a| `variable` a| The string representation of a variable a| `string`
 conceptMap.explainables.attribute(variable)
 ----
 
-[#_Explainables_ownershipownership_owner__attribute_:_Explainable]
+[#_Explainables_ownership__owner_string__attribute_string]
 ==== ownership
 
 [source,nodejs]
@@ -78,7 +78,7 @@ a| `attribute` a| The string representation of the attribute variable a| `string
 conceptMap.explainables.ownership(owner, attribute)
 ----
 
-[#_Explainables_relationrelation_variable_:_Explainable]
+[#_Explainables_relation__variable_string]
 ==== relation
 
 [source,nodejs]

--- a/nodejs/docs/answer/Stream_T_.adoc
+++ b/nodejs/docs/answer/Stream_T_.adoc
@@ -4,7 +4,7 @@
 A stream of elements offering a functional interface to manipulate elements. Typically the elements are generated/retrieved lazily.
 
 // tag::methods[]
-[#_Stream_T__asyncIterator__asyncIterator___:_AsyncIterator_T__any__undefined]
+[#_Stream_T__asyncIterator___]
 ==== [asyncIterator]
 
 [source,nodejs]
@@ -18,7 +18,7 @@ A stream of elements offering a functional interface to manipulate elements. Typ
 .Returns
 `AsyncIterator<T, any, undefined>`
 
-[#_Stream_T_collectcollect__:_Promise_T__]
+[#_Stream_T_collect__]
 ==== collect
 
 [source,nodejs]
@@ -39,7 +39,7 @@ Collects all the answers from this stream into an array
 results = transaction.query.match(query).collect().await;
 ----
 
-[#_Stream_T_everyevery_callbackFn_:_Promise_boolean]
+[#_Stream_T_every__callbackFn___value____unknown_]
 ==== every
 
 [source,nodejs]
@@ -62,7 +62,7 @@ a| `callbackFn` a|  a| `((value) => unknown)`
 .Returns
 `Promise<boolean>`
 
-[#_Stream_T_filterfilter_filter_:_Stream_T]
+[#_Stream_T_filter__filter___value____boolean_]
 ==== filter
 
 [source,nodejs]
@@ -88,7 +88,7 @@ Examples
 .Returns
 `Stream<T>`
 
-[#_Stream_T_firstfirst__:_Promise_T]
+[#_Stream_T_first__]
 ==== first
 
 [source,nodejs]
@@ -102,7 +102,7 @@ Returns the first element in the stream.
 .Returns
 `Promise<T>`
 
-[#_Stream_T_flatMapflatMap_U__mapper_:_Stream_U]
+[#_Stream_T_flatMap__mapper___value____Stream_U__]
 ==== flatMap
 
 [source,nodejs]
@@ -125,7 +125,7 @@ a| `mapper` a| The mapping function to apply. Must return a stream. a| `((value)
 .Returns
 `Stream<U>`
 
-[#_Stream_T_forEachforEach_fn_:_Promise_void]
+[#_Stream_T_forEach__fn___value____void_]
 ==== forEach
 
 [source,nodejs]
@@ -148,7 +148,7 @@ a| `fn` a| The function to evaluate for each element. a| `((value) => void)`
 .Returns
 `Promise<void>`
 
-[#_Stream_T_iteratoriterator__:_AsyncIterator_T__any__undefined]
+[#_Stream_T_iterator__]
 ==== iterator
 
 [source,nodejs]
@@ -162,7 +162,7 @@ iterator(): AsyncIterator<T, any, undefined>
 .Returns
 `AsyncIterator<T, any, undefined>`
 
-[#_Stream_T_mapmap_U__mapper_:_Stream_U]
+[#_Stream_T_map__mapper___value____U_]
 ==== map
 
 [source,nodejs]
@@ -185,7 +185,7 @@ a| `mapper` a| The mapping function to apply. Returns a new stream from this str
 .Returns
 `Stream<U>`
 
-[#_Stream_T_new_Streamnew_Stream_T___:_Stream_T]
+[#_Stream_T_new_Stream__]
 ==== new Stream
 
 [source,nodejs]
@@ -199,7 +199,7 @@ new Stream<T>(): Stream<T>
 .Returns
 `Stream<T>`
 
-[#_Stream_T_somesome_callbackFn_:_Promise_boolean]
+[#_Stream_T_some__callbackFn___value____unknown_]
 ==== some
 
 [source,nodejs]

--- a/nodejs/docs/concept/Concept.adoc
+++ b/nodejs/docs/concept/Concept.adoc
@@ -2,7 +2,7 @@
 === Concept
 
 // tag::methods[]
-[#_Concept_asAttributeasAttribute__:_Attribute]
+[#_Concept_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -23,7 +23,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_Concept_asAttributeTypeasAttributeType__:_AttributeType]
+[#_Concept_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -44,7 +44,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_Concept_asEntityasEntity__:_Entity]
+[#_Concept_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -65,7 +65,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_Concept_asEntityTypeasEntityType__:_EntityType]
+[#_Concept_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -86,7 +86,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_Concept_asRelationasRelation__:_Relation]
+[#_Concept_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -107,7 +107,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_Concept_asRelationTypeasRelationType__:_RelationType]
+[#_Concept_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -128,7 +128,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_Concept_asRoleTypeasRoleType__:_RoleType]
+[#_Concept_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -149,7 +149,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_Concept_asThingasThing__:_Thing]
+[#_Concept_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -170,7 +170,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_Concept_asThingTypeasThingType__:_ThingType]
+[#_Concept_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -191,7 +191,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_Concept_asTypeasType__:_Type]
+[#_Concept_asType__]
 ==== asType
 
 [source,nodejs]
@@ -212,7 +212,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_Concept_asValueasValue__:_Value]
+[#_Concept_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -233,7 +233,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_Concept_equalsequals_concept_:_boolean]
+[#_Concept_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -256,7 +256,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_Concept_isAttributeisAttribute__:_boolean]
+[#_Concept_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -277,7 +277,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_Concept_isAttributeTypeisAttributeType__:_boolean]
+[#_Concept_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -298,7 +298,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_Concept_isEntityisEntity__:_boolean]
+[#_Concept_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -319,7 +319,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_Concept_isEntityTypeisEntityType__:_boolean]
+[#_Concept_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -340,7 +340,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_Concept_isRelationisRelation__:_boolean]
+[#_Concept_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -361,7 +361,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_Concept_isRelationTypeisRelationType__:_boolean]
+[#_Concept_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -382,7 +382,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_Concept_isRoleTypeisRoleType__:_boolean]
+[#_Concept_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -403,7 +403,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_Concept_isThingisThing__:_boolean]
+[#_Concept_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -424,7 +424,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_Concept_isThingTypeisThingType__:_boolean]
+[#_Concept_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -445,7 +445,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_Concept_isTypeisType__:_boolean]
+[#_Concept_isType__]
 ==== isType
 
 [source,nodejs]
@@ -466,7 +466,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_Concept_isValueisValue__:_boolean]
+[#_Concept_isValue__]
 ==== isValue
 
 [source,nodejs]

--- a/nodejs/docs/concept/ConceptManager.adoc
+++ b/nodejs/docs/concept/ConceptManager.adoc
@@ -4,7 +4,7 @@
 Provides access for all Concept API methods.
 
 // tag::methods[]
-[#_ConceptManager_getAttributegetAttribute_iid_:_Promise_Attribute]
+[#_ConceptManager_getAttribute__iid_string]
 ==== getAttribute
 
 [source,nodejs]
@@ -34,7 +34,7 @@ a| `iid` a| The iid of the ``Attribute`` to retrieve a| `string`
 transaction.concepts().getAttribute(iid)
 ----
 
-[#_ConceptManager_getAttributeTypegetAttributeType_label_:_Promise_AttributeType]
+[#_ConceptManager_getAttributeType__label_string]
 ==== getAttributeType
 
 [source,nodejs]
@@ -64,7 +64,7 @@ a| `label` a| The label of the ``AttributeType`` to retrieve a| `string`
 transaction.concepts().getAttributeType(label)
 ----
 
-[#_ConceptManager_getEntitygetEntity_iid_:_Promise_Entity]
+[#_ConceptManager_getEntity__iid_string]
 ==== getEntity
 
 [source,nodejs]
@@ -94,7 +94,7 @@ a| `iid` a| The iid of the ``Entity`` to retrieve a| `string`
 transaction.concepts().getEntity(iid)
 ----
 
-[#_ConceptManager_getEntityTypegetEntityType_label_:_Promise_EntityType]
+[#_ConceptManager_getEntityType__label_string]
 ==== getEntityType
 
 [source,nodejs]
@@ -124,7 +124,7 @@ a| `label` a| The label of the ``EntityType`` to retrieve a| `string`
 transaction.concepts().getEntityType(label)
 ----
 
-[#_ConceptManager_getRelationgetRelation_iid_:_Promise_Relation]
+[#_ConceptManager_getRelation__iid_string]
 ==== getRelation
 
 [source,nodejs]
@@ -154,7 +154,7 @@ a| `iid` a| The iid of the ``Relation`` to retrieve a| `string`
 transaction.concepts().getRelation(iid)
 ----
 
-[#_ConceptManager_getRelationTypegetRelationType_label_:_Promise_RelationType]
+[#_ConceptManager_getRelationType__label_string]
 ==== getRelationType
 
 [source,nodejs]
@@ -184,7 +184,7 @@ a| `label` a| The label of the ``RelationType`` to retrieve a| `string`
 transaction.concepts().getRelationType(label)
 ----
 
-[#_ConceptManager_getRootAttributeTypegetRootAttributeType__:_Promise_AttributeType]
+[#_ConceptManager_getRootAttributeType__]
 ==== getRootAttributeType
 
 [source,nodejs]
@@ -205,7 +205,7 @@ Retrieve the root ``AttributeType``, “attribute”.
 transaction.concepts().getRootAttributeType()
 ----
 
-[#_ConceptManager_getRootEntityTypegetRootEntityType__:_Promise_EntityType]
+[#_ConceptManager_getRootEntityType__]
 ==== getRootEntityType
 
 [source,nodejs]
@@ -226,7 +226,7 @@ Retrieves the root ``EntityType``, “entity”.
 transaction.concepts().getRootEntityType()
 ----
 
-[#_ConceptManager_getRootRelationTypegetRootRelationType__:_Promise_RelationType]
+[#_ConceptManager_getRootRelationType__]
 ==== getRootRelationType
 
 [source,nodejs]
@@ -247,7 +247,7 @@ Retrieve the root ``RelationType``, “relation”.
 transaction.concepts().getRootRelationType()
 ----
 
-[#_ConceptManager_getRootThingTypegetRootThingType__:_Promise_ThingType]
+[#_ConceptManager_getRootThingType__]
 ==== getRootThingType
 
 [source,nodejs]
@@ -268,7 +268,7 @@ Retrieves the root ``ThingType``, “thing”.
 transaction.concepts().getRootThingType()
 ----
 
-[#_ConceptManager_getSchemaExceptionsgetSchemaExceptions__:_Promise_TypeDBDriverError__]
+[#_ConceptManager_getSchemaExceptions__]
 ==== getSchemaExceptions
 
 [source,nodejs]
@@ -289,7 +289,7 @@ Retrieves a list of all schema exceptions for the current transaction.
 transaction.concepts().getSchemaException()
 ----
 
-[#_ConceptManager_putAttributeTypeputAttributeType_label__valueType_:_Promise_AttributeType]
+[#_ConceptManager_putAttributeType__label_string__valueType_ValueType]
 ==== putAttributeType
 
 [source,nodejs]
@@ -320,7 +320,7 @@ a| `valueType` a| The value type of the ``AttributeType`` to create a| `ValueTyp
 await transaction.concepts().putAttributeType(label, valueType)
 ----
 
-[#_ConceptManager_putEntityTypeputEntityType_label_:_Promise_EntityType]
+[#_ConceptManager_putEntityType__label_string]
 ==== putEntityType
 
 [source,nodejs]
@@ -350,7 +350,7 @@ a| `label` a| The label of the ``EntityType`` to create or retrieve a| `string`
 transaction.concepts().putEntityType(label)
 ----
 
-[#_ConceptManager_putRelationTypeputRelationType_label_:_Promise_RelationType]
+[#_ConceptManager_putRelationType__label_string]
 ==== putRelationType
 
 [source,nodejs]

--- a/nodejs/docs/connection/Database.adoc
+++ b/nodejs/docs/connection/Database.adoc
@@ -16,7 +16,7 @@ a| `replicas` a| `Replica` a| The Replica instances for this database. Only work
 // end::properties[]
 
 // tag::methods[]
-[#_Database_deletedelete__:_Promise_void]
+[#_Database_delete__]
 ==== delete
 
 [source,nodejs]
@@ -37,7 +37,7 @@ Deletes this database.
 database.delete()
 ----
 
-[#_Database_schemaschema__:_Promise_string]
+[#_Database_schema__]
 ==== schema
 
 [source,nodejs]

--- a/nodejs/docs/connection/DatabaseManager.adoc
+++ b/nodejs/docs/connection/DatabaseManager.adoc
@@ -4,7 +4,7 @@
 Provides access to all database management methods.
 
 // tag::methods[]
-[#_DatabaseManager_allall__:_Promise_Database__]
+[#_DatabaseManager_all__]
 ==== all
 
 [source,nodejs]
@@ -25,7 +25,7 @@ Retrieves all databases present on the TypeDB server
 driver.databases().all()
 ----
 
-[#_DatabaseManager_containscontains_name_:_Promise_boolean]
+[#_DatabaseManager_contains__name_string]
 ==== contains
 
 [source,nodejs]
@@ -55,7 +55,7 @@ a| `name` a| The database name to be checked a| `string`
 driver.databases().contains(name)
 ----
 
-[#_DatabaseManager_createcreate_name_:_Promise_void]
+[#_DatabaseManager_create__name_string]
 ==== create
 
 [source,nodejs]
@@ -85,7 +85,7 @@ a| `name` a| The name of the database to be created a| `string`
 driver.databases().create(name)
 ----
 
-[#_DatabaseManager_getget_name_:_Promise_Database]
+[#_DatabaseManager_get__name_string]
 ==== get
 
 [source,nodejs]

--- a/nodejs/docs/connection/TypeDB.adoc
+++ b/nodejs/docs/connection/TypeDB.adoc
@@ -13,7 +13,7 @@ a| `DEFAULT_ADDRESS`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_TypeDB_coreDrivercoreDriver_address?_:_Promise_TypeDBDriver]
+[#_TypeDB_coreDriver__address_string__DEFAULT_ADDRESS]
 ==== coreDriver
 
 [source,nodejs]
@@ -39,7 +39,7 @@ Examples
 .Returns
 `Promise<TypeDBDriver>`
 
-[#_TypeDB_enterpriseDriverenterpriseDriver_addresses__credential_:_Promise_TypeDBDriver]
+[#_TypeDB_enterpriseDriver__addresses_string__string____credential_TypeDBCredential]
 ==== enterpriseDriver
 
 [source,nodejs]

--- a/nodejs/docs/connection/TypeDBCredential.adoc
+++ b/nodejs/docs/connection/TypeDBCredential.adoc
@@ -4,7 +4,7 @@
 User credentials and TLS encryption settings for connecting to TypeDB Enterprise.
 
 // tag::methods[]
-[#__password]
+[#_TypeDBCredential__password__]
 ====  password
 
 [source,nodejs]
@@ -18,7 +18,7 @@ get password(): string
 .Returns
 `string`
 
-[#__tlsRootCAPath]
+[#_TypeDBCredential__tlsRootCAPath__]
 ====  tlsRootCAPath
 
 [source,nodejs]
@@ -32,7 +32,7 @@ get tlsRootCAPath(): string
 .Returns
 `string`
 
-[#__username]
+[#_TypeDBCredential__username__]
 ====  username
 
 [source,nodejs]
@@ -46,7 +46,7 @@ get username(): string
 .Returns
 `string`
 
-[#_TypeDBCredential_new_TypeDBCredentialnew_TypeDBCredential_username__password__tlsRootCAPath?_:_TypeDBCredential]
+[#_TypeDBCredential_new_TypeDBCredential__username_string__password_string__tlsRootCAPath_string]
 ==== new TypeDBCredential
 
 [source,nodejs]

--- a/nodejs/docs/connection/TypeDBDriver.adoc
+++ b/nodejs/docs/connection/TypeDBDriver.adoc
@@ -14,7 +14,7 @@ a| `users` a| `UserManager` a| The UserManager instance for this connection, pro
 // end::properties[]
 
 // tag::methods[]
-[#_TypeDBDriver_closeclose__:_Promise_void]
+[#_TypeDBDriver_close__]
 ==== close
 
 [source,nodejs]
@@ -35,7 +35,7 @@ Closes the driver. Before instantiating a new driver, the driver that’s curren
 driver.close()
 ----
 
-[#_TypeDBDriver_isOpenisOpen__:_boolean]
+[#_TypeDBDriver_isOpen__]
 ==== isOpen
 
 [source,nodejs]
@@ -56,7 +56,7 @@ Checks whether this connection is presently open.
 driver.isOpen()
 ----
 
-[#_TypeDBDriver_sessionsession_database__type__options?_:_Promise_TypeDBSession]
+[#_TypeDBDriver_session__database_string__type_SessionType__options_TypeDBOptions]
 ==== session
 
 [source,nodejs]
@@ -81,7 +81,7 @@ a| `options` a|  a| `TypeDBOptions`
 .Returns
 `Promise<TypeDBSession>`
 
-[#_TypeDBDriver_useruser__:_Promise_User]
+[#_TypeDBDriver_user__]
 ==== user
 
 [source,nodejs]

--- a/nodejs/docs/connection/User.adoc
+++ b/nodejs/docs/connection/User.adoc
@@ -16,7 +16,7 @@ a| `username` a| `string` a| The name of this user.
 // end::properties[]
 
 // tag::methods[]
-[#_User_passwordUpdatepasswordUpdate_oldPassword__newPassword_:_Promise_void]
+[#_User_passwordUpdate__oldPassword_string__newPassword_string]
 ==== passwordUpdate
 
 [source,nodejs]

--- a/nodejs/docs/connection/UserManager.adoc
+++ b/nodejs/docs/connection/UserManager.adoc
@@ -4,7 +4,7 @@
 Provides access to all user management methods.
 
 // tag::methods[]
-[#_UserManager_allall__:_Promise_User__]
+[#_UserManager_all__]
 ==== all
 
 [source,nodejs]
@@ -25,7 +25,7 @@ Retrieves all users which exist on the TypeDB server.
 driver.users.all()
 ----
 
-[#_UserManager_containscontains_name_:_Promise_boolean]
+[#_UserManager_contains__name_string]
 ==== contains
 
 [source,nodejs]
@@ -55,7 +55,7 @@ a| `name` a|  a| `string`
 driver.users.contains(username)
 ----
 
-[#_UserManager_createcreate_name__password_:_Promise_void]
+[#_UserManager_create__name_string__password_string]
 ==== create
 
 [source,nodejs]
@@ -86,7 +86,7 @@ a| `password` a| The password of the user to be created a| `string`
 driver.users.create(username, password)
 ----
 
-[#_UserManager_deletedelete_name_:_Promise_void]
+[#_UserManager_delete__name_string]
 ==== delete
 
 [source,nodejs]
@@ -116,7 +116,7 @@ a| `name` a|  a| `string`
 driver.users.delete(username)
 ----
 
-[#_UserManager_getget_name_:_Promise_User]
+[#_UserManager_get__name_string]
 ==== get
 
 [source,nodejs]
@@ -146,7 +146,7 @@ a| `name` a|  a| `string`
 driver.users.get(username)
 ----
 
-[#_UserManager_passwordSetpasswordSet_name__password_:_Promise_void]
+[#_UserManager_passwordSet__name_string__password_string]
 ==== passwordSet
 
 [source,nodejs]

--- a/nodejs/docs/data/Attribute.adoc
+++ b/nodejs/docs/data/Attribute.adoc
@@ -23,7 +23,7 @@ a| `valueType` a| `ValueType` a| The type of the value which the Attribute insta
 // end::properties[]
 
 // tag::methods[]
-[#_Attribute_asAttributeasAttribute__:_Attribute]
+[#_Attribute_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -44,7 +44,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_Attribute_asAttributeTypeasAttributeType__:_AttributeType]
+[#_Attribute_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -65,7 +65,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_Attribute_asEntityasEntity__:_Entity]
+[#_Attribute_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -86,7 +86,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_Attribute_asEntityTypeasEntityType__:_EntityType]
+[#_Attribute_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -107,7 +107,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_Attribute_asRelationasRelation__:_Relation]
+[#_Attribute_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -128,7 +128,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_Attribute_asRelationTypeasRelationType__:_RelationType]
+[#_Attribute_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -149,7 +149,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_Attribute_asRoleTypeasRoleType__:_RoleType]
+[#_Attribute_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -170,7 +170,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_Attribute_asThingasThing__:_Thing]
+[#_Attribute_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -191,7 +191,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_Attribute_asThingTypeasThingType__:_ThingType]
+[#_Attribute_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -212,7 +212,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_Attribute_asTypeasType__:_Type]
+[#_Attribute_asType__]
 ==== asType
 
 [source,nodejs]
@@ -233,7 +233,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_Attribute_asValueasValue__:_Value]
+[#_Attribute_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -254,7 +254,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_Attribute_deletedelete_transaction_:_Promise_void]
+[#_Attribute_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -284,7 +284,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.delete(transaction)
 ----
 
-[#_Attribute_equalsequals_concept_:_boolean]
+[#_Attribute_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -307,7 +307,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_Attribute_getHasgetHas_transaction_:_Stream_Attribute]
+[#_Attribute_getHas__transaction_TypeDBTransaction]
 ==== getHas
 
 [source,nodejs]
@@ -337,7 +337,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Attribute_getHasgetHas_transaction__annotations_:_Stream_Attribute]
+[#_Attribute_getHas__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -368,7 +368,7 @@ a| `annotations` a| The ``AttributeType``s to filter the attributes by a| `Annot
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Attribute_getHasgetHas_transaction__attributeType_:_Stream_Attribute]
+[#_Attribute_getHas__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getHas
 
 [source,nodejs]
@@ -399,7 +399,7 @@ a| `attributeType` a| The ``AttributeType``s to filter the attributes by a| `Att
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Attribute_getHasgetHas_transaction__attributeTypes_:_Stream_Attribute]
+[#_Attribute_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType__]
 ==== getHas
 
 [source,nodejs]
@@ -430,7 +430,7 @@ a| `attributeTypes` a| The ``AttributeType``s to filter the attributes by a| `At
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Attribute_getHasgetHas_transaction__attributeTypes__annotations_:_Stream_Attribute]
+[#_Attribute_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType____annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -462,7 +462,7 @@ a| `annotations` a| Only retrieve attributes with all given ``Annotation``s a| `
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Attribute_getOwnersgetOwners_transaction__ownerType?_:_Stream_Thing]
+[#_Attribute_getOwners__transaction_TypeDBTransaction__ownerType_ThingType]
 ==== getOwners
 
 [source,nodejs]
@@ -493,7 +493,7 @@ a| `ownerType` a| If specified, filter results for only owners of the given type
 attribute.getOwners(transaction) attribute.getOwners(transaction, ownerType)
 ----
 
-[#_Attribute_getPlayinggetPlaying_transaction_:_Stream_RoleType]
+[#_Attribute_getPlaying__transaction_TypeDBTransaction]
 ==== getPlaying
 
 [source,nodejs]
@@ -523,7 +523,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getPlaying(transaction)
 ----
 
-[#_Attribute_getRelationsgetRelations_transaction_:_Stream_Relation]
+[#_Attribute_getRelations__transaction_TypeDBTransaction]
 ==== getRelations
 
 [source,nodejs]
@@ -553,7 +553,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Attribute_getRelationsgetRelations_transaction__roleTypes_:_Stream_Relation]
+[#_Attribute_getRelations__transaction_TypeDBTransaction__roleTypes_RoleType__]
 ==== getRelations
 
 [source,nodejs]
@@ -584,7 +584,7 @@ a| `roleTypes` a| The list of roles to filter the relations by. a| `RoleType[]`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Attribute_isAttributeisAttribute__:_boolean]
+[#_Attribute_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -605,7 +605,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_Attribute_isAttributeTypeisAttributeType__:_boolean]
+[#_Attribute_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -626,7 +626,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_Attribute_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_Attribute_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -656,7 +656,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.isDeleted(transaction)
 ----
 
-[#_Attribute_isEntityisEntity__:_boolean]
+[#_Attribute_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -677,7 +677,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_Attribute_isEntityTypeisEntityType__:_boolean]
+[#_Attribute_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -698,7 +698,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_Attribute_isRelationisRelation__:_boolean]
+[#_Attribute_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -719,7 +719,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_Attribute_isRelationTypeisRelationType__:_boolean]
+[#_Attribute_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -740,7 +740,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_Attribute_isRoleTypeisRoleType__:_boolean]
+[#_Attribute_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -761,7 +761,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_Attribute_isThingisThing__:_boolean]
+[#_Attribute_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -782,7 +782,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_Attribute_isThingTypeisThingType__:_boolean]
+[#_Attribute_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -803,7 +803,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_Attribute_isTypeisType__:_boolean]
+[#_Attribute_isType__]
 ==== isType
 
 [source,nodejs]
@@ -824,7 +824,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_Attribute_isValueisValue__:_boolean]
+[#_Attribute_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -845,7 +845,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_Attribute_setHassetHas_transaction__attribute_:_Promise_void]
+[#_Attribute_setHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== setHas
 
 [source,nodejs]
@@ -876,7 +876,7 @@ a| `attribute` a| The ``Attribute`` to be owned by this ``Thing``. a| `Attribute
 thing.setHas(transaction, attribute)
 ----
 
-[#_Attribute_unsetHasunsetHas_transaction__attribute_:_Promise_void]
+[#_Attribute_unsetHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== unsetHas
 
 [source,nodejs]

--- a/nodejs/docs/data/Entity.adoc
+++ b/nodejs/docs/data/Entity.adoc
@@ -21,7 +21,7 @@ a| `type` a| `EntityType` a| The type which this Entity belongs to.
 // end::properties[]
 
 // tag::methods[]
-[#_Entity_asAttributeasAttribute__:_Attribute]
+[#_Entity_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -42,7 +42,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_Entity_asAttributeTypeasAttributeType__:_AttributeType]
+[#_Entity_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -63,7 +63,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_Entity_asEntityasEntity__:_Entity]
+[#_Entity_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -84,7 +84,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_Entity_asEntityTypeasEntityType__:_EntityType]
+[#_Entity_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -105,7 +105,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_Entity_asRelationasRelation__:_Relation]
+[#_Entity_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -126,7 +126,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_Entity_asRelationTypeasRelationType__:_RelationType]
+[#_Entity_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -147,7 +147,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_Entity_asRoleTypeasRoleType__:_RoleType]
+[#_Entity_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -168,7 +168,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_Entity_asThingasThing__:_Thing]
+[#_Entity_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -189,7 +189,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_Entity_asThingTypeasThingType__:_ThingType]
+[#_Entity_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -210,7 +210,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_Entity_asTypeasType__:_Type]
+[#_Entity_asType__]
 ==== asType
 
 [source,nodejs]
@@ -231,7 +231,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_Entity_asValueasValue__:_Value]
+[#_Entity_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -252,7 +252,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_Entity_deletedelete_transaction_:_Promise_void]
+[#_Entity_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -282,7 +282,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.delete(transaction)
 ----
 
-[#_Entity_equalsequals_concept_:_boolean]
+[#_Entity_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -305,7 +305,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_Entity_getHasgetHas_transaction_:_Stream_Attribute]
+[#_Entity_getHas__transaction_TypeDBTransaction]
 ==== getHas
 
 [source,nodejs]
@@ -335,7 +335,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Entity_getHasgetHas_transaction__annotations_:_Stream_Attribute]
+[#_Entity_getHas__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -366,7 +366,7 @@ a| `annotations` a| The ``AttributeType``s to filter the attributes by a| `Annot
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Entity_getHasgetHas_transaction__attributeType_:_Stream_Attribute]
+[#_Entity_getHas__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getHas
 
 [source,nodejs]
@@ -397,7 +397,7 @@ a| `attributeType` a| The ``AttributeType``s to filter the attributes by a| `Att
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Entity_getHasgetHas_transaction__attributeTypes_:_Stream_Attribute]
+[#_Entity_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType__]
 ==== getHas
 
 [source,nodejs]
@@ -428,7 +428,7 @@ a| `attributeTypes` a| The ``AttributeType``s to filter the attributes by a| `At
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Entity_getHasgetHas_transaction__attributeTypes__annotations_:_Stream_Attribute]
+[#_Entity_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType____annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -460,7 +460,7 @@ a| `annotations` a| Only retrieve attributes with all given ``Annotation``s a| `
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Entity_getPlayinggetPlaying_transaction_:_Stream_RoleType]
+[#_Entity_getPlaying__transaction_TypeDBTransaction]
 ==== getPlaying
 
 [source,nodejs]
@@ -490,7 +490,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getPlaying(transaction)
 ----
 
-[#_Entity_getRelationsgetRelations_transaction_:_Stream_Relation]
+[#_Entity_getRelations__transaction_TypeDBTransaction]
 ==== getRelations
 
 [source,nodejs]
@@ -520,7 +520,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Entity_getRelationsgetRelations_transaction__roleTypes_:_Stream_Relation]
+[#_Entity_getRelations__transaction_TypeDBTransaction__roleTypes_RoleType__]
 ==== getRelations
 
 [source,nodejs]
@@ -551,7 +551,7 @@ a| `roleTypes` a| The list of roles to filter the relations by. a| `RoleType[]`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Entity_isAttributeisAttribute__:_boolean]
+[#_Entity_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -572,7 +572,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_Entity_isAttributeTypeisAttributeType__:_boolean]
+[#_Entity_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -593,7 +593,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_Entity_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_Entity_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -623,7 +623,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.isDeleted(transaction)
 ----
 
-[#_Entity_isEntityisEntity__:_boolean]
+[#_Entity_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -644,7 +644,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_Entity_isEntityTypeisEntityType__:_boolean]
+[#_Entity_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -665,7 +665,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_Entity_isRelationisRelation__:_boolean]
+[#_Entity_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -686,7 +686,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_Entity_isRelationTypeisRelationType__:_boolean]
+[#_Entity_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -707,7 +707,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_Entity_isRoleTypeisRoleType__:_boolean]
+[#_Entity_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -728,7 +728,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_Entity_isThingisThing__:_boolean]
+[#_Entity_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -749,7 +749,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_Entity_isThingTypeisThingType__:_boolean]
+[#_Entity_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -770,7 +770,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_Entity_isTypeisType__:_boolean]
+[#_Entity_isType__]
 ==== isType
 
 [source,nodejs]
@@ -791,7 +791,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_Entity_isValueisValue__:_boolean]
+[#_Entity_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -812,7 +812,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_Entity_setHassetHas_transaction__attribute_:_Promise_void]
+[#_Entity_setHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== setHas
 
 [source,nodejs]
@@ -843,7 +843,7 @@ a| `attribute` a| The ``Attribute`` to be owned by this ``Thing``. a| `Attribute
 thing.setHas(transaction, attribute)
 ----
 
-[#_Entity_unsetHasunsetHas_transaction__attribute_:_Promise_void]
+[#_Entity_unsetHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== unsetHas
 
 [source,nodejs]

--- a/nodejs/docs/data/Relation.adoc
+++ b/nodejs/docs/data/Relation.adoc
@@ -21,7 +21,7 @@ a| `type` a| `RelationType` a| The type which this Relation belongs to.
 // end::properties[]
 
 // tag::methods[]
-[#_Relation_addRolePlayeraddRolePlayer_transaction__roleType__player_:_Promise_void]
+[#_Relation_addRolePlayer__transaction_TypeDBTransaction__roleType_RoleType__player_Thing]
 ==== addRolePlayer
 
 [source,nodejs]
@@ -53,7 +53,7 @@ a| `player` a| The thing to play the role a| `Thing`
 relation.addRolePlayer(transaction, roleType, player)
 ----
 
-[#_Relation_asAttributeasAttribute__:_Attribute]
+[#_Relation_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -74,7 +74,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_Relation_asAttributeTypeasAttributeType__:_AttributeType]
+[#_Relation_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -95,7 +95,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_Relation_asEntityasEntity__:_Entity]
+[#_Relation_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -116,7 +116,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_Relation_asEntityTypeasEntityType__:_EntityType]
+[#_Relation_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -137,7 +137,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_Relation_asRelationasRelation__:_Relation]
+[#_Relation_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -158,7 +158,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_Relation_asRelationTypeasRelationType__:_RelationType]
+[#_Relation_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -179,7 +179,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_Relation_asRoleTypeasRoleType__:_RoleType]
+[#_Relation_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -200,7 +200,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_Relation_asThingasThing__:_Thing]
+[#_Relation_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -221,7 +221,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_Relation_asThingTypeasThingType__:_ThingType]
+[#_Relation_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -242,7 +242,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_Relation_asTypeasType__:_Type]
+[#_Relation_asType__]
 ==== asType
 
 [source,nodejs]
@@ -263,7 +263,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_Relation_asValueasValue__:_Value]
+[#_Relation_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -284,7 +284,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_Relation_deletedelete_transaction_:_Promise_void]
+[#_Relation_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -314,7 +314,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.delete(transaction)
 ----
 
-[#_Relation_equalsequals_concept_:_boolean]
+[#_Relation_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -337,7 +337,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_Relation_getHasgetHas_transaction_:_Stream_Attribute]
+[#_Relation_getHas__transaction_TypeDBTransaction]
 ==== getHas
 
 [source,nodejs]
@@ -367,7 +367,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Relation_getHasgetHas_transaction__annotations_:_Stream_Attribute]
+[#_Relation_getHas__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -398,7 +398,7 @@ a| `annotations` a| The ``AttributeType``s to filter the attributes by a| `Annot
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Relation_getHasgetHas_transaction__attributeType_:_Stream_Attribute]
+[#_Relation_getHas__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getHas
 
 [source,nodejs]
@@ -429,7 +429,7 @@ a| `attributeType` a| The ``AttributeType``s to filter the attributes by a| `Att
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Relation_getHasgetHas_transaction__attributeTypes_:_Stream_Attribute]
+[#_Relation_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType__]
 ==== getHas
 
 [source,nodejs]
@@ -460,7 +460,7 @@ a| `attributeTypes` a| The ``AttributeType``s to filter the attributes by a| `At
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Relation_getHasgetHas_transaction__attributeTypes__annotations_:_Stream_Attribute]
+[#_Relation_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType____annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -492,7 +492,7 @@ a| `annotations` a| Only retrieve attributes with all given ``Annotation``s a| `
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Relation_getPlayersByRoleTypegetPlayersByRoleType_transaction_:_Stream_Thing]
+[#_Relation_getPlayersByRoleType__transaction_TypeDBTransaction]
 ==== getPlayersByRoleType
 
 [source,nodejs]
@@ -522,7 +522,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 relation.getPlayersByRoleType(transaction) relation.getPlayersByRoleType(transaction, [roleType1, roleType2])
 ----
 
-[#_Relation_getPlayersByRoleTypegetPlayersByRoleType_transaction__roleTypes_:_Stream_Thing]
+[#_Relation_getPlayersByRoleType__transaction_TypeDBTransaction__roleTypes_RoleType__]
 ==== getPlayersByRoleType
 
 [source,nodejs]
@@ -553,7 +553,7 @@ a| `roleTypes` a| 0 or more role types a| `RoleType[]`
 relation.getPlayersByRoleType(transaction) relation.getPlayersByRoleType(transaction, [roleType1, roleType2])
 ----
 
-[#_Relation_getPlayinggetPlaying_transaction_:_Stream_RoleType]
+[#_Relation_getPlaying__transaction_TypeDBTransaction]
 ==== getPlaying
 
 [source,nodejs]
@@ -583,7 +583,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getPlaying(transaction)
 ----
 
-[#_Relation_getRelatinggetRelating_transaction_:_Stream_RoleType]
+[#_Relation_getRelating__transaction_TypeDBTransaction]
 ==== getRelating
 
 [source,nodejs]
@@ -613,7 +613,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 relation.getRelating(transaction)
 ----
 
-[#_Relation_getRelationsgetRelations_transaction_:_Stream_Relation]
+[#_Relation_getRelations__transaction_TypeDBTransaction]
 ==== getRelations
 
 [source,nodejs]
@@ -643,7 +643,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Relation_getRelationsgetRelations_transaction__roleTypes_:_Stream_Relation]
+[#_Relation_getRelations__transaction_TypeDBTransaction__roleTypes_RoleType__]
 ==== getRelations
 
 [source,nodejs]
@@ -674,7 +674,7 @@ a| `roleTypes` a| The list of roles to filter the relations by. a| `RoleType[]`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Relation_getRolePlayersgetRolePlayers_transaction_:_Promise_Map_RoleType__Thing___]
+[#_Relation_getRolePlayers__transaction_TypeDBTransaction]
 ==== getRolePlayers
 
 [source,nodejs]
@@ -704,7 +704,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 relation.getRolePlayers(transaction)
 ----
 
-[#_Relation_isAttributeisAttribute__:_boolean]
+[#_Relation_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -725,7 +725,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_Relation_isAttributeTypeisAttributeType__:_boolean]
+[#_Relation_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -746,7 +746,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_Relation_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_Relation_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -776,7 +776,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.isDeleted(transaction)
 ----
 
-[#_Relation_isEntityisEntity__:_boolean]
+[#_Relation_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -797,7 +797,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_Relation_isEntityTypeisEntityType__:_boolean]
+[#_Relation_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -818,7 +818,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_Relation_isRelationisRelation__:_boolean]
+[#_Relation_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -839,7 +839,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_Relation_isRelationTypeisRelationType__:_boolean]
+[#_Relation_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -860,7 +860,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_Relation_isRoleTypeisRoleType__:_boolean]
+[#_Relation_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -881,7 +881,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_Relation_isThingisThing__:_boolean]
+[#_Relation_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -902,7 +902,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_Relation_isThingTypeisThingType__:_boolean]
+[#_Relation_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -923,7 +923,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_Relation_isTypeisType__:_boolean]
+[#_Relation_isType__]
 ==== isType
 
 [source,nodejs]
@@ -944,7 +944,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_Relation_isValueisValue__:_boolean]
+[#_Relation_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -965,7 +965,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_Relation_removeRolePlayerremoveRolePlayer_transaction__roleType__player_:_Promise_void]
+[#_Relation_removeRolePlayer__transaction_TypeDBTransaction__roleType_RoleType__player_Thing]
 ==== removeRolePlayer
 
 [source,nodejs]
@@ -997,7 +997,7 @@ a| `player` a| The instance to no longer play the role in this ``Relation`` a| `
 relation.removeRolePlayer(transaction, roleType, player)
 ----
 
-[#_Relation_setHassetHas_transaction__attribute_:_Promise_void]
+[#_Relation_setHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== setHas
 
 [source,nodejs]
@@ -1028,7 +1028,7 @@ a| `attribute` a| The ``Attribute`` to be owned by this ``Thing``. a| `Attribute
 thing.setHas(transaction, attribute)
 ----
 
-[#_Relation_unsetHasunsetHas_transaction__attribute_:_Promise_void]
+[#_Relation_unsetHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== unsetHas
 
 [source,nodejs]

--- a/nodejs/docs/data/Thing.adoc
+++ b/nodejs/docs/data/Thing.adoc
@@ -19,7 +19,7 @@ a| `type` a| `ThingType` a| Retrieves the type which this Thing belongs to.
 // end::properties[]
 
 // tag::methods[]
-[#_Thing_asAttributeasAttribute__:_Attribute]
+[#_Thing_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -40,7 +40,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_Thing_asAttributeTypeasAttributeType__:_AttributeType]
+[#_Thing_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -61,7 +61,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_Thing_asEntityasEntity__:_Entity]
+[#_Thing_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -82,7 +82,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_Thing_asEntityTypeasEntityType__:_EntityType]
+[#_Thing_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -103,7 +103,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_Thing_asRelationasRelation__:_Relation]
+[#_Thing_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -124,7 +124,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_Thing_asRelationTypeasRelationType__:_RelationType]
+[#_Thing_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -145,7 +145,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_Thing_asRoleTypeasRoleType__:_RoleType]
+[#_Thing_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -166,7 +166,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_Thing_asThingasThing__:_Thing]
+[#_Thing_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -187,7 +187,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_Thing_asThingTypeasThingType__:_ThingType]
+[#_Thing_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -208,7 +208,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_Thing_asTypeasType__:_Type]
+[#_Thing_asType__]
 ==== asType
 
 [source,nodejs]
@@ -229,7 +229,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_Thing_asValueasValue__:_Value]
+[#_Thing_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -250,7 +250,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_Thing_deletedelete_transaction_:_Promise_void]
+[#_Thing_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -280,7 +280,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.delete(transaction)
 ----
 
-[#_Thing_equalsequals_concept_:_boolean]
+[#_Thing_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -303,7 +303,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_Thing_getHasgetHas_transaction_:_Stream_Attribute]
+[#_Thing_getHas__transaction_TypeDBTransaction]
 ==== getHas
 
 [source,nodejs]
@@ -333,7 +333,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Thing_getHasgetHas_transaction__annotations_:_Stream_Attribute]
+[#_Thing_getHas__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -364,7 +364,7 @@ a| `annotations` a| The ``AttributeType``s to filter the attributes by a| `Annot
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Thing_getHasgetHas_transaction__attributeType_:_Stream_Attribute]
+[#_Thing_getHas__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getHas
 
 [source,nodejs]
@@ -395,7 +395,7 @@ a| `attributeType` a| The ``AttributeType``s to filter the attributes by a| `Att
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Thing_getHasgetHas_transaction__attributeTypes_:_Stream_Attribute]
+[#_Thing_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType__]
 ==== getHas
 
 [source,nodejs]
@@ -426,7 +426,7 @@ a| `attributeTypes` a| The ``AttributeType``s to filter the attributes by a| `At
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Thing_getHasgetHas_transaction__attributeTypes__annotations_:_Stream_Attribute]
+[#_Thing_getHas__transaction_TypeDBTransaction__attributeTypes_AttributeType____annotations_Annotation__]
 ==== getHas
 
 [source,nodejs]
@@ -458,7 +458,7 @@ a| `annotations` a| Only retrieve attributes with all given ``Annotation``s a| `
 thing.getHas(transaction) thing.getHas(transaction, attributeType, [Annotation.KEY])
 ----
 
-[#_Thing_getPlayinggetPlaying_transaction_:_Stream_RoleType]
+[#_Thing_getPlaying__transaction_TypeDBTransaction]
 ==== getPlaying
 
 [source,nodejs]
@@ -488,7 +488,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getPlaying(transaction)
 ----
 
-[#_Thing_getRelationsgetRelations_transaction_:_Stream_Relation]
+[#_Thing_getRelations__transaction_TypeDBTransaction]
 ==== getRelations
 
 [source,nodejs]
@@ -518,7 +518,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Thing_getRelationsgetRelations_transaction__roleTypes_:_Stream_Relation]
+[#_Thing_getRelations__transaction_TypeDBTransaction__roleTypes_RoleType__]
 ==== getRelations
 
 [source,nodejs]
@@ -549,7 +549,7 @@ a| `roleTypes` a| The list of roles to filter the relations by. a| `RoleType[]`
 thing.getRelations(transaction, roleTypes)
 ----
 
-[#_Thing_isAttributeisAttribute__:_boolean]
+[#_Thing_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -570,7 +570,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_Thing_isAttributeTypeisAttributeType__:_boolean]
+[#_Thing_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -591,7 +591,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_Thing_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_Thing_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -621,7 +621,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thing.isDeleted(transaction)
 ----
 
-[#_Thing_isEntityisEntity__:_boolean]
+[#_Thing_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -642,7 +642,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_Thing_isEntityTypeisEntityType__:_boolean]
+[#_Thing_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -663,7 +663,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_Thing_isRelationisRelation__:_boolean]
+[#_Thing_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -684,7 +684,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_Thing_isRelationTypeisRelationType__:_boolean]
+[#_Thing_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -705,7 +705,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_Thing_isRoleTypeisRoleType__:_boolean]
+[#_Thing_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -726,7 +726,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_Thing_isThingisThing__:_boolean]
+[#_Thing_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -747,7 +747,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_Thing_isThingTypeisThingType__:_boolean]
+[#_Thing_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -768,7 +768,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_Thing_isTypeisType__:_boolean]
+[#_Thing_isType__]
 ==== isType
 
 [source,nodejs]
@@ -789,7 +789,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_Thing_isValueisValue__:_boolean]
+[#_Thing_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -810,7 +810,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_Thing_setHassetHas_transaction__attribute_:_Promise_void]
+[#_Thing_setHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== setHas
 
 [source,nodejs]
@@ -841,7 +841,7 @@ a| `attribute` a| The ``Attribute`` to be owned by this ``Thing``. a| `Attribute
 thing.setHas(transaction, attribute)
 ----
 
-[#_Thing_unsetHasunsetHas_transaction__attribute_:_Promise_void]
+[#_Thing_unsetHas__transaction_TypeDBTransaction__attribute_Attribute]
 ==== unsetHas
 
 [source,nodejs]

--- a/nodejs/docs/data/Value.adoc
+++ b/nodejs/docs/data/Value.adoc
@@ -18,7 +18,7 @@ a| `valueType` a| `ValueType` a| The ValueType of this value concept
 // end::properties[]
 
 // tag::methods[]
-[#_Value_asAttributeasAttribute__:_Attribute]
+[#_Value_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -39,7 +39,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_Value_asAttributeTypeasAttributeType__:_AttributeType]
+[#_Value_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -60,7 +60,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_Value_asBooleanasBoolean__:_boolean]
+[#_Value_asBoolean__]
 ==== asBoolean
 
 [source,nodejs]
@@ -81,7 +81,7 @@ Returns a ``boolean`` value of this value concept. If the value has another type
 value.asBoolean()
 ----
 
-[#_Value_asDateTimeasDateTime__:_Date]
+[#_Value_asDateTime__]
 ==== asDateTime
 
 [source,nodejs]
@@ -102,7 +102,7 @@ Returns a ``datetime`` value of this value concept. If the value has another typ
 value.asDatetime()
 ----
 
-[#_Value_asDoubleasDouble__:_number]
+[#_Value_asDouble__]
 ==== asDouble
 
 [source,nodejs]
@@ -123,7 +123,7 @@ Returns a ``number`` value of this value concept. If the value has another type,
 value.asDouble()
 ----
 
-[#_Value_asEntityasEntity__:_Entity]
+[#_Value_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -144,7 +144,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_Value_asEntityTypeasEntityType__:_EntityType]
+[#_Value_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -165,7 +165,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_Value_asLongasLong__:_number]
+[#_Value_asLong__]
 ==== asLong
 
 [source,nodejs]
@@ -186,7 +186,7 @@ Returns a ``number`` value of this value concept. If the value has another type,
 value.asLong()
 ----
 
-[#_Value_asRelationasRelation__:_Relation]
+[#_Value_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -207,7 +207,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_Value_asRelationTypeasRelationType__:_RelationType]
+[#_Value_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -228,7 +228,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_Value_asRoleTypeasRoleType__:_RoleType]
+[#_Value_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -249,7 +249,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_Value_asStringasString__:_string]
+[#_Value_asString__]
 ==== asString
 
 [source,nodejs]
@@ -270,7 +270,7 @@ Returns a ``string`` value of this value concept. If the value has another type,
 value.asString()
 ----
 
-[#_Value_asThingasThing__:_Thing]
+[#_Value_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -291,7 +291,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_Value_asThingTypeasThingType__:_ThingType]
+[#_Value_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -312,7 +312,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_Value_asTypeasType__:_Type]
+[#_Value_asType__]
 ==== asType
 
 [source,nodejs]
@@ -333,7 +333,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_Value_asValueasValue__:_Value]
+[#_Value_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -354,7 +354,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_Value_equalsequals_concept_:_boolean]
+[#_Value_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -377,7 +377,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_Value_isAttributeisAttribute__:_boolean]
+[#_Value_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -398,7 +398,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_Value_isAttributeTypeisAttributeType__:_boolean]
+[#_Value_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -419,7 +419,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_Value_isBooleanisBoolean__:_boolean]
+[#_Value_isBoolean__]
 ==== isBoolean
 
 [source,nodejs]
@@ -440,7 +440,7 @@ Returns ``True`` if the value which this value concept holds is of type ``boolea
 value.isBoolean()
 ----
 
-[#_Value_isDateTimeisDateTime__:_boolean]
+[#_Value_isDateTime__]
 ==== isDateTime
 
 [source,nodejs]
@@ -461,7 +461,7 @@ Returns ``True`` if the value which this value concept holds is of type ``dateti
 value.isDatetime()
 ----
 
-[#_Value_isDoubleisDouble__:_boolean]
+[#_Value_isDouble__]
 ==== isDouble
 
 [source,nodejs]
@@ -482,7 +482,7 @@ Returns ``True`` if the value which this value concept holds is of type ``double
 value.isDouble()
 ----
 
-[#_Value_isEntityisEntity__:_boolean]
+[#_Value_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -503,7 +503,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_Value_isEntityTypeisEntityType__:_boolean]
+[#_Value_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -524,7 +524,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_Value_isLongisLong__:_boolean]
+[#_Value_isLong__]
 ==== isLong
 
 [source,nodejs]
@@ -545,7 +545,7 @@ Returns ``True`` if the value which this value concept holds is of type ``long``
 value.isLong()
 ----
 
-[#_Value_isRelationisRelation__:_boolean]
+[#_Value_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -566,7 +566,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_Value_isRelationTypeisRelationType__:_boolean]
+[#_Value_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -587,7 +587,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_Value_isRoleTypeisRoleType__:_boolean]
+[#_Value_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -608,7 +608,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_Value_isStringisString__:_boolean]
+[#_Value_isString__]
 ==== isString
 
 [source,nodejs]
@@ -629,7 +629,7 @@ Returns ``True`` if the value which this value concept holds is of type ``string
 value.isString()
 ----
 
-[#_Value_isThingisThing__:_boolean]
+[#_Value_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -650,7 +650,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_Value_isThingTypeisThingType__:_boolean]
+[#_Value_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -671,7 +671,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_Value_isTypeisType__:_boolean]
+[#_Value_isType__]
 ==== isType
 
 [source,nodejs]
@@ -692,7 +692,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_Value_isValueisValue__:_boolean]
+[#_Value_isValue__]
 ==== isValue
 
 [source,nodejs]

--- a/nodejs/docs/errors/ErrorMessage.adoc
+++ b/nodejs/docs/errors/ErrorMessage.adoc
@@ -4,7 +4,7 @@
 Class defining the error-code and message template for ``TypeDBDriverError``s
 
 // tag::methods[]
-[#_ErrorMessage_codecode__:_string]
+[#_ErrorMessage_code__]
 ==== code
 
 [source,nodejs]
@@ -18,7 +18,7 @@ Retrieves the error-code for this ErrorMessage
 .Returns
 `string`
 
-[#_ErrorMessage_messagemessage____args_:_string]
+[#_ErrorMessage_message__args_Stringable__]
 ==== message
 
 [source,nodejs]
@@ -41,7 +41,7 @@ a| `args` a| The format arguments to the message-template. a| `Stringable[]`
 .Returns
 `string`
 
-[#_ErrorMessage_new_ErrorMessagenew_ErrorMessage_codePrefix__codeNumber__messagePrefix__messageBody_:_ErrorMessage]
+[#_ErrorMessage_new_ErrorMessage__codePrefix_string__codeNumber_number__messagePrefix_string__messageBody___args____string_]
 ==== new ErrorMessage
 
 [source,nodejs]
@@ -67,7 +67,7 @@ a| `messageBody` a|  a| `((args) => string)`
 .Returns
 `ErrorMessage`
 
-[#_ErrorMessage_toStringtoString__:_string]
+[#_ErrorMessage_toString__]
 ==== toString
 
 [source,nodejs]

--- a/nodejs/docs/errors/TypeDBDriverError.adoc
+++ b/nodejs/docs/errors/TypeDBDriverError.adoc
@@ -23,7 +23,7 @@ a| `stackTraceLimit` a| `number` a|
 // end::properties[]
 
 // tag::methods[]
-[#__messageTemplate]
+[#_TypeDBDriverError__messageTemplate__]
 ====  messageTemplate
 
 [source,nodejs]
@@ -37,7 +37,7 @@ Returns the message template for this error.
 .Returns
 `ErrorMessage`
 
-[#_TypeDBDriverError_captureStackTracecaptureStackTrace_targetObject__constructorOpt?_:_void]
+[#_TypeDBDriverError_captureStackTrace__targetObject_object__constructorOpt_Function]
 ==== captureStackTrace
 
 [source,nodejs]
@@ -61,7 +61,7 @@ a| `constructorOpt` a|  a| `Function`
 .Returns
 `void`
 
-[#_TypeDBDriverError_new_TypeDBDriverErrornew_TypeDBDriverError_error_:_TypeDBDriverError]
+[#_TypeDBDriverError_new_TypeDBDriverError__error_string__ErrorMessage__Error__ServiceError]
 ==== new TypeDBDriverError
 
 [source,nodejs]

--- a/nodejs/docs/logic/LogicManager.adoc
+++ b/nodejs/docs/logic/LogicManager.adoc
@@ -4,7 +4,7 @@
 Provides methods for manipulating rules in the database.
 
 // tag::methods[]
-[#_LogicManager_getRulegetRule_label_:_Promise_Rule]
+[#_LogicManager_getRule__label_string]
 ==== getRule
 
 [source,nodejs]
@@ -34,7 +34,7 @@ a| `label` a| The label of the Rule to create or retrieve a| `string`
 transaction.logic.getRule(label)
 ----
 
-[#_LogicManager_getRulesgetRules__:_Stream_Rule]
+[#_LogicManager_getRules__]
 ==== getRules
 
 [source,nodejs]
@@ -55,7 +55,7 @@ Retrieves all rules.
 transaction.logic.getRules()
 ----
 
-[#_LogicManager_putRuleputRule_label__when__then_:_Promise_Rule]
+[#_LogicManager_putRule__label_string__when_string__then_string]
 ==== putRule
 
 [source,nodejs]

--- a/nodejs/docs/logic/Rule.adoc
+++ b/nodejs/docs/logic/Rule.adoc
@@ -17,7 +17,7 @@ a| `when` a| `string` a| The statements that constitute the ‘when’ of the ru
 // end::properties[]
 
 // tag::methods[]
-[#_Rule_deletedelete_transaction_:_Promise_void]
+[#_Rule_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -47,7 +47,7 @@ a| `transaction` a| The current ``Transaction`` a| `TypeDBTransaction`
 rule.delete(transaction)
 ----
 
-[#_Rule_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_Rule_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -77,7 +77,7 @@ a| `transaction` a| The current ``Transaction`` a| `TypeDBTransaction`
 rule.isDeleted(transaction)
 ----
 
-[#_Rule_setLabelsetLabel_transaction__label_:_Promise_void]
+[#_Rule_setLabel__transaction_TypeDBTransaction__label_string]
 ==== setLabel
 
 [source,nodejs]

--- a/nodejs/docs/schema/Annotation.adoc
+++ b/nodejs/docs/schema/Annotation.adoc
@@ -16,7 +16,7 @@ a| `UNIQUE` a| `Annotation` a| Annotation to specify the owned is UNIQUE
 // end::properties[]
 
 // tag::methods[]
-[#_Annotation_parseparse_string_:_Annotation]
+[#_Annotation_parse__string_string]
 ==== parse
 
 [source,nodejs]
@@ -39,7 +39,7 @@ a| `string` a| name of the attribute as a string. e.g.: "key", "unique" a| `stri
 .Returns
 `Annotation`
 
-[#_Annotation_toStringtoString__:_string]
+[#_Annotation_toString__]
 ==== toString
 
 [source,nodejs]

--- a/nodejs/docs/schema/AttributeType.adoc
+++ b/nodejs/docs/schema/AttributeType.adoc
@@ -19,7 +19,7 @@ a| `NAME`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_AttributeType_asAttributeasAttribute__:_Attribute]
+[#_AttributeType_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -40,7 +40,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_AttributeType_asAttributeTypeasAttributeType__:_AttributeType]
+[#_AttributeType_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -61,7 +61,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_AttributeType_asEntityasEntity__:_Entity]
+[#_AttributeType_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -82,7 +82,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_AttributeType_asEntityTypeasEntityType__:_EntityType]
+[#_AttributeType_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -103,7 +103,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_AttributeType_asRelationasRelation__:_Relation]
+[#_AttributeType_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -124,7 +124,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_AttributeType_asRelationTypeasRelationType__:_RelationType]
+[#_AttributeType_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -145,7 +145,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_AttributeType_asRoleTypeasRoleType__:_RoleType]
+[#_AttributeType_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -166,7 +166,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_AttributeType_asThingasThing__:_Thing]
+[#_AttributeType_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -187,7 +187,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_AttributeType_asThingTypeasThingType__:_ThingType]
+[#_AttributeType_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -208,7 +208,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_AttributeType_asTypeasType__:_Type]
+[#_AttributeType_asType__]
 ==== asType
 
 [source,nodejs]
@@ -229,7 +229,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_AttributeType_asValueasValue__:_Value]
+[#_AttributeType_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -250,7 +250,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_AttributeType_deletedelete_transaction_:_Promise_void]
+[#_AttributeType_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -280,7 +280,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.delete(transaction)
 ----
 
-[#_AttributeType_equalsequals_concept_:_boolean]
+[#_AttributeType_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -303,7 +303,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_AttributeType_getget_transaction__value_:_Promise_Attribute]
+[#_AttributeType_get__transaction_TypeDBTransaction__value_Value]
 ==== get
 
 [source,nodejs]
@@ -334,7 +334,7 @@ a| `value` a| ``Attribute``’s value a| `Value`
 attribute = attributeType.get(transaction, value)
 ----
 
-[#_AttributeType_getBooleangetBoolean_transaction__value_:_Promise_Attribute]
+[#_AttributeType_getBoolean__transaction_TypeDBTransaction__value_boolean]
 ==== getBoolean
 
 [source,nodejs]
@@ -365,7 +365,7 @@ a| `value` a| ``Attribute``’s value a| `boolean`
 attribute = attributeType.get(transaction, value)
 ----
 
-[#_AttributeType_getDateTimegetDateTime_transaction__value_:_Promise_Attribute]
+[#_AttributeType_getDateTime__transaction_TypeDBTransaction__value_Date]
 ==== getDateTime
 
 [source,nodejs]
@@ -396,7 +396,7 @@ a| `value` a| ``Attribute``’s value a| `Date`
 attribute = attributeType.get(transaction, value)
 ----
 
-[#_AttributeType_getDoublegetDouble_transaction__value_:_Promise_Attribute]
+[#_AttributeType_getDouble__transaction_TypeDBTransaction__value_number]
 ==== getDouble
 
 [source,nodejs]
@@ -427,7 +427,7 @@ a| `value` a| ``Attribute``’s value a| `number`
 attribute = attributeType.get(transaction, value)
 ----
 
-[#_AttributeType_getInstancesgetInstances_transaction__transitivity_:_Stream_Attribute]
+[#_AttributeType_getInstances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getInstances
 
 [source,nodejs]
@@ -458,7 +458,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 attributeType.getInstances(transaction) attributeType.getInstances(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_getInstancesgetInstances_transaction_:_Stream_Attribute]
+[#_AttributeType_getInstances__transaction_TypeDBTransaction]
 ==== getInstances
 
 [source,nodejs]
@@ -488,7 +488,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getInstances(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_getLonggetLong_transaction__value_:_Promise_Attribute]
+[#_AttributeType_getLong__transaction_TypeDBTransaction__value_number]
 ==== getLong
 
 [source,nodejs]
@@ -519,7 +519,7 @@ a| `value` a| ``Attribute``’s value a| `number`
 attribute = attributeType.get(transaction, value)
 ----
 
-[#_AttributeType_getOwnersgetOwners_transaction__annotations__transitivity_:_Stream_ThingType]
+[#_AttributeType_getOwners__transaction_TypeDBTransaction__annotations_Annotation____transitivity_Transitivity]
 ==== getOwners
 
 [source,nodejs]
@@ -551,7 +551,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited owners
 attributeType.getOwners(transaction) attributeType.getOwners(transaction, [Annotation.UNIQUE]) attributeType.getOwners(transaction, Transitivity.TRANSITIVE) attributeType.getOwners(transaction, [Annotation.UNIQUE], Transitivity.TRANSITIVE)
 ----
 
-[#_AttributeType_getOwnersgetOwners_transaction_:_Stream_ThingType]
+[#_AttributeType_getOwners__transaction_TypeDBTransaction]
 ==== getOwners
 
 [source,nodejs]
@@ -574,7 +574,7 @@ a| `transaction` a|  a| `TypeDBTransaction`
 .Returns
 `Stream<ThingType>`
 
-[#_AttributeType_getOwnersgetOwners_transaction__annotations_:_Stream_ThingType]
+[#_AttributeType_getOwners__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getOwners
 
 [source,nodejs]
@@ -598,7 +598,7 @@ a| `annotations` a|  a| `Annotation[]`
 .Returns
 `Stream<ThingType>`
 
-[#_AttributeType_getOwnersgetOwners_transaction__transitivity_:_Stream_ThingType]
+[#_AttributeType_getOwners__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getOwners
 
 [source,nodejs]
@@ -622,7 +622,7 @@ a| `transitivity` a|  a| `Transitivity`
 .Returns
 `Stream<ThingType>`
 
-[#_AttributeType_getOwnsgetOwns_transaction_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction]
 ==== getOwns
 
 [source,nodejs]
@@ -652,7 +652,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsgetOwns_transaction__valueType_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction__valueType_ValueType]
 ==== getOwns
 
 [source,nodejs]
@@ -683,7 +683,7 @@ a| `valueType` a| If specified, only attribute types of this ``ValueType`` will 
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsgetOwns_transaction__annotations_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -714,7 +714,7 @@ a| `annotations` a| If specified, only attribute types of this ``ValueType`` wil
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsgetOwns_transaction__valueType__annotations_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -746,7 +746,7 @@ a| `annotations` a| Only retrieve attribute types owned with annotations. a| `An
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsgetOwns_transaction__transitivity_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -777,7 +777,7 @@ a| `transitivity` a| If specified, only attribute types of this ``ValueType`` wi
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsgetOwns_transaction__valueType__transitivity_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -809,7 +809,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsgetOwns_transaction__annotations__transitivity_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -841,7 +841,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsgetOwns_transaction__valueType__annotations__transitivity_:_Stream_AttributeType]
+[#_AttributeType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -874,7 +874,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited owners
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_AttributeType_getOwnsOverriddengetOwnsOverridden_transaction__attributeType_:_Promise_AttributeType]
+[#_AttributeType_getOwnsOverridden__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getOwnsOverridden
 
 [source,nodejs]
@@ -905,7 +905,7 @@ a| `attributeType` a| The ``AttributeType`` that overrides requested ``Attribute
 thingType.getOwnsOverridden(transaction, attributeType)
 ----
 
-[#_AttributeType_getPlaysgetPlays_transaction_:_Stream_RoleType]
+[#_AttributeType_getPlays__transaction_TypeDBTransaction]
 ==== getPlays
 
 [source,nodejs]
@@ -935,7 +935,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_getPlaysgetPlays_transaction__transitivity_:_Stream_RoleType]
+[#_AttributeType_getPlays__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getPlays
 
 [source,nodejs]
@@ -966,7 +966,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_getPlaysOverriddengetPlaysOverridden_transaction__role_:_Promise_RoleType]
+[#_AttributeType_getPlaysOverridden__transaction_TypeDBTransaction__role_RoleType]
 ==== getPlaysOverridden
 
 [source,nodejs]
@@ -997,7 +997,7 @@ a| `role` a| The ``RoleType`` that overrides an inherited role a| `RoleType`
 thingType.getPlaysOverridden(transaction, role)
 ----
 
-[#_AttributeType_getRegexgetRegex_transaction_:_Promise_string]
+[#_AttributeType_getRegex__transaction_TypeDBTransaction]
 ==== getRegex
 
 [source,nodejs]
@@ -1027,7 +1027,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 attributeType.getRegex(transaction)
 ----
 
-[#_AttributeType_getStringgetString_transaction__value_:_Promise_Attribute]
+[#_AttributeType_getString__transaction_TypeDBTransaction__value_string]
 ==== getString
 
 [source,nodejs]
@@ -1058,7 +1058,7 @@ a| `value` a| ``Attribute``’s value a| `string`
 attribute = attributeType.get(transaction, value)
 ----
 
-[#_AttributeType_getSubtypesgetSubtypes_transaction_:_Stream_AttributeType]
+[#_AttributeType_getSubtypes__transaction_TypeDBTransaction]
 ==== getSubtypes
 
 [source,nodejs]
@@ -1088,7 +1088,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSubtypes(transaction)
 ----
 
-[#_AttributeType_getSubtypesgetSubtypes_transaction__valueType_:_Stream_AttributeType]
+[#_AttributeType_getSubtypes__transaction_TypeDBTransaction__valueType_ValueType]
 ==== getSubtypes
 
 [source,nodejs]
@@ -1119,7 +1119,7 @@ a| `valueType` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtypes, 
 thingType.getSubtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_getSubtypesgetSubtypes_transaction__transitivity_:_Stream_AttributeType]
+[#_AttributeType_getSubtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getSubtypes
 
 [source,nodejs]
@@ -1143,7 +1143,7 @@ a| `transitivity` a|  a| `Transitivity`
 .Returns
 `Stream<AttributeType>`
 
-[#_AttributeType_getSubtypesgetSubtypes_transaction__valueType__transitivity_:_Stream_AttributeType]
+[#_AttributeType_getSubtypes__transaction_TypeDBTransaction__valueType_ValueType__transitivity_Transitivity]
 ==== getSubtypes
 
 [source,nodejs]
@@ -1168,7 +1168,7 @@ a| `transitivity` a|  a| `Transitivity`
 .Returns
 `Stream<AttributeType>`
 
-[#_AttributeType_getSupertypegetSupertype_transaction_:_Promise_AttributeType]
+[#_AttributeType_getSupertype__transaction_TypeDBTransaction]
 ==== getSupertype
 
 [source,nodejs]
@@ -1198,7 +1198,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertype(transaction)
 ----
 
-[#_AttributeType_getSupertypesgetSupertypes_transaction_:_Stream_AttributeType]
+[#_AttributeType_getSupertypes__transaction_TypeDBTransaction]
 ==== getSupertypes
 
 [source,nodejs]
@@ -1228,7 +1228,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertypes(transaction)
 ----
 
-[#_AttributeType_getSyntaxgetSyntax_transaction_:_Promise_string]
+[#_AttributeType_getSyntax__transaction_TypeDBTransaction]
 ==== getSyntax
 
 [source,nodejs]
@@ -1258,7 +1258,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSyntax(transaction)
 ----
 
-[#_AttributeType_isAttributeisAttribute__:_boolean]
+[#_AttributeType_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -1279,7 +1279,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_AttributeType_isAttributeTypeisAttributeType__:_boolean]
+[#_AttributeType_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -1300,7 +1300,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_AttributeType_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_AttributeType_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -1323,7 +1323,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 .Returns
 `Promise<boolean>`
 
-[#_AttributeType_isEntityisEntity__:_boolean]
+[#_AttributeType_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -1344,7 +1344,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_AttributeType_isEntityTypeisEntityType__:_boolean]
+[#_AttributeType_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -1365,7 +1365,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_AttributeType_isRelationisRelation__:_boolean]
+[#_AttributeType_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -1386,7 +1386,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_AttributeType_isRelationTypeisRelationType__:_boolean]
+[#_AttributeType_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -1407,7 +1407,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_AttributeType_isRoleTypeisRoleType__:_boolean]
+[#_AttributeType_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -1428,7 +1428,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_AttributeType_isThingisThing__:_boolean]
+[#_AttributeType_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -1449,7 +1449,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_AttributeType_isThingTypeisThingType__:_boolean]
+[#_AttributeType_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -1470,7 +1470,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_AttributeType_isTypeisType__:_boolean]
+[#_AttributeType_isType__]
 ==== isType
 
 [source,nodejs]
@@ -1491,7 +1491,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_AttributeType_isValueisValue__:_boolean]
+[#_AttributeType_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -1512,7 +1512,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_AttributeType_putput_transaction__value_:_Promise_Attribute]
+[#_AttributeType_put__transaction_TypeDBTransaction__value_Value]
 ==== put
 
 [source,nodejs]
@@ -1543,7 +1543,7 @@ a| `value` a| New ``Attribute``’s value a| `Value`
 attribute = attributeType.put(transaction, value)
 ----
 
-[#_AttributeType_putBooleanputBoolean_transaction__value_:_Promise_Attribute]
+[#_AttributeType_putBoolean__transaction_TypeDBTransaction__value_boolean]
 ==== putBoolean
 
 [source,nodejs]
@@ -1574,7 +1574,7 @@ a| `value` a| New ``Attribute``’s value a| `boolean`
 attribute = attributeType.put(transaction, value)
 ----
 
-[#_AttributeType_putDateTimeputDateTime_transaction__value_:_Promise_Attribute]
+[#_AttributeType_putDateTime__transaction_TypeDBTransaction__value_Date]
 ==== putDateTime
 
 [source,nodejs]
@@ -1605,7 +1605,7 @@ a| `value` a| New ``Attribute``’s value a| `Date`
 attribute = attributeType.put(transaction, value)
 ----
 
-[#_AttributeType_putDoubleputDouble_transaction__value_:_Promise_Attribute]
+[#_AttributeType_putDouble__transaction_TypeDBTransaction__value_number]
 ==== putDouble
 
 [source,nodejs]
@@ -1636,7 +1636,7 @@ a| `value` a| New ``Attribute``’s value a| `number`
 attribute = attributeType.put(transaction, value)
 ----
 
-[#_AttributeType_putLongputLong_transaction__value_:_Promise_Attribute]
+[#_AttributeType_putLong__transaction_TypeDBTransaction__value_number]
 ==== putLong
 
 [source,nodejs]
@@ -1667,7 +1667,7 @@ a| `value` a| New ``Attribute``’s value a| `number`
 attribute = attributeType.put(transaction, value)
 ----
 
-[#_AttributeType_putStringputString_transaction__value_:_Promise_Attribute]
+[#_AttributeType_putString__transaction_TypeDBTransaction__value_string]
 ==== putString
 
 [source,nodejs]
@@ -1698,7 +1698,7 @@ a| `value` a| New ``Attribute``’s value a| `string`
 attribute = attributeType.put(transaction, value)
 ----
 
-[#_AttributeType_setAbstractsetAbstract_transaction_:_Promise_void]
+[#_AttributeType_setAbstract__transaction_TypeDBTransaction]
 ==== setAbstract
 
 [source,nodejs]
@@ -1728,7 +1728,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.setAbstract(transaction)
 ----
 
-[#_AttributeType_setLabelsetLabel_transaction__label_:_Promise_void]
+[#_AttributeType_setLabel__transaction_TypeDBTransaction__label_string]
 ==== setLabel
 
 [source,nodejs]
@@ -1759,7 +1759,7 @@ a| `label` a| The new ``Label`` to be given to the type. a| `string`
 type.setLabel(transaction, label)
 ----
 
-[#_AttributeType_setOwnssetOwns_transaction__attributeType_:_Promise_void]
+[#_AttributeType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1790,7 +1790,7 @@ a| `attributeType` a| The ``AttributeType`` to be owned by the instances of this
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_AttributeType_setOwnssetOwns_transaction__attributeType__annotations_:_Promise_void]
+[#_AttributeType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1822,7 +1822,7 @@ a| `annotations` a| The ``AttributeType`` that this attribute ownership override
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_AttributeType_setOwnssetOwns_transaction__attributeType__overriddenType_:_Promise_void]
+[#_AttributeType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1854,7 +1854,7 @@ a| `overriddenType` a| The ``AttributeType`` that this attribute ownership overr
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_AttributeType_setOwnssetOwns_transaction__attributeType__overriddenType__annotations_:_Promise_void]
+[#_AttributeType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1887,7 +1887,7 @@ a| `annotations` a| Adds annotations to the ownership. a| `Annotation[]`
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_AttributeType_setPlayssetPlays_transaction__role_:_Promise_void]
+[#_AttributeType_setPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1918,7 +1918,7 @@ a| `role` a| The role to be played by the instances of this type a| `RoleType`
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_AttributeType_setPlayssetPlays_transaction__role__overriddenType_:_Promise_void]
+[#_AttributeType_setPlays__transaction_TypeDBTransaction__role_RoleType__overriddenType_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1950,7 +1950,7 @@ a| `overriddenType` a| The role type that this role overrides, if applicable a| 
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_AttributeType_setRegexsetRegex_transaction__regex_:_Promise_void]
+[#_AttributeType_setRegex__transaction_TypeDBTransaction__regex_string]
 ==== setRegex
 
 [source,nodejs]
@@ -1981,7 +1981,7 @@ a| `regex` a| Regular expression a| `string`
 attributeType.setRegex(transaction, regex)
 ----
 
-[#_AttributeType_setSupertypesetSupertype_transaction__type_:_Promise_void]
+[#_AttributeType_setSupertype__transaction_TypeDBTransaction__type_AttributeType]
 ==== setSupertype
 
 [source,nodejs]
@@ -2005,7 +2005,7 @@ a| `type` a|  a| `AttributeType`
 .Returns
 `Promise<void>`
 
-[#_AttributeType_unsetAbstractunsetAbstract_transaction_:_Promise_void]
+[#_AttributeType_unsetAbstract__transaction_TypeDBTransaction]
 ==== unsetAbstract
 
 [source,nodejs]
@@ -2035,7 +2035,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.unsetAbstract(transaction)
 ----
 
-[#_AttributeType_unsetOwnsunsetOwns_transaction__attributeType_:_Promise_void]
+[#_AttributeType_unsetOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== unsetOwns
 
 [source,nodejs]
@@ -2066,7 +2066,7 @@ a| `attributeType` a| The ``AttributeType`` to not be owned by the type. a| `Att
 thingType.unsetOwns(transaction, attributeType)
 ----
 
-[#_AttributeType_unsetPlaysunsetPlays_transaction__role_:_Promise_void]
+[#_AttributeType_unsetPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== unsetPlays
 
 [source,nodejs]
@@ -2097,7 +2097,7 @@ a| `role` a| The role to not be played by the instances of this type. a| `RoleTy
 thingType.unsetPlays(transaction, role)
 ----
 
-[#_AttributeType_unsetRegexunsetRegex_transaction_:_Promise_void]
+[#_AttributeType_unsetRegex__transaction_TypeDBTransaction]
 ==== unsetRegex
 
 [source,nodejs]

--- a/nodejs/docs/schema/EntityType.adoc
+++ b/nodejs/docs/schema/EntityType.adoc
@@ -17,7 +17,7 @@ a| `NAME`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_EntityType_asAttributeasAttribute__:_Attribute]
+[#_EntityType_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -38,7 +38,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_EntityType_asAttributeTypeasAttributeType__:_AttributeType]
+[#_EntityType_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -59,7 +59,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_EntityType_asEntityasEntity__:_Entity]
+[#_EntityType_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -80,7 +80,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_EntityType_asEntityTypeasEntityType__:_EntityType]
+[#_EntityType_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -101,7 +101,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_EntityType_asRelationasRelation__:_Relation]
+[#_EntityType_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -122,7 +122,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_EntityType_asRelationTypeasRelationType__:_RelationType]
+[#_EntityType_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -143,7 +143,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_EntityType_asRoleTypeasRoleType__:_RoleType]
+[#_EntityType_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -164,7 +164,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_EntityType_asThingasThing__:_Thing]
+[#_EntityType_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -185,7 +185,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_EntityType_asThingTypeasThingType__:_ThingType]
+[#_EntityType_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -206,7 +206,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_EntityType_asTypeasType__:_Type]
+[#_EntityType_asType__]
 ==== asType
 
 [source,nodejs]
@@ -227,7 +227,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_EntityType_asValueasValue__:_Value]
+[#_EntityType_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -248,7 +248,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_EntityType_createcreate_transaction_:_Promise_Entity]
+[#_EntityType_create__transaction_TypeDBTransaction]
 ==== create
 
 [source,nodejs]
@@ -271,7 +271,7 @@ a| `transaction` a|  a| `TypeDBTransaction`
 .Returns
 `Promise<Entity>`
 
-[#_EntityType_deletedelete_transaction_:_Promise_void]
+[#_EntityType_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -301,7 +301,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.delete(transaction)
 ----
 
-[#_EntityType_equalsequals_concept_:_boolean]
+[#_EntityType_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -324,7 +324,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_EntityType_getInstancesgetInstances_transaction_:_Stream_Entity]
+[#_EntityType_getInstances__transaction_TypeDBTransaction]
 ==== getInstances
 
 [source,nodejs]
@@ -354,7 +354,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getInstances(transaction)
 ----
 
-[#_EntityType_getInstancesgetInstances_transaction__transitivity_:_Stream_Entity]
+[#_EntityType_getInstances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getInstances
 
 [source,nodejs]
@@ -385,7 +385,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect instanc
 thingType.getInstances(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction]
 ==== getOwns
 
 [source,nodejs]
@@ -415,7 +415,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction__valueType_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction__valueType_ValueType]
 ==== getOwns
 
 [source,nodejs]
@@ -446,7 +446,7 @@ a| `valueType` a| If specified, only attribute types of this ``ValueType`` will 
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction__annotations_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -477,7 +477,7 @@ a| `annotations` a| If specified, only attribute types of this ``ValueType`` wil
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction__valueType__annotations_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -509,7 +509,7 @@ a| `annotations` a| Only retrieve attribute types owned with annotations. a| `An
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction__transitivity_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -540,7 +540,7 @@ a| `transitivity` a| If specified, only attribute types of this ``ValueType`` wi
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction__valueType__transitivity_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -572,7 +572,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction__annotations__transitivity_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -604,7 +604,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsgetOwns_transaction__valueType__annotations__transitivity_:_Stream_AttributeType]
+[#_EntityType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -637,7 +637,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited owners
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_EntityType_getOwnsOverriddengetOwnsOverridden_transaction__attributeType_:_Promise_AttributeType]
+[#_EntityType_getOwnsOverridden__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getOwnsOverridden
 
 [source,nodejs]
@@ -668,7 +668,7 @@ a| `attributeType` a| The ``AttributeType`` that overrides requested ``Attribute
 thingType.getOwnsOverridden(transaction, attributeType)
 ----
 
-[#_EntityType_getPlaysgetPlays_transaction_:_Stream_RoleType]
+[#_EntityType_getPlays__transaction_TypeDBTransaction]
 ==== getPlays
 
 [source,nodejs]
@@ -698,7 +698,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_EntityType_getPlaysgetPlays_transaction__transitivity_:_Stream_RoleType]
+[#_EntityType_getPlays__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getPlays
 
 [source,nodejs]
@@ -729,7 +729,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_EntityType_getPlaysOverriddengetPlaysOverridden_transaction__role_:_Promise_RoleType]
+[#_EntityType_getPlaysOverridden__transaction_TypeDBTransaction__role_RoleType]
 ==== getPlaysOverridden
 
 [source,nodejs]
@@ -760,7 +760,7 @@ a| `role` a| The ``RoleType`` that overrides an inherited role a| `RoleType`
 thingType.getPlaysOverridden(transaction, role)
 ----
 
-[#_EntityType_getSubtypesgetSubtypes_transaction_:_Stream_EntityType]
+[#_EntityType_getSubtypes__transaction_TypeDBTransaction]
 ==== getSubtypes
 
 [source,nodejs]
@@ -790,7 +790,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSubtypes(transaction)
 ----
 
-[#_EntityType_getSubtypesgetSubtypes_transaction__transitivity_:_Stream_EntityType]
+[#_EntityType_getSubtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getSubtypes
 
 [source,nodejs]
@@ -821,7 +821,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 thingType.getSubtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_EntityType_getSupertypegetSupertype_transaction_:_Promise_EntityType]
+[#_EntityType_getSupertype__transaction_TypeDBTransaction]
 ==== getSupertype
 
 [source,nodejs]
@@ -851,7 +851,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertype(transaction)
 ----
 
-[#_EntityType_getSupertypesgetSupertypes_transaction_:_Stream_EntityType]
+[#_EntityType_getSupertypes__transaction_TypeDBTransaction]
 ==== getSupertypes
 
 [source,nodejs]
@@ -881,7 +881,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertypes(transaction)
 ----
 
-[#_EntityType_getSyntaxgetSyntax_transaction_:_Promise_string]
+[#_EntityType_getSyntax__transaction_TypeDBTransaction]
 ==== getSyntax
 
 [source,nodejs]
@@ -911,7 +911,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSyntax(transaction)
 ----
 
-[#_EntityType_isAttributeisAttribute__:_boolean]
+[#_EntityType_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -932,7 +932,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_EntityType_isAttributeTypeisAttributeType__:_boolean]
+[#_EntityType_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -953,7 +953,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_EntityType_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_EntityType_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -976,7 +976,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 .Returns
 `Promise<boolean>`
 
-[#_EntityType_isEntityisEntity__:_boolean]
+[#_EntityType_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -997,7 +997,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_EntityType_isEntityTypeisEntityType__:_boolean]
+[#_EntityType_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -1018,7 +1018,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_EntityType_isRelationisRelation__:_boolean]
+[#_EntityType_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -1039,7 +1039,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_EntityType_isRelationTypeisRelationType__:_boolean]
+[#_EntityType_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -1060,7 +1060,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_EntityType_isRoleTypeisRoleType__:_boolean]
+[#_EntityType_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -1081,7 +1081,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_EntityType_isThingisThing__:_boolean]
+[#_EntityType_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -1102,7 +1102,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_EntityType_isThingTypeisThingType__:_boolean]
+[#_EntityType_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -1123,7 +1123,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_EntityType_isTypeisType__:_boolean]
+[#_EntityType_isType__]
 ==== isType
 
 [source,nodejs]
@@ -1144,7 +1144,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_EntityType_isValueisValue__:_boolean]
+[#_EntityType_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -1165,7 +1165,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_EntityType_setAbstractsetAbstract_transaction_:_Promise_void]
+[#_EntityType_setAbstract__transaction_TypeDBTransaction]
 ==== setAbstract
 
 [source,nodejs]
@@ -1195,7 +1195,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.setAbstract(transaction)
 ----
 
-[#_EntityType_setLabelsetLabel_transaction__label_:_Promise_void]
+[#_EntityType_setLabel__transaction_TypeDBTransaction__label_string]
 ==== setLabel
 
 [source,nodejs]
@@ -1226,7 +1226,7 @@ a| `label` a| The new ``Label`` to be given to the type. a| `string`
 type.setLabel(transaction, label)
 ----
 
-[#_EntityType_setOwnssetOwns_transaction__attributeType_:_Promise_void]
+[#_EntityType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1257,7 +1257,7 @@ a| `attributeType` a| The ``AttributeType`` to be owned by the instances of this
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_EntityType_setOwnssetOwns_transaction__attributeType__annotations_:_Promise_void]
+[#_EntityType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1289,7 +1289,7 @@ a| `annotations` a| The ``AttributeType`` that this attribute ownership override
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_EntityType_setOwnssetOwns_transaction__attributeType__overriddenType_:_Promise_void]
+[#_EntityType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1321,7 +1321,7 @@ a| `overriddenType` a| The ``AttributeType`` that this attribute ownership overr
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_EntityType_setOwnssetOwns_transaction__attributeType__overriddenType__annotations_:_Promise_void]
+[#_EntityType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1354,7 +1354,7 @@ a| `annotations` a| Adds annotations to the ownership. a| `Annotation[]`
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_EntityType_setPlayssetPlays_transaction__role_:_Promise_void]
+[#_EntityType_setPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1385,7 +1385,7 @@ a| `role` a| The role to be played by the instances of this type a| `RoleType`
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_EntityType_setPlayssetPlays_transaction__role__overriddenType_:_Promise_void]
+[#_EntityType_setPlays__transaction_TypeDBTransaction__role_RoleType__overriddenType_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1417,7 +1417,7 @@ a| `overriddenType` a| The role type that this role overrides, if applicable a| 
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_EntityType_setSupertypesetSupertype_transaction__superEntityType_:_Promise_void]
+[#_EntityType_setSupertype__transaction_TypeDBTransaction__superEntityType_EntityType]
 ==== setSupertype
 
 [source,nodejs]
@@ -1441,7 +1441,7 @@ a| `superEntityType` a|  a| `EntityType`
 .Returns
 `Promise<void>`
 
-[#_EntityType_unsetAbstractunsetAbstract_transaction_:_Promise_void]
+[#_EntityType_unsetAbstract__transaction_TypeDBTransaction]
 ==== unsetAbstract
 
 [source,nodejs]
@@ -1471,7 +1471,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.unsetAbstract(transaction)
 ----
 
-[#_EntityType_unsetOwnsunsetOwns_transaction__attributeType_:_Promise_void]
+[#_EntityType_unsetOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== unsetOwns
 
 [source,nodejs]
@@ -1502,7 +1502,7 @@ a| `attributeType` a| The ``AttributeType`` to not be owned by the type. a| `Att
 thingType.unsetOwns(transaction, attributeType)
 ----
 
-[#_EntityType_unsetPlaysunsetPlays_transaction__role_:_Promise_void]
+[#_EntityType_unsetPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== unsetPlays
 
 [source,nodejs]

--- a/nodejs/docs/schema/Label.adoc
+++ b/nodejs/docs/schema/Label.adoc
@@ -6,7 +6,7 @@ A ``Label`` holds the uniquely identifying name of a type.
 It consists of an optional 'scope', and a 'name', represented "scope:name". The scope is used only used to distinguish between role-types of the same name declared in different relation types.
 
 // tag::methods[]
-[#__name]
+[#_Label__name__]
 ====  name
 
 [source,nodejs]
@@ -20,7 +20,7 @@ Returns the name part of the label.
 .Returns
 `string`
 
-[#__scope]
+[#_Label__scope__]
 ====  scope
 
 [source,nodejs]
@@ -34,7 +34,7 @@ Returns the (possibly null) scope part of the label.
 .Returns
 `string`
 
-[#__scopedName]
+[#_Label__scopedName__]
 ====  scopedName
 
 [source,nodejs]
@@ -48,7 +48,7 @@ Returns the string representation of the scoped name.
 .Returns
 `string`
 
-[#_Label_equalsequals_that_:_boolean]
+[#_Label_equals__that_Label]
 ==== equals
 
 [source,nodejs]
@@ -71,7 +71,7 @@ a| `that` a| The label to compare to. a| `Label`
 .Returns
 `boolean`
 
-[#_Label_toStringtoString__:_string]
+[#_Label_toString__]
 ==== toString
 
 [source,nodejs]

--- a/nodejs/docs/schema/RelationType.adoc
+++ b/nodejs/docs/schema/RelationType.adoc
@@ -17,7 +17,7 @@ a| `NAME`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_RelationType_asAttributeasAttribute__:_Attribute]
+[#_RelationType_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -38,7 +38,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_RelationType_asAttributeTypeasAttributeType__:_AttributeType]
+[#_RelationType_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -59,7 +59,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_RelationType_asEntityasEntity__:_Entity]
+[#_RelationType_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -80,7 +80,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_RelationType_asEntityTypeasEntityType__:_EntityType]
+[#_RelationType_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -101,7 +101,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_RelationType_asRelationasRelation__:_Relation]
+[#_RelationType_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -122,7 +122,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_RelationType_asRelationTypeasRelationType__:_RelationType]
+[#_RelationType_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -143,7 +143,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_RelationType_asRoleTypeasRoleType__:_RoleType]
+[#_RelationType_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -164,7 +164,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_RelationType_asThingasThing__:_Thing]
+[#_RelationType_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -185,7 +185,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_RelationType_asThingTypeasThingType__:_ThingType]
+[#_RelationType_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -206,7 +206,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_RelationType_asTypeasType__:_Type]
+[#_RelationType_asType__]
 ==== asType
 
 [source,nodejs]
@@ -227,7 +227,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_RelationType_asValueasValue__:_Value]
+[#_RelationType_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -248,7 +248,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_RelationType_createcreate_transaction_:_Promise_Relation]
+[#_RelationType_create__transaction_TypeDBTransaction]
 ==== create
 
 [source,nodejs]
@@ -278,7 +278,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 relationType.create(transaction)
 ----
 
-[#_RelationType_deletedelete_transaction_:_Promise_void]
+[#_RelationType_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -308,7 +308,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.delete(transaction)
 ----
 
-[#_RelationType_equalsequals_concept_:_boolean]
+[#_RelationType_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -331,7 +331,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_RelationType_getInstancesgetInstances_transaction_:_Stream_Relation]
+[#_RelationType_getInstances__transaction_TypeDBTransaction]
 ==== getInstances
 
 [source,nodejs]
@@ -361,7 +361,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getInstances(transaction)
 ----
 
-[#_RelationType_getInstancesgetInstances_transaction__transitivity_:_Stream_Relation]
+[#_RelationType_getInstances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getInstances
 
 [source,nodejs]
@@ -392,7 +392,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect instanc
 thingType.getInstances(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction]
 ==== getOwns
 
 [source,nodejs]
@@ -422,7 +422,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction__valueType_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction__valueType_ValueType]
 ==== getOwns
 
 [source,nodejs]
@@ -453,7 +453,7 @@ a| `valueType` a| If specified, only attribute types of this ``ValueType`` will 
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction__annotations_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -484,7 +484,7 @@ a| `annotations` a| If specified, only attribute types of this ``ValueType`` wil
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction__valueType__annotations_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -516,7 +516,7 @@ a| `annotations` a| Only retrieve attribute types owned with annotations. a| `An
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction__transitivity_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -547,7 +547,7 @@ a| `transitivity` a| If specified, only attribute types of this ``ValueType`` wi
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction__valueType__transitivity_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -579,7 +579,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction__annotations__transitivity_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -611,7 +611,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsgetOwns_transaction__valueType__annotations__transitivity_:_Stream_AttributeType]
+[#_RelationType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -644,7 +644,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited owners
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_RelationType_getOwnsOverriddengetOwnsOverridden_transaction__attributeType_:_Promise_AttributeType]
+[#_RelationType_getOwnsOverridden__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getOwnsOverridden
 
 [source,nodejs]
@@ -675,7 +675,7 @@ a| `attributeType` a| The ``AttributeType`` that overrides requested ``Attribute
 thingType.getOwnsOverridden(transaction, attributeType)
 ----
 
-[#_RelationType_getPlaysgetPlays_transaction_:_Stream_RoleType]
+[#_RelationType_getPlays__transaction_TypeDBTransaction]
 ==== getPlays
 
 [source,nodejs]
@@ -705,7 +705,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_RelationType_getPlaysgetPlays_transaction__transitivity_:_Stream_RoleType]
+[#_RelationType_getPlays__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getPlays
 
 [source,nodejs]
@@ -736,7 +736,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_RelationType_getPlaysOverriddengetPlaysOverridden_transaction__role_:_Promise_RoleType]
+[#_RelationType_getPlaysOverridden__transaction_TypeDBTransaction__role_RoleType]
 ==== getPlaysOverridden
 
 [source,nodejs]
@@ -767,7 +767,7 @@ a| `role` a| The ``RoleType`` that overrides an inherited role a| `RoleType`
 thingType.getPlaysOverridden(transaction, role)
 ----
 
-[#_RelationType_getRelatesgetRelates_transaction_:_Stream_RoleType]
+[#_RelationType_getRelates__transaction_TypeDBTransaction]
 ==== getRelates
 
 [source,nodejs]
@@ -790,7 +790,7 @@ a| `transaction` a|  a| `TypeDBTransaction`
 .Returns
 `Stream<RoleType>`
 
-[#_RelationType_getRelatesgetRelates_transaction__transitivity_:_Stream_RoleType]
+[#_RelationType_getRelates__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getRelates
 
 [source,nodejs]
@@ -821,7 +821,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited relate
 relationType.getRelates(transaction, roleLabel, transitivity)
 ----
 
-[#_RelationType_getRelatesForRoleLabelgetRelatesForRoleLabel_transaction__roleLabel_:_Promise_RoleType]
+[#_RelationType_getRelatesForRoleLabel__transaction_TypeDBTransaction__roleLabel_string]
 ==== getRelatesForRoleLabel
 
 [source,nodejs]
@@ -845,7 +845,7 @@ a| `roleLabel` a|  a| `string`
 .Returns
 `Promise<RoleType>`
 
-[#_RelationType_getRelatesOverriddengetRelatesOverridden_transaction__roleLabel_:_Promise_RoleType]
+[#_RelationType_getRelatesOverridden__transaction_TypeDBTransaction__roleLabel_string]
 ==== getRelatesOverridden
 
 [source,nodejs]
@@ -876,7 +876,7 @@ a| `roleLabel` a| Label of the role that overrides an inherited role a| `string`
 relationType.getRelatesOverridden(transaction, roleLabel)
 ----
 
-[#_RelationType_getSubtypesgetSubtypes_transaction_:_Stream_RelationType]
+[#_RelationType_getSubtypes__transaction_TypeDBTransaction]
 ==== getSubtypes
 
 [source,nodejs]
@@ -906,7 +906,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSubtypes(transaction)
 ----
 
-[#_RelationType_getSubtypesgetSubtypes_transaction__transitivity_:_Stream_RelationType]
+[#_RelationType_getSubtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getSubtypes
 
 [source,nodejs]
@@ -937,7 +937,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 thingType.getSubtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_RelationType_getSupertypegetSupertype_transaction_:_Promise_RelationType]
+[#_RelationType_getSupertype__transaction_TypeDBTransaction]
 ==== getSupertype
 
 [source,nodejs]
@@ -967,7 +967,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertype(transaction)
 ----
 
-[#_RelationType_getSupertypesgetSupertypes_transaction_:_Stream_RelationType]
+[#_RelationType_getSupertypes__transaction_TypeDBTransaction]
 ==== getSupertypes
 
 [source,nodejs]
@@ -997,7 +997,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertypes(transaction)
 ----
 
-[#_RelationType_getSyntaxgetSyntax_transaction_:_Promise_string]
+[#_RelationType_getSyntax__transaction_TypeDBTransaction]
 ==== getSyntax
 
 [source,nodejs]
@@ -1027,7 +1027,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSyntax(transaction)
 ----
 
-[#_RelationType_isAttributeisAttribute__:_boolean]
+[#_RelationType_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -1048,7 +1048,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_RelationType_isAttributeTypeisAttributeType__:_boolean]
+[#_RelationType_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -1069,7 +1069,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_RelationType_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_RelationType_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -1092,7 +1092,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 .Returns
 `Promise<boolean>`
 
-[#_RelationType_isEntityisEntity__:_boolean]
+[#_RelationType_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -1113,7 +1113,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_RelationType_isEntityTypeisEntityType__:_boolean]
+[#_RelationType_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -1134,7 +1134,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_RelationType_isRelationisRelation__:_boolean]
+[#_RelationType_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -1155,7 +1155,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_RelationType_isRelationTypeisRelationType__:_boolean]
+[#_RelationType_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -1176,7 +1176,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_RelationType_isRoleTypeisRoleType__:_boolean]
+[#_RelationType_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -1197,7 +1197,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_RelationType_isThingisThing__:_boolean]
+[#_RelationType_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -1218,7 +1218,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_RelationType_isThingTypeisThingType__:_boolean]
+[#_RelationType_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -1239,7 +1239,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_RelationType_isTypeisType__:_boolean]
+[#_RelationType_isType__]
 ==== isType
 
 [source,nodejs]
@@ -1260,7 +1260,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_RelationType_isValueisValue__:_boolean]
+[#_RelationType_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -1281,7 +1281,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_RelationType_setAbstractsetAbstract_transaction_:_Promise_void]
+[#_RelationType_setAbstract__transaction_TypeDBTransaction]
 ==== setAbstract
 
 [source,nodejs]
@@ -1311,7 +1311,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.setAbstract(transaction)
 ----
 
-[#_RelationType_setLabelsetLabel_transaction__label_:_Promise_void]
+[#_RelationType_setLabel__transaction_TypeDBTransaction__label_string]
 ==== setLabel
 
 [source,nodejs]
@@ -1342,7 +1342,7 @@ a| `label` a| The new ``Label`` to be given to the type. a| `string`
 type.setLabel(transaction, label)
 ----
 
-[#_RelationType_setOwnssetOwns_transaction__attributeType_:_Promise_void]
+[#_RelationType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1373,7 +1373,7 @@ a| `attributeType` a| The ``AttributeType`` to be owned by the instances of this
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_RelationType_setOwnssetOwns_transaction__attributeType__annotations_:_Promise_void]
+[#_RelationType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1405,7 +1405,7 @@ a| `annotations` a| The ``AttributeType`` that this attribute ownership override
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_RelationType_setOwnssetOwns_transaction__attributeType__overriddenType_:_Promise_void]
+[#_RelationType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1437,7 +1437,7 @@ a| `overriddenType` a| The ``AttributeType`` that this attribute ownership overr
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_RelationType_setOwnssetOwns_transaction__attributeType__overriddenType__annotations_:_Promise_void]
+[#_RelationType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1470,7 +1470,7 @@ a| `annotations` a| Adds annotations to the ownership. a| `Annotation[]`
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_RelationType_setPlayssetPlays_transaction__role_:_Promise_void]
+[#_RelationType_setPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1501,7 +1501,7 @@ a| `role` a| The role to be played by the instances of this type a| `RoleType`
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_RelationType_setPlayssetPlays_transaction__role__overriddenType_:_Promise_void]
+[#_RelationType_setPlays__transaction_TypeDBTransaction__role_RoleType__overriddenType_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1533,7 +1533,7 @@ a| `overriddenType` a| The role type that this role overrides, if applicable a| 
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_RelationType_setRelatessetRelates_transaction__roleLabel__overriddenLabel?_:_Promise_void]
+[#_RelationType_setRelates__transaction_TypeDBTransaction__roleLabel_string__overriddenLabel_string]
 ==== setRelates
 
 [source,nodejs]
@@ -1565,7 +1565,7 @@ a| `overriddenLabel` a| The label being overridden, if applicable a| `string`
 relationType.setRelates(transaction, roleLabel) relationType.setRelates(transaction, roleLabel, overriddenLabel)
 ----
 
-[#_RelationType_setSupertypesetSupertype_transaction__type_:_Promise_void]
+[#_RelationType_setSupertype__transaction_TypeDBTransaction__type_RelationType]
 ==== setSupertype
 
 [source,nodejs]
@@ -1589,7 +1589,7 @@ a| `type` a|  a| `RelationType`
 .Returns
 `Promise<void>`
 
-[#_RelationType_unsetAbstractunsetAbstract_transaction_:_Promise_void]
+[#_RelationType_unsetAbstract__transaction_TypeDBTransaction]
 ==== unsetAbstract
 
 [source,nodejs]
@@ -1619,7 +1619,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.unsetAbstract(transaction)
 ----
 
-[#_RelationType_unsetOwnsunsetOwns_transaction__attributeType_:_Promise_void]
+[#_RelationType_unsetOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== unsetOwns
 
 [source,nodejs]
@@ -1650,7 +1650,7 @@ a| `attributeType` a| The ``AttributeType`` to not be owned by the type. a| `Att
 thingType.unsetOwns(transaction, attributeType)
 ----
 
-[#_RelationType_unsetPlaysunsetPlays_transaction__role_:_Promise_void]
+[#_RelationType_unsetPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== unsetPlays
 
 [source,nodejs]
@@ -1681,7 +1681,7 @@ a| `role` a| The role to not be played by the instances of this type. a| `RoleTy
 thingType.unsetPlays(transaction, role)
 ----
 
-[#_RelationType_unsetRelatesunsetRelates_transaction__roleLabel_:_Promise_void]
+[#_RelationType_unsetRelates__transaction_TypeDBTransaction__roleLabel_string]
 ==== unsetRelates
 
 [source,nodejs]

--- a/nodejs/docs/schema/RoleType.adoc
+++ b/nodejs/docs/schema/RoleType.adoc
@@ -19,7 +19,7 @@ a| `NAME`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_RoleType_asAttributeasAttribute__:_Attribute]
+[#_RoleType_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -40,7 +40,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_RoleType_asAttributeTypeasAttributeType__:_AttributeType]
+[#_RoleType_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -61,7 +61,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_RoleType_asEntityasEntity__:_Entity]
+[#_RoleType_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -82,7 +82,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_RoleType_asEntityTypeasEntityType__:_EntityType]
+[#_RoleType_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -103,7 +103,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_RoleType_asRelationasRelation__:_Relation]
+[#_RoleType_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -124,7 +124,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_RoleType_asRelationTypeasRelationType__:_RelationType]
+[#_RoleType_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -145,7 +145,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_RoleType_asRoleTypeasRoleType__:_RoleType]
+[#_RoleType_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -166,7 +166,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_RoleType_asThingasThing__:_Thing]
+[#_RoleType_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -187,7 +187,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_RoleType_asThingTypeasThingType__:_ThingType]
+[#_RoleType_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -208,7 +208,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_RoleType_asTypeasType__:_Type]
+[#_RoleType_asType__]
 ==== asType
 
 [source,nodejs]
@@ -229,7 +229,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_RoleType_asValueasValue__:_Value]
+[#_RoleType_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -250,7 +250,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_RoleType_deletedelete_transaction_:_Promise_void]
+[#_RoleType_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -280,7 +280,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.delete(transaction)
 ----
 
-[#_RoleType_equalsequals_concept_:_boolean]
+[#_RoleType_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -303,7 +303,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_RoleType_getPlayerInstancesgetPlayerInstances_transaction_:_Stream_Thing]
+[#_RoleType_getPlayerInstances__transaction_TypeDBTransaction]
 ==== getPlayerInstances
 
 [source,nodejs]
@@ -333,7 +333,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getPlayerInstances(transaction, transitivity)
 ----
 
-[#_RoleType_getPlayerInstancesgetPlayerInstances_transaction__transitivity_:_Stream_Thing]
+[#_RoleType_getPlayerInstances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getPlayerInstances
 
 [source,nodejs]
@@ -364,7 +364,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 roleType.getPlayerInstances(transaction, transitivity)
 ----
 
-[#_RoleType_getPlayerTypesgetPlayerTypes_transaction_:_Stream_ThingType]
+[#_RoleType_getPlayerTypes__transaction_TypeDBTransaction]
 ==== getPlayerTypes
 
 [source,nodejs]
@@ -394,7 +394,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getPlayerTypes(transaction, transitivity)
 ----
 
-[#_RoleType_getPlayerTypesgetPlayerTypes_transaction__transitivity_:_Stream_ThingType]
+[#_RoleType_getPlayerTypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getPlayerTypes
 
 [source,nodejs]
@@ -425,7 +425,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 roleType.getPlayerTypes(transaction, transitivity)
 ----
 
-[#_RoleType_getRelationInstancesgetRelationInstances_transaction_:_Stream_Relation]
+[#_RoleType_getRelationInstances__transaction_TypeDBTransaction]
 ==== getRelationInstances
 
 [source,nodejs]
@@ -455,7 +455,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getRelationInstances(transaction, transitivity)
 ----
 
-[#_RoleType_getRelationInstancesgetRelationInstances_transaction__transitivity_:_Stream_Relation]
+[#_RoleType_getRelationInstances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getRelationInstances
 
 [source,nodejs]
@@ -486,7 +486,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect relatio
 roleType.getRelationInstances(transaction, transitivity)
 ----
 
-[#_RoleType_getRelationTypegetRelationType_transaction_:_Promise_RelationType]
+[#_RoleType_getRelationType__transaction_TypeDBTransaction]
 ==== getRelationType
 
 [source,nodejs]
@@ -516,7 +516,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getRelationType(transaction)
 ----
 
-[#_RoleType_getRelationTypesgetRelationTypes_transaction_:_Stream_RelationType]
+[#_RoleType_getRelationTypes__transaction_TypeDBTransaction]
 ==== getRelationTypes
 
 [source,nodejs]
@@ -546,7 +546,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 roleType.getRelationTypes(transaction)
 ----
 
-[#_RoleType_getSubtypesgetSubtypes_transaction_:_Stream_RoleType]
+[#_RoleType_getSubtypes__transaction_TypeDBTransaction]
 ==== getSubtypes
 
 [source,nodejs]
@@ -576,7 +576,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSubtypes(transaction) type.getSubtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_RoleType_getSupertypegetSupertype_transaction_:_Promise_RoleType]
+[#_RoleType_getSupertype__transaction_TypeDBTransaction]
 ==== getSupertype
 
 [source,nodejs]
@@ -606,7 +606,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertype(transaction)
 ----
 
-[#_RoleType_getSupertypesgetSupertypes_transaction_:_Stream_RoleType]
+[#_RoleType_getSupertypes__transaction_TypeDBTransaction]
 ==== getSupertypes
 
 [source,nodejs]
@@ -636,7 +636,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertypes(transaction)
 ----
 
-[#_RoleType_isAttributeisAttribute__:_boolean]
+[#_RoleType_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -657,7 +657,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_RoleType_isAttributeTypeisAttributeType__:_boolean]
+[#_RoleType_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -678,7 +678,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_RoleType_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_RoleType_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -701,7 +701,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 .Returns
 `Promise<boolean>`
 
-[#_RoleType_isEntityisEntity__:_boolean]
+[#_RoleType_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -722,7 +722,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_RoleType_isEntityTypeisEntityType__:_boolean]
+[#_RoleType_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -743,7 +743,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_RoleType_isRelationisRelation__:_boolean]
+[#_RoleType_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -764,7 +764,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_RoleType_isRelationTypeisRelationType__:_boolean]
+[#_RoleType_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -785,7 +785,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_RoleType_isRoleTypeisRoleType__:_boolean]
+[#_RoleType_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -806,7 +806,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_RoleType_isThingisThing__:_boolean]
+[#_RoleType_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -827,7 +827,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_RoleType_isThingTypeisThingType__:_boolean]
+[#_RoleType_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -848,7 +848,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_RoleType_isTypeisType__:_boolean]
+[#_RoleType_isType__]
 ==== isType
 
 [source,nodejs]
@@ -869,7 +869,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_RoleType_isValueisValue__:_boolean]
+[#_RoleType_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -890,7 +890,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_RoleType_setLabelsetLabel_transaction__label_:_Promise_void]
+[#_RoleType_setLabel__transaction_TypeDBTransaction__label_string]
 ==== setLabel
 
 [source,nodejs]

--- a/nodejs/docs/schema/ThingType.adoc
+++ b/nodejs/docs/schema/ThingType.adoc
@@ -17,7 +17,7 @@ a| `NAME`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_ThingType_asAttributeasAttribute__:_Attribute]
+[#_ThingType_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -38,7 +38,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_ThingType_asAttributeTypeasAttributeType__:_AttributeType]
+[#_ThingType_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -59,7 +59,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_ThingType_asEntityasEntity__:_Entity]
+[#_ThingType_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -80,7 +80,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_ThingType_asEntityTypeasEntityType__:_EntityType]
+[#_ThingType_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -101,7 +101,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_ThingType_asRelationasRelation__:_Relation]
+[#_ThingType_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -122,7 +122,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_ThingType_asRelationTypeasRelationType__:_RelationType]
+[#_ThingType_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -143,7 +143,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_ThingType_asRoleTypeasRoleType__:_RoleType]
+[#_ThingType_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -164,7 +164,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_ThingType_asThingasThing__:_Thing]
+[#_ThingType_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -185,7 +185,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_ThingType_asThingTypeasThingType__:_ThingType]
+[#_ThingType_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -206,7 +206,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_ThingType_asTypeasType__:_Type]
+[#_ThingType_asType__]
 ==== asType
 
 [source,nodejs]
@@ -227,7 +227,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_ThingType_asValueasValue__:_Value]
+[#_ThingType_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -248,7 +248,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_ThingType_deletedelete_transaction_:_Promise_void]
+[#_ThingType_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -278,7 +278,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.delete(transaction)
 ----
 
-[#_ThingType_equalsequals_concept_:_boolean]
+[#_ThingType_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -301,7 +301,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_ThingType_getInstancesgetInstances_transaction_:_Stream_Thing]
+[#_ThingType_getInstances__transaction_TypeDBTransaction]
 ==== getInstances
 
 [source,nodejs]
@@ -331,7 +331,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getInstances(transaction)
 ----
 
-[#_ThingType_getInstancesgetInstances_transaction__transitivity_:_Stream_Thing]
+[#_ThingType_getInstances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getInstances
 
 [source,nodejs]
@@ -362,7 +362,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect instanc
 thingType.getInstances(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction]
 ==== getOwns
 
 [source,nodejs]
@@ -392,7 +392,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction__valueType_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction__valueType_ValueType]
 ==== getOwns
 
 [source,nodejs]
@@ -423,7 +423,7 @@ a| `valueType` a| If specified, only attribute types of this ``ValueType`` will 
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction__annotations_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -454,7 +454,7 @@ a| `annotations` a| If specified, only attribute types of this ``ValueType`` wil
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction__valueType__annotations_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation__]
 ==== getOwns
 
 [source,nodejs]
@@ -486,7 +486,7 @@ a| `annotations` a| Only retrieve attribute types owned with annotations. a| `An
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction__transitivity_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -517,7 +517,7 @@ a| `transitivity` a| If specified, only attribute types of this ``ValueType`` wi
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction__valueType__transitivity_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -549,7 +549,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction__annotations__transitivity_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -581,7 +581,7 @@ a| `transitivity` a| Only retrieve attribute types owned with annotations. a| `T
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsgetOwns_transaction__valueType__annotations__transitivity_:_Stream_AttributeType]
+[#_ThingType_getOwns__transaction_TypeDBTransaction__valueType_ValueType__annotations_Annotation____transitivity_Transitivity]
 ==== getOwns
 
 [source,nodejs]
@@ -614,7 +614,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and inherited owners
 thingType.getOwns(transaction) thingType.getOwns(transaction, valueType, Transitivity.EXPLICIT,[Annotation.KEY])
 ----
 
-[#_ThingType_getOwnsOverriddengetOwnsOverridden_transaction__attributeType_:_Promise_AttributeType]
+[#_ThingType_getOwnsOverridden__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== getOwnsOverridden
 
 [source,nodejs]
@@ -645,7 +645,7 @@ a| `attributeType` a| The ``AttributeType`` that overrides requested ``Attribute
 thingType.getOwnsOverridden(transaction, attributeType)
 ----
 
-[#_ThingType_getPlaysgetPlays_transaction_:_Stream_RoleType]
+[#_ThingType_getPlays__transaction_TypeDBTransaction]
 ==== getPlays
 
 [source,nodejs]
@@ -675,7 +675,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_ThingType_getPlaysgetPlays_transaction__transitivity_:_Stream_RoleType]
+[#_ThingType_getPlays__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getPlays
 
 [source,nodejs]
@@ -706,7 +706,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 thingType.getPlays(transaction) thingType.getPlays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_ThingType_getPlaysOverriddengetPlaysOverridden_transaction__role_:_Promise_RoleType]
+[#_ThingType_getPlaysOverridden__transaction_TypeDBTransaction__role_RoleType]
 ==== getPlaysOverridden
 
 [source,nodejs]
@@ -737,7 +737,7 @@ a| `role` a| The ``RoleType`` that overrides an inherited role a| `RoleType`
 thingType.getPlaysOverridden(transaction, role)
 ----
 
-[#_ThingType_getSubtypesgetSubtypes_transaction_:_Stream_ThingType]
+[#_ThingType_getSubtypes__transaction_TypeDBTransaction]
 ==== getSubtypes
 
 [source,nodejs]
@@ -767,7 +767,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSubtypes(transaction)
 ----
 
-[#_ThingType_getSubtypesgetSubtypes_transaction__transitivity_:_Stream_ThingType]
+[#_ThingType_getSubtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getSubtypes
 
 [source,nodejs]
@@ -798,7 +798,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 thingType.getSubtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_ThingType_getSupertypegetSupertype_transaction_:_Promise_ThingType]
+[#_ThingType_getSupertype__transaction_TypeDBTransaction]
 ==== getSupertype
 
 [source,nodejs]
@@ -828,7 +828,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertype(transaction)
 ----
 
-[#_ThingType_getSupertypesgetSupertypes_transaction_:_Stream_ThingType]
+[#_ThingType_getSupertypes__transaction_TypeDBTransaction]
 ==== getSupertypes
 
 [source,nodejs]
@@ -858,7 +858,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSupertypes(transaction)
 ----
 
-[#_ThingType_getSyntaxgetSyntax_transaction_:_Promise_string]
+[#_ThingType_getSyntax__transaction_TypeDBTransaction]
 ==== getSyntax
 
 [source,nodejs]
@@ -888,7 +888,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.getSyntax(transaction)
 ----
 
-[#_ThingType_isAttributeisAttribute__:_boolean]
+[#_ThingType_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -909,7 +909,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_ThingType_isAttributeTypeisAttributeType__:_boolean]
+[#_ThingType_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -930,7 +930,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_ThingType_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_ThingType_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -953,7 +953,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 .Returns
 `Promise<boolean>`
 
-[#_ThingType_isEntityisEntity__:_boolean]
+[#_ThingType_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -974,7 +974,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_ThingType_isEntityTypeisEntityType__:_boolean]
+[#_ThingType_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -995,7 +995,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_ThingType_isRelationisRelation__:_boolean]
+[#_ThingType_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -1016,7 +1016,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_ThingType_isRelationTypeisRelationType__:_boolean]
+[#_ThingType_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -1037,7 +1037,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_ThingType_isRoleTypeisRoleType__:_boolean]
+[#_ThingType_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -1058,7 +1058,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_ThingType_isThingisThing__:_boolean]
+[#_ThingType_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -1079,7 +1079,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_ThingType_isThingTypeisThingType__:_boolean]
+[#_ThingType_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -1100,7 +1100,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_ThingType_isTypeisType__:_boolean]
+[#_ThingType_isType__]
 ==== isType
 
 [source,nodejs]
@@ -1121,7 +1121,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_ThingType_isValueisValue__:_boolean]
+[#_ThingType_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -1142,7 +1142,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_ThingType_setAbstractsetAbstract_transaction_:_Promise_void]
+[#_ThingType_setAbstract__transaction_TypeDBTransaction]
 ==== setAbstract
 
 [source,nodejs]
@@ -1172,7 +1172,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.setAbstract(transaction)
 ----
 
-[#_ThingType_setLabelsetLabel_transaction__label_:_Promise_void]
+[#_ThingType_setLabel__transaction_TypeDBTransaction__label_string]
 ==== setLabel
 
 [source,nodejs]
@@ -1203,7 +1203,7 @@ a| `label` a| The new ``Label`` to be given to the type. a| `string`
 type.setLabel(transaction, label)
 ----
 
-[#_ThingType_setOwnssetOwns_transaction__attributeType_:_Promise_void]
+[#_ThingType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1234,7 +1234,7 @@ a| `attributeType` a| The ``AttributeType`` to be owned by the instances of this
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_ThingType_setOwnssetOwns_transaction__attributeType__annotations_:_Promise_void]
+[#_ThingType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1266,7 +1266,7 @@ a| `annotations` a| The ``AttributeType`` that this attribute ownership override
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_ThingType_setOwnssetOwns_transaction__attributeType__overriddenType_:_Promise_void]
+[#_ThingType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType]
 ==== setOwns
 
 [source,nodejs]
@@ -1298,7 +1298,7 @@ a| `overriddenType` a| The ``AttributeType`` that this attribute ownership overr
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_ThingType_setOwnssetOwns_transaction__attributeType__overriddenType__annotations_:_Promise_void]
+[#_ThingType_setOwns__transaction_TypeDBTransaction__attributeType_AttributeType__overriddenType_AttributeType__annotations_Annotation__]
 ==== setOwns
 
 [source,nodejs]
@@ -1331,7 +1331,7 @@ a| `annotations` a| Adds annotations to the ownership. a| `Annotation[]`
 thingType.setOwns(transaction, attributeType) thingType.setOwns(transaction, attributeType, overriddenType,[Annotation.KEY])
 ----
 
-[#_ThingType_setPlayssetPlays_transaction__role_:_Promise_void]
+[#_ThingType_setPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1362,7 +1362,7 @@ a| `role` a| The role to be played by the instances of this type a| `RoleType`
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_ThingType_setPlayssetPlays_transaction__role__overriddenType_:_Promise_void]
+[#_ThingType_setPlays__transaction_TypeDBTransaction__role_RoleType__overriddenType_RoleType]
 ==== setPlays
 
 [source,nodejs]
@@ -1394,7 +1394,7 @@ a| `overriddenType` a| The role type that this role overrides, if applicable a| 
 thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, overriddenType)
 ----
 
-[#_ThingType_unsetAbstractunsetAbstract_transaction_:_Promise_void]
+[#_ThingType_unsetAbstract__transaction_TypeDBTransaction]
 ==== unsetAbstract
 
 [source,nodejs]
@@ -1424,7 +1424,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 thingType.unsetAbstract(transaction)
 ----
 
-[#_ThingType_unsetOwnsunsetOwns_transaction__attributeType_:_Promise_void]
+[#_ThingType_unsetOwns__transaction_TypeDBTransaction__attributeType_AttributeType]
 ==== unsetOwns
 
 [source,nodejs]
@@ -1455,7 +1455,7 @@ a| `attributeType` a| The ``AttributeType`` to not be owned by the type. a| `Att
 thingType.unsetOwns(transaction, attributeType)
 ----
 
-[#_ThingType_unsetPlaysunsetPlays_transaction__role_:_Promise_void]
+[#_ThingType_unsetPlays__transaction_TypeDBTransaction__role_RoleType]
 ==== unsetPlays
 
 [source,nodejs]

--- a/nodejs/docs/schema/Transitivity.adoc
+++ b/nodejs/docs/schema/Transitivity.adoc
@@ -14,7 +14,7 @@ a| `TRANSITIVE`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_Transitivity_new_Transitivitynew_Transitivity_transitivity_:_Transitivity]
+[#_Transitivity_new_Transitivity__transitivity_TypeTransitivity]
 ==== new Transitivity
 
 [source,nodejs]

--- a/nodejs/docs/schema/Type.adoc
+++ b/nodejs/docs/schema/Type.adoc
@@ -19,7 +19,7 @@ a| `root` a| `boolean` a| Whether the type is a root type.
 // end::properties[]
 
 // tag::methods[]
-[#_Type_asAttributeasAttribute__:_Attribute]
+[#_Type_asAttribute__]
 ==== asAttribute
 
 [source,nodejs]
@@ -40,7 +40,7 @@ Casts the concept to ``Attribute``.
 concept.asAttribute()
 ----
 
-[#_Type_asAttributeTypeasAttributeType__:_AttributeType]
+[#_Type_asAttributeType__]
 ==== asAttributeType
 
 [source,nodejs]
@@ -61,7 +61,7 @@ Casts the concept to ``AttributeType``.
 concept.asAttributeType()
 ----
 
-[#_Type_asEntityasEntity__:_Entity]
+[#_Type_asEntity__]
 ==== asEntity
 
 [source,nodejs]
@@ -82,7 +82,7 @@ Casts the concept to ``Entity``.
 concept.asEntity()
 ----
 
-[#_Type_asEntityTypeasEntityType__:_EntityType]
+[#_Type_asEntityType__]
 ==== asEntityType
 
 [source,nodejs]
@@ -103,7 +103,7 @@ Casts the concept to ``EntityType``.
 concept.asEntityType()
 ----
 
-[#_Type_asRelationasRelation__:_Relation]
+[#_Type_asRelation__]
 ==== asRelation
 
 [source,nodejs]
@@ -124,7 +124,7 @@ Casts the concept to ``Relation``.
 concept.asRelation()
 ----
 
-[#_Type_asRelationTypeasRelationType__:_RelationType]
+[#_Type_asRelationType__]
 ==== asRelationType
 
 [source,nodejs]
@@ -145,7 +145,7 @@ Casts the concept to ``RelationType``.
 concept.asRelationType()
 ----
 
-[#_Type_asRoleTypeasRoleType__:_RoleType]
+[#_Type_asRoleType__]
 ==== asRoleType
 
 [source,nodejs]
@@ -166,7 +166,7 @@ Casts the concept to ``RoleType``.
 concept.asRoleType()
 ----
 
-[#_Type_asThingasThing__:_Thing]
+[#_Type_asThing__]
 ==== asThing
 
 [source,nodejs]
@@ -187,7 +187,7 @@ Casts the concept to ``Thing``.
 concept.asThing()
 ----
 
-[#_Type_asThingTypeasThingType__:_ThingType]
+[#_Type_asThingType__]
 ==== asThingType
 
 [source,nodejs]
@@ -208,7 +208,7 @@ Casts the concept to ``ThingType``.
 concept.asThingType()
 ----
 
-[#_Type_asTypeasType__:_Type]
+[#_Type_asType__]
 ==== asType
 
 [source,nodejs]
@@ -229,7 +229,7 @@ Casts the concept to ``Type``.
 concept.asType()
 ----
 
-[#_Type_asValueasValue__:_Value]
+[#_Type_asValue__]
 ==== asValue
 
 [source,nodejs]
@@ -250,7 +250,7 @@ Casts the concept to ``Value``.
 concept.asValue()
 ----
 
-[#_Type_deletedelete_transaction_:_Promise_void]
+[#_Type_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,nodejs]
@@ -280,7 +280,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.delete(transaction)
 ----
 
-[#_Type_equalsequals_concept_:_boolean]
+[#_Type_equals__concept_Concept]
 ==== equals
 
 [source,nodejs]
@@ -303,7 +303,7 @@ a| `concept` a| The concept to compare to. a| `Concept`
 .Returns
 `boolean`
 
-[#_Type_getSubtypesgetSubtypes_transaction_:_Stream_Type]
+[#_Type_getSubtypes__transaction_TypeDBTransaction]
 ==== getSubtypes
 
 [source,nodejs]
@@ -333,7 +333,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSubtypes(transaction) type.getSubtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_Type_getSubtypesgetSubtypes_transaction__transitivity_:_Stream_Type]
+[#_Type_getSubtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== getSubtypes
 
 [source,nodejs]
@@ -364,7 +364,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 type.getSubtypes(transaction) type.getSubtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_Type_getSupertypegetSupertype_transaction_:_Promise_Type]
+[#_Type_getSupertype__transaction_TypeDBTransaction]
 ==== getSupertype
 
 [source,nodejs]
@@ -394,7 +394,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertype(transaction)
 ----
 
-[#_Type_getSupertypesgetSupertypes_transaction_:_Stream_Type]
+[#_Type_getSupertypes__transaction_TypeDBTransaction]
 ==== getSupertypes
 
 [source,nodejs]
@@ -424,7 +424,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 type.getSupertypes(transaction)
 ----
 
-[#_Type_isAttributeisAttribute__:_boolean]
+[#_Type_isAttribute__]
 ==== isAttribute
 
 [source,nodejs]
@@ -445,7 +445,7 @@ Checks if the concept is an ``Attribute``.
 concept.isAttribute()
 ----
 
-[#_Type_isAttributeTypeisAttributeType__:_boolean]
+[#_Type_isAttributeType__]
 ==== isAttributeType
 
 [source,nodejs]
@@ -466,7 +466,7 @@ Checks if the concept is an ``AttributeType``.
 concept.isAttributeType()
 ----
 
-[#_Type_isDeletedisDeleted_transaction_:_Promise_boolean]
+[#_Type_isDeleted__transaction_TypeDBTransaction]
 ==== isDeleted
 
 [source,nodejs]
@@ -489,7 +489,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction`
 .Returns
 `Promise<boolean>`
 
-[#_Type_isEntityisEntity__:_boolean]
+[#_Type_isEntity__]
 ==== isEntity
 
 [source,nodejs]
@@ -510,7 +510,7 @@ Checks if the concept is an ``Entity``.
 concept.isEntity()
 ----
 
-[#_Type_isEntityTypeisEntityType__:_boolean]
+[#_Type_isEntityType__]
 ==== isEntityType
 
 [source,nodejs]
@@ -531,7 +531,7 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType()
 ----
 
-[#_Type_isRelationisRelation__:_boolean]
+[#_Type_isRelation__]
 ==== isRelation
 
 [source,nodejs]
@@ -552,7 +552,7 @@ Checks if the concept is a ``Relation``.
 concept.isRelation()
 ----
 
-[#_Type_isRelationTypeisRelationType__:_boolean]
+[#_Type_isRelationType__]
 ==== isRelationType
 
 [source,nodejs]
@@ -573,7 +573,7 @@ Checks if the concept is a ``RelationType``.
 concept.isRelationType()
 ----
 
-[#_Type_isRoleTypeisRoleType__:_boolean]
+[#_Type_isRoleType__]
 ==== isRoleType
 
 [source,nodejs]
@@ -594,7 +594,7 @@ Checks if the concept is a ``RoleType``.
 concept.isRoleType()
 ----
 
-[#_Type_isThingisThing__:_boolean]
+[#_Type_isThing__]
 ==== isThing
 
 [source,nodejs]
@@ -615,7 +615,7 @@ Checks if the concept is a ``Thing``.
 concept.isThing()
 ----
 
-[#_Type_isThingTypeisThingType__:_boolean]
+[#_Type_isThingType__]
 ==== isThingType
 
 [source,nodejs]
@@ -636,7 +636,7 @@ Checks if the concept is a ``ThingType``.
 concept.isThingType()
 ----
 
-[#_Type_isTypeisType__:_boolean]
+[#_Type_isType__]
 ==== isType
 
 [source,nodejs]
@@ -657,7 +657,7 @@ Checks if the concept is a ``Type``.
 concept.isType()
 ----
 
-[#_Type_isValueisValue__:_boolean]
+[#_Type_isValue__]
 ==== isValue
 
 [source,nodejs]
@@ -678,7 +678,7 @@ Checks if the concept is a ``Value``.
 concept.isValue()
 ----
 
-[#_Type_setLabelsetLabel_transaction__label_:_Promise_void]
+[#_Type_setLabel__transaction_TypeDBTransaction__label_string]
 ==== setLabel
 
 [source,nodejs]

--- a/nodejs/docs/schema/ValueType.adoc
+++ b/nodejs/docs/schema/ValueType.adoc
@@ -20,7 +20,7 @@ a| `STRING`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_ValueType_namename__:_string]
+[#_ValueType_name__]
 ==== name
 
 [source,nodejs]
@@ -34,7 +34,7 @@ name(): string
 .Returns
 `string`
 
-[#_ValueType_new_ValueTypenew_ValueType_type__name_:_ValueType]
+[#_ValueType_new_ValueType__type_ValueType__name_string]
 ==== new ValueType
 
 [source,nodejs]
@@ -58,7 +58,7 @@ a| `name` a|  a| `string`
 .Returns
 `ValueType`
 
-[#_ValueType_toStringtoString__:_string]
+[#_ValueType_toString__]
 ==== toString
 
 [source,nodejs]

--- a/nodejs/docs/session/SessionType.adoc
+++ b/nodejs/docs/session/SessionType.adoc
@@ -16,7 +16,7 @@ a| `SCHEMA`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_SessionType_isDataisData__:_boolean]
+[#_SessionType_isData__]
 ==== isData
 
 [source,nodejs]
@@ -30,7 +30,7 @@ isData(): boolean
 .Returns
 `boolean`
 
-[#_SessionType_isSchemaisSchema__:_boolean]
+[#_SessionType_isSchema__]
 ==== isSchema
 
 [source,nodejs]

--- a/nodejs/docs/session/TypeDBOptions.adoc
+++ b/nodejs/docs/session/TypeDBOptions.adoc
@@ -4,7 +4,7 @@
 TypeDB session and transaction options. ``TypeDBOptions`` object can be used to override the default server behaviour. Options could be specified either as constructor arguments or using setters.
 
 // tag::methods[]
-[#__explain]
+[#_TypeDBOptions__explain__]
 ====  explain
 
 [source,nodejs]
@@ -18,7 +18,7 @@ If set to ``True``, enables explanations for queries. Only affects read transact
 .Returns
 `boolean`
 
-[#__explain]
+[#_TypeDBOptions__explain__value_boolean]
 ====  explain
 
 [source,nodejs]
@@ -32,7 +32,7 @@ If set to ``True``, enables explanations for queries. Only affects read transact
 .Returns
 `void`
 
-[#__infer]
+[#_TypeDBOptions__infer__]
 ====  infer
 
 [source,nodejs]
@@ -46,7 +46,7 @@ If set to ``True``, enables inference for queries. Only settable at transaction 
 .Returns
 `boolean`
 
-[#__infer]
+[#_TypeDBOptions__infer__value_boolean]
 ====  infer
 
 [source,nodejs]
@@ -60,7 +60,7 @@ If set to ``True``, enables inference for queries. Only settable at transaction 
 .Returns
 `void`
 
-[#__parallel]
+[#_TypeDBOptions__parallel__]
 ====  parallel
 
 [source,nodejs]
@@ -74,7 +74,7 @@ If set to ``True``, the server uses parallel instead of single-threaded executio
 .Returns
 `boolean`
 
-[#__parallel]
+[#_TypeDBOptions__parallel__value_boolean]
 ====  parallel
 
 [source,nodejs]
@@ -88,7 +88,7 @@ If set to ``True``, the server uses parallel instead of single-threaded executio
 .Returns
 `void`
 
-[#__prefetch]
+[#_TypeDBOptions__prefetch__]
 ====  prefetch
 
 [source,nodejs]
@@ -102,7 +102,7 @@ If set to ``True``, the first batch of answers is streamed to the driver even wi
 .Returns
 `boolean`
 
-[#__prefetch]
+[#_TypeDBOptions__prefetch__value_boolean]
 ====  prefetch
 
 [source,nodejs]
@@ -116,7 +116,7 @@ If set to ``True``, the first batch of answers is streamed to the driver even wi
 .Returns
 `void`
 
-[#__prefetchSize]
+[#_TypeDBOptions__prefetchSize__]
 ====  prefetchSize
 
 [source,nodejs]
@@ -130,7 +130,7 @@ If set, specifies a guideline number of answers that the server should send befo
 .Returns
 `number`
 
-[#__prefetchSize]
+[#_TypeDBOptions__prefetchSize__value_number]
 ====  prefetchSize
 
 [source,nodejs]
@@ -144,7 +144,7 @@ If set, specifies a guideline number of answers that the server should send befo
 .Returns
 `void`
 
-[#__readAnyReplica]
+[#_TypeDBOptions__readAnyReplica__]
 ====  readAnyReplica
 
 [source,nodejs]
@@ -158,7 +158,7 @@ If set to ``True``, enables reading data from any replica, potentially boosting 
 .Returns
 `boolean`
 
-[#__readAnyReplica]
+[#_TypeDBOptions__readAnyReplica__value_boolean]
 ====  readAnyReplica
 
 [source,nodejs]
@@ -172,7 +172,7 @@ If set to ``True``, enables reading data from any replica, potentially boosting 
 .Returns
 `void`
 
-[#__schemaLockAcquireTimeoutMillis]
+[#_TypeDBOptions__schemaLockAcquireTimeoutMillis__]
 ====  schemaLockAcquireTimeoutMillis
 
 [source,nodejs]
@@ -186,7 +186,7 @@ If set, specifies how long the driver should wait if opening a session or transa
 .Returns
 `number`
 
-[#__schemaLockAcquireTimeoutMillis]
+[#_TypeDBOptions__schemaLockAcquireTimeoutMillis__value_number]
 ====  schemaLockAcquireTimeoutMillis
 
 [source,nodejs]
@@ -200,7 +200,7 @@ If set, specifies how long the driver should wait if opening a session or transa
 .Returns
 `void`
 
-[#__sessionIdleTimeoutMillis]
+[#_TypeDBOptions__sessionIdleTimeoutMillis__]
 ====  sessionIdleTimeoutMillis
 
 [source,nodejs]
@@ -214,7 +214,7 @@ If set, specifies a timeout that allows the server to close sessions if the driv
 .Returns
 `number`
 
-[#__sessionIdleTimeoutMillis]
+[#_TypeDBOptions__sessionIdleTimeoutMillis__millis_number]
 ====  sessionIdleTimeoutMillis
 
 [source,nodejs]
@@ -228,7 +228,7 @@ If set, specifies a timeout that allows the server to close sessions if the driv
 .Returns
 `void`
 
-[#__traceInference]
+[#_TypeDBOptions__traceInference__]
 ====  traceInference
 
 [source,nodejs]
@@ -242,7 +242,7 @@ If set to ``True``, reasoning tracing graphs are output in the logging directory
 .Returns
 `boolean`
 
-[#__traceInference]
+[#_TypeDBOptions__traceInference__value_boolean]
 ====  traceInference
 
 [source,nodejs]
@@ -256,7 +256,7 @@ If set to ``True``, reasoning tracing graphs are output in the logging directory
 .Returns
 `void`
 
-[#__transactionTimeoutMillis]
+[#_TypeDBOptions__transactionTimeoutMillis__]
 ====  transactionTimeoutMillis
 
 [source,nodejs]
@@ -270,7 +270,7 @@ If set, specifies a timeout for killing transactions automatically, preventing m
 .Returns
 `number`
 
-[#__transactionTimeoutMillis]
+[#_TypeDBOptions__transactionTimeoutMillis__millis_number]
 ====  transactionTimeoutMillis
 
 [source,nodejs]
@@ -284,7 +284,7 @@ If set, specifies a timeout for killing transactions automatically, preventing m
 .Returns
 `void`
 
-[#_TypeDBOptions_new_TypeDBOptionsnew_TypeDBOptions_obj?_:_TypeDBOptions]
+[#_TypeDBOptions_new_TypeDBOptions__obj__explain_boolean_infer_boolean_parallel_boolean_prefetch_boolean_prefetchSize_number_readAnyReplica_boolean_schemaLockAcquireTimeoutMillis_number_sessionIdleTimeoutMillis_number_traceInference_boolean_transactionTimeoutMillis_number___]
 ==== new TypeDBOptions
 
 [source,nodejs]

--- a/nodejs/docs/session/TypeDBSession.adoc
+++ b/nodejs/docs/session/TypeDBSession.adoc
@@ -16,7 +16,7 @@ a| `type` a| `SessionType` a| The current session’s type (SCHEMA or DATA)
 // end::properties[]
 
 // tag::methods[]
-[#_TypeDBSession_closeclose__:_Promise_void]
+[#_TypeDBSession_close__]
 ==== close
 
 [source,nodejs]
@@ -37,7 +37,7 @@ Closes the session. Before opening a new session, the session currently open sho
 session.close()
 ----
 
-[#_TypeDBSession_isOpenisOpen__:_boolean]
+[#_TypeDBSession_isOpen__]
 ==== isOpen
 
 [source,nodejs]
@@ -58,7 +58,7 @@ Checks whether this session is open.
 session.isOpen()
 ----
 
-[#_TypeDBSession_transactiontransaction_type__options?_:_Promise_TypeDBTransaction]
+[#_TypeDBSession_transaction__type_TransactionType__options_TypeDBOptions]
 ==== transaction
 
 [source,nodejs]

--- a/nodejs/docs/transaction/QueryManager.adoc
+++ b/nodejs/docs/transaction/QueryManager.adoc
@@ -4,7 +4,7 @@
 Provides methods for executing TypeQL queries in the transaction.
 
 // tag::methods[]
-[#_QueryManager_definedefine_query__options?_:_Promise_void]
+[#_QueryManager_define__query_string__options_TypeDBOptions]
 ==== define
 
 [source,nodejs]
@@ -35,7 +35,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.define(query, options)
 ----
 
-[#_QueryManager_deletedelete_query__options?_:_Promise_void]
+[#_QueryManager_delete__query_string__options_TypeDBOptions]
 ==== delete
 
 [source,nodejs]
@@ -66,7 +66,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.delete(query, options)
 ----
 
-[#_QueryManager_explainexplain_explainable__options?_:_Stream_Explanation]
+[#_QueryManager_explain__explainable_Explainable__options_TypeDBOptions]
 ==== explain
 
 [source,nodejs]
@@ -97,7 +97,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.explain(explainable, options)
 ----
 
-[#_QueryManager_fetchfetch_query__options?_:_Stream_JSONObject]
+[#_QueryManager_fetch__query_string__options_TypeDBOptions]
 ==== fetch
 
 [source,nodejs]
@@ -130,7 +130,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.fetch(query, options)
 ----
 
-[#_QueryManager_getget_query__options?_:_Stream_ConceptMap]
+[#_QueryManager_get__query_string__options_TypeDBOptions]
 ==== get
 
 [source,nodejs]
@@ -161,7 +161,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.get(query, options)
 ----
 
-[#_QueryManager_getAggregategetAggregate_query__options?_:_Promise_Value]
+[#_QueryManager_getAggregate__query_string__options_TypeDBOptions]
 ==== getAggregate
 
 [source,nodejs]
@@ -192,7 +192,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.getAggregate(query, options)
 ----
 
-[#_QueryManager_getGroupgetGroup_query__options?_:_Stream_ConceptMapGroup]
+[#_QueryManager_getGroup__query_string__options_TypeDBOptions]
 ==== getGroup
 
 [source,nodejs]
@@ -223,7 +223,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.getGroup(query, options)
 ----
 
-[#_QueryManager_getGroupAggregategetGroupAggregate_query__options?_:_Stream_ValueGroup]
+[#_QueryManager_getGroupAggregate__query_string__options_TypeDBOptions]
 ==== getGroupAggregate
 
 [source,nodejs]
@@ -254,7 +254,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.getGroupAggregate(query, options)
 ----
 
-[#_QueryManager_insertinsert_query__options?_:_Stream_ConceptMap]
+[#_QueryManager_insert__query_string__options_TypeDBOptions]
 ==== insert
 
 [source,nodejs]
@@ -285,7 +285,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.insert(query, options)
 ----
 
-[#_QueryManager_undefineundefine_query__options?_:_Promise_void]
+[#_QueryManager_undefine__query_string__options_TypeDBOptions]
 ==== undefine
 
 [source,nodejs]
@@ -316,7 +316,7 @@ a| `options` a| Specify query options a| `TypeDBOptions`
 transaction.query.undefine(query, options)
 ----
 
-[#_QueryManager_updateupdate_query__options?_:_Stream_ConceptMap]
+[#_QueryManager_update__query_string__options_TypeDBOptions]
 ==== update
 
 [source,nodejs]

--- a/nodejs/docs/transaction/TransactionType.adoc
+++ b/nodejs/docs/transaction/TransactionType.adoc
@@ -16,7 +16,7 @@ a| `WRITE`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_TransactionType_isReadisRead__:_boolean]
+[#_TransactionType_isRead__]
 ==== isRead
 
 [source,nodejs]
@@ -30,7 +30,7 @@ Checks whether this is the READ TransactionType
 .Returns
 `boolean`
 
-[#_TransactionType_isWriteisWrite__:_boolean]
+[#_TransactionType_isWrite__]
 ==== isWrite
 
 [source,nodejs]

--- a/nodejs/docs/transaction/TypeDBTransaction.adoc
+++ b/nodejs/docs/transaction/TypeDBTransaction.adoc
@@ -17,7 +17,7 @@ a| `type` a| `TransactionType` a| The transaction’s type (READ or WRITE)
 // end::properties[]
 
 // tag::methods[]
-[#_TypeDBTransaction_closeclose__:_Promise_void]
+[#_TypeDBTransaction_close__]
 ==== close
 
 [source,nodejs]
@@ -38,7 +38,7 @@ Closes the transaction.
 transaction.close()
 ----
 
-[#_TypeDBTransaction_commitcommit__:_Promise_void]
+[#_TypeDBTransaction_commit__]
 ==== commit
 
 [source,nodejs]
@@ -59,7 +59,7 @@ Commits the changes made via this transaction to the TypeDB database. Whether or
 transaction.commit()
 ----
 
-[#_TypeDBTransaction_isOpenisOpen__:_boolean]
+[#_TypeDBTransaction_isOpen__]
 ==== isOpen
 
 [source,nodejs]
@@ -80,7 +80,7 @@ Checks whether this transaction is open.
 transaction.isOpen()
 ----
 
-[#_TypeDBTransaction_rollbackrollback__:_Promise_void]
+[#_TypeDBTransaction_rollback__]
 ==== rollback
 
 [source,nodejs]

--- a/python/docs/answer/ConceptMap.adoc
+++ b/python/docs/answer/ConceptMap.adoc
@@ -4,7 +4,7 @@
 Contains a mapping of variables to concepts.
 
 // tag::methods[]
-[#_ConceptMap_concepts]
+[#_ConceptMap_concepts__]
 ==== concepts
 
 [source,python]
@@ -25,7 +25,7 @@ Produces an iterator over all concepts in this ``ConceptMap``.
 concept_map.concepts()
 ----
 
-[#_ConceptMap_explainables]
+[#_ConceptMap_explainables__]
 ==== explainables
 
 [source,python]
@@ -46,7 +46,7 @@ Gets the ``Explainables`` object for this ``ConceptMap``, exposing which of the 
 concept_map.explainables()
 ----
 
-[#_ConceptMap_get]
+[#_ConceptMap_get__variable_str]
 ==== get
 
 [source,python]
@@ -76,7 +76,7 @@ a| `variable` a| The string representation of a variable a| `str` a|
 concept_map.get(variable)
 ----
 
-[#_ConceptMap_variables]
+[#_ConceptMap_variables__]
 ==== variables
 
 [source,python]

--- a/python/docs/answer/ConceptMapGroup.adoc
+++ b/python/docs/answer/ConceptMapGroup.adoc
@@ -4,7 +4,7 @@
 Contains an element of the group query result.
 
 // tag::methods[]
-[#_ConceptMapGroup_concept_maps]
+[#_ConceptMapGroup_concept_maps__]
 ==== concept_maps
 
 [source,python]
@@ -25,7 +25,7 @@ Retrieves the ConceptMaps of the group.
 concept_map_group.concept_maps()
 ----
 
-[#_ConceptMapGroup_owner]
+[#_ConceptMapGroup_owner__]
 ==== owner
 
 [source,python]

--- a/python/docs/answer/Explainable.adoc
+++ b/python/docs/answer/Explainable.adoc
@@ -4,7 +4,7 @@
 Contains an explainable object.
 
 // tag::methods[]
-[#_Explainable_conjunction]
+[#_Explainable_conjunction__]
 ==== conjunction
 
 [source,python]
@@ -25,7 +25,7 @@ Retrieves the subquery of the original query that is actually being explained.
 explainable.conjunction()
 ----
 
-[#_Explainable_id]
+[#_Explainable_id__]
 ==== id
 
 [source,python]

--- a/python/docs/answer/Explainables.adoc
+++ b/python/docs/answer/Explainables.adoc
@@ -4,7 +4,7 @@
 Contains explainable objects.
 
 // tag::methods[]
-[#_Explainables_attribute]
+[#_Explainables_attribute__variable_str]
 ==== attribute
 
 [source,python]
@@ -34,7 +34,7 @@ a| `variable` a| The string representation of a variable a| `str` a|
 concept_map.explainables().attribute(variable)
 ----
 
-[#_Explainables_attributes]
+[#_Explainables_attributes__]
 ==== attributes
 
 [source,python]
@@ -55,7 +55,7 @@ Retrieves all of this ``ConceptMap``’s explainable attributes.
 concept_map.explainables().attributes()
 ----
 
-[#_Explainables_ownership]
+[#_Explainables_ownership__owner_str__attribute_str]
 ==== ownership
 
 [source,python]
@@ -86,7 +86,7 @@ a| `attribute` a| The string representation of the attribute variable a| `str` a
 concept_map.explainables().ownership(owner, attribute)
 ----
 
-[#_Explainables_ownerships]
+[#_Explainables_ownerships__]
 ==== ownerships
 
 [source,python]
@@ -107,7 +107,7 @@ Retrieves all of this ``ConceptMap``’s explainable ownerships.
 concept_map.explainables().ownerships()
 ----
 
-[#_Explainables_relation]
+[#_Explainables_relation__variable_str]
 ==== relation
 
 [source,python]
@@ -137,7 +137,7 @@ a| `variable` a| The string representation of a variable a| `str` a|
 concept_map.explainables().relation(variable)
 ----
 
-[#_Explainables_relations]
+[#_Explainables_relations__]
 ==== relations
 
 [source,python]

--- a/python/docs/answer/Explanation.adoc
+++ b/python/docs/answer/Explanation.adoc
@@ -4,7 +4,7 @@
 An explanation of which rule was used for inferring the explained concept, the condition of the rule, the conclusion of the rule, and the mapping of variables between the query and the rule’s conclusion.
 
 // tag::methods[]
-[#_Explanation_conclusion]
+[#_Explanation_conclusion__]
 ==== conclusion
 
 [source,python]
@@ -25,7 +25,7 @@ Retrieves the Conclusion for this Explanation.
 explanation.conclusion()
 ----
 
-[#_Explanation_condition]
+[#_Explanation_condition__]
 ==== condition
 
 [source,python]
@@ -46,7 +46,7 @@ Retrieves the Condition for this Explanation.
 explanation.condition()
 ----
 
-[#_Explanation_query_variable_mapping]
+[#_Explanation_query_variable_mapping__var_str]
 ==== query_variable_mapping
 
 [source,python]
@@ -76,7 +76,7 @@ a| `var` a| The query variable to map to rule variables. a| `str` a|
 explanation.variable_mapping(var)
 ----
 
-[#_Explanation_query_variables]
+[#_Explanation_query_variables__]
 ==== query_variables
 
 [source,python]
@@ -97,7 +97,7 @@ Retrieves the query variables for this ``Explanation``.
 explanation.query_variables()
 ----
 
-[#_Explanation_rule]
+[#_Explanation_rule__]
 ==== rule
 
 [source,python]

--- a/python/docs/answer/Promise.adoc
+++ b/python/docs/answer/Promise.adoc
@@ -6,7 +6,7 @@ A ``Promise`` represents an asynchronous network operation.
 The request it represents is performed immediately. The response is only retrieved once the ``Promise`` is ``resolve``d.
 
 // tag::methods[]
-[#_Promise_map]
+[#_Promise_map__]
 ==== map
 
 [source,python]
@@ -20,7 +20,7 @@ classmethod map(ctor: Callable[[U], T], raw: Callable[[], U]) -> Promise[T]
 .Returns
 `Promise[T]`
 
-[#_Promise_resolve]
+[#_Promise_resolve__]
 ==== resolve
 
 [source,python]

--- a/python/docs/answer/ValueGroup.adoc
+++ b/python/docs/answer/ValueGroup.adoc
@@ -4,7 +4,7 @@
 Contains an element of the group aggregate query result.
 
 // tag::methods[]
-[#_ValueGroup_owner]
+[#_ValueGroup_owner__]
 ==== owner
 
 [source,python]
@@ -25,7 +25,7 @@ Retrieves the concept that is the group owner.
 value_group.owner()
 ----
 
-[#_ValueGroup_value]
+[#_ValueGroup_value__]
 ==== value
 
 [source,python]

--- a/python/docs/concept/Concept.adoc
+++ b/python/docs/concept/Concept.adoc
@@ -2,7 +2,7 @@
 === Concept
 
 // tag::methods[]
-[#_Concept_as_attribute]
+[#_Concept_as_attribute__]
 ==== as_attribute
 
 [source,python]
@@ -23,7 +23,7 @@ Casts the concept to ``Attribute``.
 concept.as_attribute()
 ----
 
-[#_Concept_as_attribute_type]
+[#_Concept_as_attribute_type__]
 ==== as_attribute_type
 
 [source,python]
@@ -44,7 +44,7 @@ Casts the concept to ``AttributeType``.
 concept.as_attribute_type()
 ----
 
-[#_Concept_as_entity]
+[#_Concept_as_entity__]
 ==== as_entity
 
 [source,python]
@@ -65,7 +65,7 @@ Casts the concept to ``Entity``.
 concept.as_entity()
 ----
 
-[#_Concept_as_entity_type]
+[#_Concept_as_entity_type__]
 ==== as_entity_type
 
 [source,python]
@@ -86,7 +86,7 @@ Casts the concept to ``EntityType``.
 concept.as_entity_type()
 ----
 
-[#_Concept_as_relation]
+[#_Concept_as_relation__]
 ==== as_relation
 
 [source,python]
@@ -107,7 +107,7 @@ Casts the concept to ``Relation``.
 concept.as_relation()
 ----
 
-[#_Concept_as_relation_type]
+[#_Concept_as_relation_type__]
 ==== as_relation_type
 
 [source,python]
@@ -128,7 +128,7 @@ Casts the concept to ``RelationType``.
 concept.as_relation_type()
 ----
 
-[#_Concept_as_role_type]
+[#_Concept_as_role_type__]
 ==== as_role_type
 
 [source,python]
@@ -149,7 +149,7 @@ Casts the concept to ``RoleType``.
 concept.as_role_type()
 ----
 
-[#_Concept_as_thing]
+[#_Concept_as_thing__]
 ==== as_thing
 
 [source,python]
@@ -170,7 +170,7 @@ Casts the concept to ``Thing``.
 concept.as_thing()
 ----
 
-[#_Concept_as_thing_type]
+[#_Concept_as_thing_type__]
 ==== as_thing_type
 
 [source,python]
@@ -191,7 +191,7 @@ Casts the concept to ``ThingType``.
 concept.as_thing_type()
 ----
 
-[#_Concept_as_type]
+[#_Concept_as_type__]
 ==== as_type
 
 [source,python]
@@ -212,7 +212,7 @@ Casts the concept to ``Type``.
 concept.as_type()
 ----
 
-[#_Concept_as_value]
+[#_Concept_as_value__]
 ==== as_value
 
 [source,python]
@@ -233,7 +233,7 @@ Casts the concept to ``Value``.
 concept.as_value()
 ----
 
-[#_Concept_is_attribute]
+[#_Concept_is_attribute__]
 ==== is_attribute
 
 [source,python]
@@ -254,7 +254,7 @@ Checks if the concept is an ``Attribute``.
 concept.is_attribute()
 ----
 
-[#_Concept_is_attribute_type]
+[#_Concept_is_attribute_type__]
 ==== is_attribute_type
 
 [source,python]
@@ -275,7 +275,7 @@ Checks if the concept is an ``AttributeType``.
 concept.is_attribute_type()
 ----
 
-[#_Concept_is_entity]
+[#_Concept_is_entity__]
 ==== is_entity
 
 [source,python]
@@ -296,7 +296,7 @@ Checks if the concept is an ``Entity``.
 concept.is_entity()
 ----
 
-[#_Concept_is_entity_type]
+[#_Concept_is_entity_type__]
 ==== is_entity_type
 
 [source,python]
@@ -317,7 +317,7 @@ Checks if the concept is an ``EntityType``.
 concept.is_entity_type()
 ----
 
-[#_Concept_is_relation]
+[#_Concept_is_relation__]
 ==== is_relation
 
 [source,python]
@@ -338,7 +338,7 @@ Checks if the concept is a ``Relation``.
 concept.is_relation()
 ----
 
-[#_Concept_is_relation_type]
+[#_Concept_is_relation_type__]
 ==== is_relation_type
 
 [source,python]
@@ -359,7 +359,7 @@ Checks if the concept is a ``RelationType``.
 concept.is_relation_type()
 ----
 
-[#_Concept_is_role_type]
+[#_Concept_is_role_type__]
 ==== is_role_type
 
 [source,python]
@@ -380,7 +380,7 @@ Checks if the concept is a ``RoleType``.
 concept.is_role_type()
 ----
 
-[#_Concept_is_thing]
+[#_Concept_is_thing__]
 ==== is_thing
 
 [source,python]
@@ -401,7 +401,7 @@ Checks if the concept is a ``Thing``.
 concept.is_thing()
 ----
 
-[#_Concept_is_thing_type]
+[#_Concept_is_thing_type__]
 ==== is_thing_type
 
 [source,python]
@@ -422,7 +422,7 @@ Checks if the concept is a ``ThingType``.
 concept.is_thing_type()
 ----
 
-[#_Concept_is_type]
+[#_Concept_is_type__]
 ==== is_type
 
 [source,python]
@@ -443,7 +443,7 @@ Checks if the concept is a ``Type``.
 concept.is_type()
 ----
 
-[#_Concept_is_value]
+[#_Concept_is_value__]
 ==== is_value
 
 [source,python]

--- a/python/docs/concept/ConceptManager.adoc
+++ b/python/docs/concept/ConceptManager.adoc
@@ -4,7 +4,7 @@
 Provides access for all Concept API methods.
 
 // tag::methods[]
-[#_ConceptManager_get_attribute]
+[#_ConceptManager_get_attribute__iid_str]
 ==== get_attribute
 
 [source,python]
@@ -34,7 +34,7 @@ a| `iid` a| The iid of the ``Attribute`` to retrieve a| `str` a|
 transaction.concepts.get_attribute(iid).resolve()
 ----
 
-[#_ConceptManager_get_attribute_type]
+[#_ConceptManager_get_attribute_type__label_str]
 ==== get_attribute_type
 
 [source,python]
@@ -64,7 +64,7 @@ a| `label` a| The label of the ``AttributeType`` to retrieve a| `str` a|
 transaction.concepts.get_attribute_type(label).resolve()
 ----
 
-[#_ConceptManager_get_entity]
+[#_ConceptManager_get_entity__iid_str]
 ==== get_entity
 
 [source,python]
@@ -94,7 +94,7 @@ a| `iid` a| The iid of the ``Entity`` to retrieve a| `str` a|
 transaction.concepts.get_entity(iid).resolve()
 ----
 
-[#_ConceptManager_get_entity_type]
+[#_ConceptManager_get_entity_type__label_str]
 ==== get_entity_type
 
 [source,python]
@@ -124,7 +124,7 @@ a| `label` a| The label of the ``EntityType`` to retrieve a| `str` a|
 transaction.concepts.get_entity_type(label).resolve()
 ----
 
-[#_ConceptManager_get_relation]
+[#_ConceptManager_get_relation__iid_str]
 ==== get_relation
 
 [source,python]
@@ -154,7 +154,7 @@ a| `iid` a| The iid of the ``Relation`` to retrieve a| `str` a|
 transaction.concepts.get_relation(iid).resolve()
 ----
 
-[#_ConceptManager_get_relation_type]
+[#_ConceptManager_get_relation_type__label_str]
 ==== get_relation_type
 
 [source,python]
@@ -184,7 +184,7 @@ a| `label` a| The label of the ``RelationType`` to retrieve a| `str` a|
 transaction.concepts.get_relation_type(label).resolve()
 ----
 
-[#_ConceptManager_get_root_attribute_type]
+[#_ConceptManager_get_root_attribute_type__]
 ==== get_root_attribute_type
 
 [source,python]
@@ -205,7 +205,7 @@ Retrieve the root ``AttributeType``, “attribute”.
 transaction.concepts.get_root_attribute_type()
 ----
 
-[#_ConceptManager_get_root_entity_type]
+[#_ConceptManager_get_root_entity_type__]
 ==== get_root_entity_type
 
 [source,python]
@@ -226,7 +226,7 @@ Retrieves the root ``EntityType``, “entity”.
 transaction.concepts.get_root_entity_type()
 ----
 
-[#_ConceptManager_get_root_relation_type]
+[#_ConceptManager_get_root_relation_type__]
 ==== get_root_relation_type
 
 [source,python]
@@ -247,7 +247,7 @@ Retrieve the root ``RelationType``, “relation”.
 transaction.concepts.get_root_relation_type()
 ----
 
-[#_ConceptManager_get_schema_exception]
+[#_ConceptManager_get_schema_exception__]
 ==== get_schema_exception
 
 [source,python]
@@ -268,7 +268,7 @@ Retrieves a list of all schema exceptions for the current transaction.
 transaction.concepts.get_schema_exception()
 ----
 
-[#_ConceptManager_put_attribute_type]
+[#_ConceptManager_put_attribute_type__label_str__value_type_ValueType]
 ==== put_attribute_type
 
 [source,python]
@@ -299,7 +299,7 @@ a| `value_type` a| The value type of the ``AttributeType`` to create or retrieve
 transaction.concepts.put_attribute_type(label, value_type).resolve()
 ----
 
-[#_ConceptManager_put_entity_type]
+[#_ConceptManager_put_entity_type__label_str]
 ==== put_entity_type
 
 [source,python]
@@ -329,7 +329,7 @@ a| `label` a| The label of the ``EntityType`` to create or retrieve a| `str` a|
 transaction.concepts.put_entity_type(label).resolve()
 ----
 
-[#_ConceptManager_put_relation_type]
+[#_ConceptManager_put_relation_type__label_str]
 ==== put_relation_type
 
 [source,python]

--- a/python/docs/connection/Database.adoc
+++ b/python/docs/connection/Database.adoc
@@ -13,7 +13,7 @@ a| `name` a| `str` a| The database name as a string.
 // end::properties[]
 
 // tag::methods[]
-[#_Database_delete]
+[#_Database_delete__]
 ==== delete
 
 [source,python]
@@ -34,7 +34,7 @@ Deletes this database.
 database.delete()
 ----
 
-[#_Database_preferred_replica]
+[#_Database_preferred_replica__]
 ==== preferred_replica
 
 [source,python]
@@ -55,7 +55,7 @@ Returns the preferred replica for this database. Operations which can be run on 
 database.preferred_replica()
 ----
 
-[#_Database_primary_replica]
+[#_Database_primary_replica__]
 ==== primary_replica
 
 [source,python]
@@ -76,7 +76,7 @@ Returns the primary replica for this database. _Only works in TypeDB Enterprise_
 database.primary_replica()
 ----
 
-[#_Database_replicas]
+[#_Database_replicas__]
 ==== replicas
 
 [source,python]
@@ -97,7 +97,7 @@ Set of ``Replica`` instances for this database. _Only works in TypeDB Enterprise
 database.replicas()
 ----
 
-[#_Database_rule_schema]
+[#_Database_rule_schema__]
 ==== rule_schema
 
 [source,python]
@@ -118,7 +118,7 @@ Returns the rules in the schema as a valid TypeQL define query string.
 database.rule_schema()
 ----
 
-[#_Database_schema]
+[#_Database_schema__]
 ==== schema
 
 [source,python]
@@ -139,7 +139,7 @@ Returns a full schema text as a valid TypeQL define query string.
 database.schema()
 ----
 
-[#_Database_type_schema]
+[#_Database_type_schema__]
 ==== type_schema
 
 [source,python]

--- a/python/docs/connection/DatabaseManager.adoc
+++ b/python/docs/connection/DatabaseManager.adoc
@@ -4,7 +4,7 @@
 Provides access to all database management methods.
 
 // tag::methods[]
-[#_DatabaseManager_all]
+[#_DatabaseManager_all__]
 ==== all
 
 [source,python]
@@ -25,7 +25,7 @@ Retrieves all databases present on the TypeDB server
 driver.databases.all()
 ----
 
-[#_DatabaseManager_contains]
+[#_DatabaseManager_contains__name_str]
 ==== contains
 
 [source,python]
@@ -55,7 +55,7 @@ a| `name` a| The database name to be checked a| `str` a|
 driver.databases.contains(name)
 ----
 
-[#_DatabaseManager_create]
+[#_DatabaseManager_create__name_str]
 ==== create
 
 [source,python]
@@ -85,7 +85,7 @@ a| `name` a| The name of the database to be created a| `str` a|
 driver.databases.create(name)
 ----
 
-[#_DatabaseManager_get]
+[#_DatabaseManager_get__name_str]
 ==== get
 
 [source,python]

--- a/python/docs/connection/Replica.adoc
+++ b/python/docs/connection/Replica.adoc
@@ -4,7 +4,7 @@
 The metadata and state of an individual raft replica of a database.
 
 // tag::methods[]
-[#_Replica_address]
+[#_Replica_address__]
 ==== address
 
 [source,python]
@@ -18,7 +18,7 @@ Retrieves address of the server hosting this replica
 .Returns
 `str`
 
-[#_Replica_database]
+[#_Replica_database__]
 ==== database
 
 [source,python]
@@ -32,7 +32,7 @@ Retrieves the database for which this is a replica
 .Returns
 `Database`
 
-[#_Replica_is_preferred]
+[#_Replica_is_preferred__]
 ==== is_preferred
 
 [source,python]
@@ -46,7 +46,7 @@ Checks whether this is the preferred replica of the raft cluster. If true, Opera
 .Returns
 `bool`
 
-[#_Replica_is_primary]
+[#_Replica_is_primary__]
 ==== is_primary
 
 [source,python]
@@ -60,7 +60,7 @@ Checks whether this is the primary replica of the raft cluster.
 .Returns
 `bool`
 
-[#_Replica_term]
+[#_Replica_term__]
 ==== term
 
 [source,python]

--- a/python/docs/connection/TypeDB.adoc
+++ b/python/docs/connection/TypeDB.adoc
@@ -2,7 +2,7 @@
 === TypeDB
 
 // tag::methods[]
-[#_TypeDB_core_driver]
+[#_TypeDB_core_driver__address_str]
 ==== core_driver
 
 [source,python]
@@ -25,7 +25,7 @@ a| `address` a| Address of the TypeDB server. a| `str` a|
 .Returns
 `TypeDBDriver`
 
-[#_TypeDB_enterprise_driver]
+[#_TypeDB_enterprise_driver__addresses_Iterable_str___str__credential_TypeDBCredential]
 ==== enterprise_driver
 
 [source,python]

--- a/python/docs/connection/TypeDBDriver.adoc
+++ b/python/docs/connection/TypeDBDriver.adoc
@@ -14,7 +14,7 @@ a| `users` a| `UserManager` a| The ``UserManager`` instance for this connection,
 // end::properties[]
 
 // tag::methods[]
-[#_TypeDBDriver_close]
+[#_TypeDBDriver_close__]
 ==== close
 
 [source,python]
@@ -35,7 +35,7 @@ Closes the driver. Before instantiating a new driver, the driver that’s curren
 driver.close()
 ----
 
-[#_TypeDBDriver_is_open]
+[#_TypeDBDriver_is_open__]
 ==== is_open
 
 [source,python]
@@ -56,7 +56,7 @@ Checks whether this connection is presently open.
 driver.is_open()
 ----
 
-[#_TypeDBDriver_session]
+[#_TypeDBDriver_session__database_name_str__session_type_SessionType__options_TypeDBOptions__None]
 ==== session
 
 [source,python]
@@ -88,7 +88,7 @@ a| `options` a| ``TypeDBOptions`` for the session a| `TypeDBOptions \| None` a| 
 driver.session(database, session_type, options)
 ----
 
-[#_TypeDBDriver_user]
+[#_TypeDBDriver_user__]
 ==== user
 
 [source,python]

--- a/python/docs/connection/User.adoc
+++ b/python/docs/connection/User.adoc
@@ -4,7 +4,7 @@
 TypeDB user information
 
 // tag::methods[]
-[#_User_password_expiry_seconds]
+[#_User_password_expiry_seconds__]
 ==== password_expiry_seconds
 
 [source,python]
@@ -18,7 +18,7 @@ Returns the number of seconds remaining till this user’s current password expi
 .Returns
 `int | None`
 
-[#_User_password_update]
+[#_User_password_update__password_old_str__password_new_str]
 ==== password_update
 
 [source,python]
@@ -42,7 +42,7 @@ a| `password_new` a| The new password a| `str` a|
 .Returns
 `None`
 
-[#_User_username]
+[#_User_username__]
 ==== username
 
 [source,python]

--- a/python/docs/connection/UserManager.adoc
+++ b/python/docs/connection/UserManager.adoc
@@ -4,7 +4,7 @@
 Provides access to all user management methods.
 
 // tag::methods[]
-[#_UserManager_all]
+[#_UserManager_all__]
 ==== all
 
 [source,python]
@@ -25,7 +25,7 @@ Retrieves all users which exist on the TypeDB server.
 driver.users.all()
 ----
 
-[#_UserManager_contains]
+[#_UserManager_contains__username_str]
 ==== contains
 
 [source,python]
@@ -55,7 +55,7 @@ a| `username` a| The user name to be checked a| `str` a|
 driver.users.contains(username)
 ----
 
-[#_UserManager_create]
+[#_UserManager_create__username_str__password_str]
 ==== create
 
 [source,python]
@@ -86,7 +86,7 @@ a| `password` a| The password of the user to be created a| `str` a|
 driver.users.create(username, password)
 ----
 
-[#_UserManager_delete]
+[#_UserManager_delete__username_str]
 ==== delete
 
 [source,python]
@@ -116,7 +116,7 @@ a| `username` a| The name of the user to be deleted a| `str` a|
 driver.users.delete(username)
 ----
 
-[#_UserManager_get]
+[#_UserManager_get__username_str]
 ==== get
 
 [source,python]
@@ -146,7 +146,7 @@ a| `username` a| The name of the user to retrieve a| `str` a|
 driver.users.get(username)
 ----
 
-[#_UserManager_password_set]
+[#_UserManager_password_set__username_str__password_str]
 ==== password_set
 
 [source,python]

--- a/python/docs/data/Attribute.adoc
+++ b/python/docs/data/Attribute.adoc
@@ -10,7 +10,7 @@ Attribute is an instance of the attribute type and has a value. This value is fi
 Attributes can be uniquely addressed by their type and value.
 
 // tag::methods[]
-[#_Attribute_as_attribute]
+[#_Attribute_as_attribute__]
 ==== as_attribute
 
 [source,python]
@@ -31,7 +31,7 @@ Casts the concept to ``Attribute``.
 attribute.as_attribute()
 ----
 
-[#_Attribute_as_boolean]
+[#_Attribute_as_boolean__]
 ==== as_boolean
 
 [source,python]
@@ -52,7 +52,7 @@ Returns a ``boolean`` value of the attribute. If the value has another type, rai
 attribute.as_boolean()
 ----
 
-[#_Attribute_as_datetime]
+[#_Attribute_as_datetime__]
 ==== as_datetime
 
 [source,python]
@@ -73,7 +73,7 @@ Returns a ``datetime`` value of the attribute. If the value has another type, ra
 attribute.as_boolean()
 ----
 
-[#_Attribute_as_double]
+[#_Attribute_as_double__]
 ==== as_double
 
 [source,python]
@@ -94,7 +94,7 @@ Returns a ``double`` value of the attribute. If the value has another type, rais
 attribute.as_boolean()
 ----
 
-[#_Attribute_as_long]
+[#_Attribute_as_long__]
 ==== as_long
 
 [source,python]
@@ -115,7 +115,7 @@ Returns a ``long`` value of the attribute. If the value has another type, raises
 attribute.as_long()
 ----
 
-[#_Attribute_as_string]
+[#_Attribute_as_string__]
 ==== as_string
 
 [source,python]
@@ -136,7 +136,7 @@ Returns a ``string`` value of the attribute. If the value has another type, rais
 attribute.as_boolean()
 ----
 
-[#_Attribute_get_owners]
+[#_Attribute_get_owners__transaction_TypeDBTransaction__owner_type_ThingType__None]
 ==== get_owners
 
 [source,python]
@@ -168,7 +168,7 @@ attribute.get_owners(transaction)
 attribute.get_owners(transaction, owner_type)
 ----
 
-[#_Attribute_get_type]
+[#_Attribute_get_type__]
 ==== get_type
 
 [source,python]
@@ -189,7 +189,7 @@ Retrieves the type which this ``Attribute`` belongs to.
 attribute.get_type()
 ----
 
-[#_Attribute_get_value]
+[#_Attribute_get_value__]
 ==== get_value
 
 [source,python]
@@ -210,7 +210,7 @@ Retrieves the value which the ``Attribute`` instance holds.
 attribute.get_value()
 ----
 
-[#_Attribute_get_value_type]
+[#_Attribute_get_value_type__]
 ==== get_value_type
 
 [source,python]
@@ -231,7 +231,7 @@ Retrieves the type of the value which the ``Attribute`` instance holds.
 attribute.get_value_type()
 ----
 
-[#_Attribute_is_attribute]
+[#_Attribute_is_attribute__]
 ==== is_attribute
 
 [source,python]
@@ -252,7 +252,7 @@ Checks if the concept is an ``Attribute``.
 attribute.is_attribute()
 ----
 
-[#_Attribute_is_boolean]
+[#_Attribute_is_boolean__]
 ==== is_boolean
 
 [source,python]
@@ -273,7 +273,7 @@ Returns ``True`` if the attribute value is of type ``boolean``. Otherwise, retur
 attribute.is_boolean()
 ----
 
-[#_Attribute_is_datetime]
+[#_Attribute_is_datetime__]
 ==== is_datetime
 
 [source,python]
@@ -294,7 +294,7 @@ Returns ``True`` if the attribute value is of type ``datetime``. Otherwise, retu
 attribute.is_datetime()
 ----
 
-[#_Attribute_is_double]
+[#_Attribute_is_double__]
 ==== is_double
 
 [source,python]
@@ -315,7 +315,7 @@ Returns ``True`` if the attribute value is of type ``double``. Otherwise, return
 attribute.is_double()
 ----
 
-[#_Attribute_is_long]
+[#_Attribute_is_long__]
 ==== is_long
 
 [source,python]
@@ -336,7 +336,7 @@ Returns ``True`` if the attribute value is of type ``long``. Otherwise, returns 
 attribute.is_long()
 ----
 
-[#_Attribute_is_string]
+[#_Attribute_is_string__]
 ==== is_string
 
 [source,python]

--- a/python/docs/data/Entity.adoc
+++ b/python/docs/data/Entity.adoc
@@ -10,7 +10,7 @@ Instance of data of an entity type, representing a standalone object that exists
 Entity does not have a value. It is usually addressed by its ownership over attribute instances and/or roles played in relation instances.
 
 // tag::methods[]
-[#_Entity_as_entity]
+[#_Entity_as_entity__]
 ==== as_entity
 
 [source,python]
@@ -31,7 +31,7 @@ Casts the concept to ``Entity``.
 entity.as_entity()
 ----
 
-[#_Entity_get_type]
+[#_Entity_get_type__]
 ==== get_type
 
 [source,python]
@@ -52,7 +52,7 @@ Retrieves the type which this ``Entity`` belongs to.
 entity.get_type()
 ----
 
-[#_Entity_is_entity]
+[#_Entity_is_entity__]
 ==== is_entity
 
 [source,python]

--- a/python/docs/data/Relation.adoc
+++ b/python/docs/data/Relation.adoc
@@ -8,7 +8,7 @@
 Relation is an instance of a relation type and can be uniquely addressed by a combination of its type, owned attributes and role players.
 
 // tag::methods[]
-[#_Relation_add_player]
+[#_Relation_add_player__transaction_TypeDBTransaction__role_type_RoleType__player_Thing]
 ==== add_player
 
 [source,python]
@@ -40,7 +40,7 @@ a| `player` a| The thing to play the role a| `Thing` a|
 relation.add_player(transaction, role_type, player).resolve()
 ----
 
-[#_Relation_as_relation]
+[#_Relation_as_relation__]
 ==== as_relation
 
 [source,python]
@@ -61,7 +61,7 @@ Casts the concept to ``Relation``.
 relation.as_relation()
 ----
 
-[#_Relation_get_players]
+[#_Relation_get_players__transaction_TypeDBTransaction]
 ==== get_players
 
 [source,python]
@@ -91,7 +91,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 relation.get_players(transaction)
 ----
 
-[#_Relation_get_players_by_role_type]
+[#_Relation_get_players_by_role_type__transaction_TypeDBTransaction__role_types_RoleType]
 ==== get_players_by_role_type
 
 [source,python]
@@ -123,7 +123,7 @@ relation.get_players_by_role_type(transaction)
 relation.get_players_by_role_type(transaction, role_type1, role_type2)
 ----
 
-[#_Relation_get_relating]
+[#_Relation_get_relating__transaction_TypeDBTransaction]
 ==== get_relating
 
 [source,python]
@@ -153,7 +153,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 relation.get_relating(transaction)
 ----
 
-[#_Relation_get_type]
+[#_Relation_get_type__]
 ==== get_type
 
 [source,python]
@@ -174,7 +174,7 @@ Retrieves the type which this ``Relation`` belongs to.
 relation.get_type()
 ----
 
-[#_Relation_is_relation]
+[#_Relation_is_relation__]
 ==== is_relation
 
 [source,python]
@@ -195,7 +195,7 @@ Checks if the concept is a ``Relation``.
 relation.is_relation()
 ----
 
-[#_Relation_remove_player]
+[#_Relation_remove_player__transaction_TypeDBTransaction__role_type_RoleType__player_Thing]
 ==== remove_player
 
 [source,python]

--- a/python/docs/data/Thing.adoc
+++ b/python/docs/data/Thing.adoc
@@ -6,7 +6,7 @@
 * `Concept`
 
 // tag::methods[]
-[#_Thing_as_thing]
+[#_Thing_as_thing__]
 ==== as_thing
 
 [source,python]
@@ -27,7 +27,7 @@ Casts the concept to ``Thing``.
 thing.as_thing()
 ----
 
-[#_Thing_delete]
+[#_Thing_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,python]
@@ -57,7 +57,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing.delete(transaction).resolve()
 ----
 
-[#_Thing_get_has]
+[#_Thing_get_has__transaction_TypeDBTransaction__attribute_type_AttributeType__attribute_types_list_AttributeType___annotations_set_Annotation_]
 ==== get_has
 
 [source,python]
@@ -92,7 +92,7 @@ thing.get_has(transaction, attribute_type=attribute_type,
               annotations=set(Annotation.key()))
 ----
 
-[#_Thing_get_iid]
+[#_Thing_get_iid__]
 ==== get_iid
 
 [source,python]
@@ -113,7 +113,7 @@ Retrieves the unique id of the ``Thing``.
 thing.get_iid()
 ----
 
-[#_Thing_get_playing]
+[#_Thing_get_playing__transaction_TypeDBTransaction]
 ==== get_playing
 
 [source,python]
@@ -143,7 +143,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing.get_playing(transaction)
 ----
 
-[#_Thing_get_relations]
+[#_Thing_get_relations__transaction_TypeDBTransaction__role_types_list_RoleType_]
 ==== get_relations
 
 [source,python]
@@ -174,7 +174,7 @@ a| `role_types` a| The list of roles to filter the relations by. a| `list[RoleTy
 thing.get_relations(transaction, role_types)
 ----
 
-[#_Thing_get_type]
+[#_Thing_get_type__]
 ==== get_type
 
 [source,python]
@@ -195,7 +195,7 @@ Retrieves the type which this ``Thing`` belongs to.
 thing.get_type()
 ----
 
-[#_Thing_is_deleted]
+[#_Thing_is_deleted__transaction_TypeDBTransaction]
 ==== is_deleted
 
 [source,python]
@@ -225,7 +225,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing.is_deleted(transaction).resolve()
 ----
 
-[#_Thing_is_inferred]
+[#_Thing_is_inferred__]
 ==== is_inferred
 
 [source,python]
@@ -246,7 +246,7 @@ Checks if this ``Thing`` is inferred by a [Reasoning Rule].
 thing.is_inferred()
 ----
 
-[#_Thing_is_thing]
+[#_Thing_is_thing__]
 ==== is_thing
 
 [source,python]
@@ -267,7 +267,7 @@ Checks if the concept is a ``Thing``.
 thing.is_thing()
 ----
 
-[#_Thing_set_has]
+[#_Thing_set_has__transaction_TypeDBTransaction__attribute_Attribute]
 ==== set_has
 
 [source,python]
@@ -298,7 +298,7 @@ a| `attribute` a| The ``Attribute`` to be owned by this ``Thing``. a| `Attribute
 thing.set_has(transaction, attribute).resolve()
 ----
 
-[#_Thing_unset_has]
+[#_Thing_unset_has__transaction_TypeDBTransaction__attribute_Attribute]
 ==== unset_has
 
 [source,python]

--- a/python/docs/data/Value.adoc
+++ b/python/docs/data/Value.adoc
@@ -6,7 +6,7 @@
 * `Concept`
 
 // tag::methods[]
-[#_Value_as_boolean]
+[#_Value_as_boolean__]
 ==== as_boolean
 
 [source,python]
@@ -27,7 +27,7 @@ Returns a ``boolean`` value of this value concept. If the value has another type
 value.as_boolean()
 ----
 
-[#_Value_as_datetime]
+[#_Value_as_datetime__]
 ==== as_datetime
 
 [source,python]
@@ -48,7 +48,7 @@ Returns a ``datetime`` value of this value concept. If the value has another typ
 value.as_datetime()
 ----
 
-[#_Value_as_double]
+[#_Value_as_double__]
 ==== as_double
 
 [source,python]
@@ -69,7 +69,7 @@ Returns a ``double`` value of this value concept. If the value has another type,
 value.as_double()
 ----
 
-[#_Value_as_long]
+[#_Value_as_long__]
 ==== as_long
 
 [source,python]
@@ -90,7 +90,7 @@ Returns a ``long`` value of this value concept. If the value has another type, r
 value.as_long()
 ----
 
-[#_Value_as_string]
+[#_Value_as_string__]
 ==== as_string
 
 [source,python]
@@ -111,7 +111,7 @@ Returns a ``string`` value of this value concept. If the value has another type,
 value.as_string()
 ----
 
-[#_Value_as_value]
+[#_Value_as_value__]
 ==== as_value
 
 [source,python]
@@ -132,7 +132,7 @@ Casts the concept to ``Value``.
 value.as_value()
 ----
 
-[#_Value_get]
+[#_Value_get__]
 ==== get
 
 [source,python]
@@ -153,7 +153,7 @@ Retrieves the value which this value concept holds.
 value.get()
 ----
 
-[#_Value_get_value_type]
+[#_Value_get_value_type__]
 ==== get_value_type
 
 [source,python]
@@ -174,7 +174,7 @@ Retrieves the ``ValueType`` of this value concept.
 value.get_value_type()
 ----
 
-[#_Value_is_boolean]
+[#_Value_is_boolean__]
 ==== is_boolean
 
 [source,python]
@@ -195,7 +195,7 @@ Returns ``True`` if the value which this value concept holds is of type ``boolea
 value.is_boolean()
 ----
 
-[#_Value_is_datetime]
+[#_Value_is_datetime__]
 ==== is_datetime
 
 [source,python]
@@ -216,7 +216,7 @@ Returns ``True`` if the value which this value concept holds is of type ``dateti
 value.is_datetime()
 ----
 
-[#_Value_is_double]
+[#_Value_is_double__]
 ==== is_double
 
 [source,python]
@@ -237,7 +237,7 @@ Returns ``True`` if the value which this value concept holds is of type ``double
 value.is_double()
 ----
 
-[#_Value_is_long]
+[#_Value_is_long__]
 ==== is_long
 
 [source,python]
@@ -258,7 +258,7 @@ Returns ``True`` if the value which this value concept holds is of type ``long``
 value.is_long()
 ----
 
-[#_Value_is_string]
+[#_Value_is_string__]
 ==== is_string
 
 [source,python]
@@ -279,7 +279,7 @@ Returns ``True`` if the value which this value concept holds is of type ``string
 value.is_string()
 ----
 
-[#_Value_is_value]
+[#_Value_is_value__]
 ==== is_value
 
 [source,python]

--- a/python/docs/logic/LogicManager.adoc
+++ b/python/docs/logic/LogicManager.adoc
@@ -4,7 +4,7 @@
 Provides methods for manipulating rules in the database.
 
 // tag::methods[]
-[#_LogicManager_get_rule]
+[#_LogicManager_get_rule__label_str]
 ==== get_rule
 
 [source,python]
@@ -34,7 +34,7 @@ a| `label` a| The label of the Rule to create or retrieve a| `str` a|
 transaction.logic.get_rule(label).resolve()
 ----
 
-[#_LogicManager_get_rules]
+[#_LogicManager_get_rules__]
 ==== get_rules
 
 [source,python]
@@ -55,7 +55,7 @@ Retrieves all rules.
 transaction.logic.get_rules()
 ----
 
-[#_LogicManager_put_rule]
+[#_LogicManager_put_rule__label_str__when_str__then_str]
 ==== put_rule
 
 [source,python]

--- a/python/docs/logic/Rule.adoc
+++ b/python/docs/logic/Rule.adoc
@@ -17,7 +17,7 @@ a| `when` a| `str` a| The statements that constitute the ‘when’ of the rule.
 // end::properties[]
 
 // tag::methods[]
-[#_Rule_delete]
+[#_Rule_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,python]
@@ -47,7 +47,7 @@ a| `transaction` a| The current ``Transaction`` a| `TypeDBTransaction` a|
 rule.delete(transaction).resolve()
 ----
 
-[#_Rule_is_deleted]
+[#_Rule_is_deleted__transaction_TypeDBTransaction]
 ==== is_deleted
 
 [source,python]
@@ -77,7 +77,7 @@ a| `transaction` a| The current ``Transaction`` a| `TypeDBTransaction` a|
 rule.is_deleted(transaction).resolve()
 ----
 
-[#_Rule_set_label]
+[#_Rule_set_label__transaction_TypeDBTransaction__new_label_str]
 ==== set_label
 
 [source,python]

--- a/python/docs/schema/Annotation.adoc
+++ b/python/docs/schema/Annotation.adoc
@@ -2,7 +2,7 @@
 === Annotation
 
 // tag::methods[]
-[#_Annotation_is_key]
+[#_Annotation_is_key__]
 ==== is_key
 
 [source,python]
@@ -23,7 +23,7 @@ Checks if this ``Annotation`` is a ``@key`` annotation.
 annotation.is_key()
 ----
 
-[#_Annotation_is_unique]
+[#_Annotation_is_unique__]
 ==== is_unique
 
 [source,python]
@@ -44,7 +44,7 @@ Checks if this ``Annotation`` is a ``@unique`` annotation.
 annotation.is_unique()
 ----
 
-[#_Annotation_key]
+[#_Annotation_key__]
 ==== key
 
 [source,python]
@@ -65,7 +65,7 @@ Produces a ``@key`` annotation.
 Annotation.key()
 ----
 
-[#_Annotation_unique]
+[#_Annotation_unique__]
 ==== unique
 
 [source,python]

--- a/python/docs/schema/AttributeType.adoc
+++ b/python/docs/schema/AttributeType.adoc
@@ -14,7 +14,7 @@ Other types can own an attribute type. That means that instances of these other 
 Multiple types can own the same attribute type, and different instances of the same type or different types can share ownership of the same attribute instance.
 
 // tag::methods[]
-[#_AttributeType_as_attribute_type]
+[#_AttributeType_as_attribute_type__]
 ==== as_attribute_type
 
 [source,python]
@@ -35,7 +35,7 @@ Casts the concept to ``AttributeType``.
 attribute.as_attribute_type()
 ----
 
-[#_AttributeType_get]
+[#_AttributeType_get__transaction_TypeDBTransaction__value_Value__bool__int__float__str__datetime]
 ==== get
 
 [source,python]
@@ -66,7 +66,7 @@ a| `value` a| ``Attribute``’s value a| `Value \| bool \| int \| float \| str \
 attribute = attribute_type.get(transaction, value).resolve()
 ----
 
-[#_AttributeType_get_instances]
+[#_AttributeType_get_instances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_instances
 
 [source,python]
@@ -98,7 +98,7 @@ attribute_type.get_instances(transaction)
 attribute_type.get_instances(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_get_owners]
+[#_AttributeType_get_owners__transaction_TypeDBTransaction__annotations_set_Annotation___None__transitivity_Transitivity]
 ==== get_owners
 
 [source,python]
@@ -131,7 +131,7 @@ attribute_type.get_owners(transaction)
 attribute_type.get_owners(transaction, annotations=Annotation.unique(), transitivity=Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_get_regex]
+[#_AttributeType_get_regex__transaction_TypeDBTransaction]
 ==== get_regex
 
 [source,python]
@@ -161,7 +161,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 attribute_type.get_regex(transaction).resolve()
 ----
 
-[#_AttributeType_get_subtypes_with_value_type]
+[#_AttributeType_get_subtypes_with_value_type__transaction_TypeDBTransaction__value_type_ValueType__transitivity_Transitivity]
 ==== get_subtypes_with_value_type
 
 [source,python]
@@ -195,7 +195,7 @@ attribute_type.get_subtypes_with_value_type(transaction, value_type,
                                             Transitivity.EXPLICIT)
 ----
 
-[#_AttributeType_get_value_type]
+[#_AttributeType_get_value_type__]
 ==== get_value_type
 
 [source,python]
@@ -216,7 +216,7 @@ Retrieves the ``ValueType`` of this ``AttributeType``.
 attribute_type.get_value_type()
 ----
 
-[#_AttributeType_is_attribute_type]
+[#_AttributeType_is_attribute_type__]
 ==== is_attribute_type
 
 [source,python]
@@ -237,7 +237,7 @@ Checks if the concept is an ``AttributeType``.
 attribute.is_attribute_type()
 ----
 
-[#_AttributeType_is_boolean]
+[#_AttributeType_is_boolean__]
 ==== is_boolean
 
 [source,python]
@@ -258,7 +258,7 @@ Returns ``True`` if the value for attributes of this type is of type ``boolean``
 attribute_type.is_boolean()
 ----
 
-[#_AttributeType_is_datetime]
+[#_AttributeType_is_datetime__]
 ==== is_datetime
 
 [source,python]
@@ -279,7 +279,7 @@ Returns ``True`` if the value for attributes of this type is of type ``datetime`
 attribute_type.is_datetime()
 ----
 
-[#_AttributeType_is_double]
+[#_AttributeType_is_double__]
 ==== is_double
 
 [source,python]
@@ -300,7 +300,7 @@ Returns ``True`` if the value for attributes of this type is of type ``double``.
 attribute_type.is_double()
 ----
 
-[#_AttributeType_is_long]
+[#_AttributeType_is_long__]
 ==== is_long
 
 [source,python]
@@ -321,7 +321,7 @@ Returns ``True`` if the value for attributes of this type is of type ``long``. O
 attribute_type.is_long()
 ----
 
-[#_AttributeType_is_string]
+[#_AttributeType_is_string__]
 ==== is_string
 
 [source,python]
@@ -342,7 +342,7 @@ Returns ``True`` if the value for attributes of this type is of type ``string``.
 attribute_type.is_string()
 ----
 
-[#_AttributeType_put]
+[#_AttributeType_put__transaction_TypeDBTransaction__value_Value__bool__int__float__str__datetime]
 ==== put
 
 [source,python]
@@ -373,7 +373,7 @@ a| `value` a| New ``Attribute``’s value a| `Value \| bool \| int \| float \| s
 attribute = attribute_type.put(transaction, value).resolve()
 ----
 
-[#_AttributeType_set_regex]
+[#_AttributeType_set_regex__transaction_TypeDBTransaction__regex_str]
 ==== set_regex
 
 [source,python]
@@ -406,7 +406,7 @@ a| `regex` a| Regular expression a| `str` a|
 attribute_type.set_regex(transaction, regex).resolve()
 ----
 
-[#_AttributeType_set_supertype]
+[#_AttributeType_set_supertype__transaction_TypeDBTransaction__super_attribute_type_AttributeType]
 ==== set_supertype
 
 [source,python]
@@ -437,7 +437,7 @@ a| `super_attribute_type` a| The ``AttributeType`` to set as the supertype of th
 attribute_type.set_supertype(transaction, super_attribute_type).resolve()
 ----
 
-[#_AttributeType_unset_regex]
+[#_AttributeType_unset_regex__transaction_TypeDBTransaction]
 ==== unset_regex
 
 [source,python]

--- a/python/docs/schema/EntityType.adoc
+++ b/python/docs/schema/EntityType.adoc
@@ -8,7 +8,7 @@
 Entity types represent the classification of independent objects in the data model of the business domain.
 
 // tag::methods[]
-[#_EntityType_as_entity_type]
+[#_EntityType_as_entity_type__]
 ==== as_entity_type
 
 [source,python]
@@ -29,7 +29,7 @@ Casts the concept to ``EntityType``.
 entity_type.as_entity_type()
 ----
 
-[#_EntityType_create]
+[#_EntityType_create__transaction_TypeDBTransaction]
 ==== create
 
 [source,python]
@@ -59,7 +59,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 entity_type.create(transaction).resolve()
 ----
 
-[#_EntityType_get_instances]
+[#_EntityType_get_instances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_instances
 
 [source,python]
@@ -90,7 +90,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect instanc
 entity_type.get_instances(transaction, transitivity)
 ----
 
-[#_EntityType_get_subtypes]
+[#_EntityType_get_subtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_subtypes
 
 [source,python]
@@ -121,7 +121,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 entity_type.get_subtypes(transaction, transitivity)
 ----
 
-[#_EntityType_is_entity_type]
+[#_EntityType_is_entity_type__]
 ==== is_entity_type
 
 [source,python]
@@ -142,7 +142,7 @@ Checks if the concept is an ``EntityType``.
 entity_type.is_entity_type()
 ----
 
-[#_EntityType_set_supertype]
+[#_EntityType_set_supertype__transaction_TypeDBTransaction__super_entity_type_EntityType]
 ==== set_supertype
 
 [source,python]

--- a/python/docs/schema/Label.adoc
+++ b/python/docs/schema/Label.adoc
@@ -18,7 +18,7 @@ a| `scope` a| `str \| None` a| The scope part of the label
 // end::properties[]
 
 // tag::methods[]
-[#_Label_of]
+[#_Label_of__args_str]
 ==== of
 
 [source,python]
@@ -49,7 +49,7 @@ Label.of("entity")
 Label.of("relation", "role")
 ----
 
-[#_Label_scoped_name]
+[#_Label_scoped_name__]
 ==== scoped_name
 
 [source,python]

--- a/python/docs/schema/RelationType.adoc
+++ b/python/docs/schema/RelationType.adoc
@@ -12,7 +12,7 @@ Other types can play roles in relations if it’s mentioned in their definition.
 A relation type must specify at least one role.
 
 // tag::methods[]
-[#_RelationType_as_relation_type]
+[#_RelationType_as_relation_type__]
 ==== as_relation_type
 
 [source,python]
@@ -33,7 +33,7 @@ Casts the concept to ``RelationType``.
 relation_type.as_relation_type()
 ----
 
-[#_RelationType_create]
+[#_RelationType_create__transaction_TypeDBTransaction]
 ==== create
 
 [source,python]
@@ -63,7 +63,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 relation_type.create(transaction).resolve()
 ----
 
-[#_RelationType_get_instances]
+[#_RelationType_get_instances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_instances
 
 [source,python]
@@ -94,7 +94,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect instanc
 relation_type.get_instances(transaction, transitivity)
 ----
 
-[#_RelationType_get_relates]
+[#_RelationType_get_relates__transaction_TypeDBTransaction__role_label_str__None__transitivity_Transitivity]
 ==== get_relates
 
 [source,python]
@@ -127,7 +127,7 @@ relation_type.get_relates(transaction, role_label, transitivity).resolve()
 relation_type.get_relates(transaction, transitivity)
 ----
 
-[#_RelationType_get_relates_overridden]
+[#_RelationType_get_relates_overridden__transaction_TypeDBTransaction__role_label_str]
 ==== get_relates_overridden
 
 [source,python]
@@ -158,7 +158,7 @@ a| `role_label` a| Label of the role that overrides an inherited role a| `str` a
 relation_type.get_relates_overridden(transaction, role_label).resolve()
 ----
 
-[#_RelationType_get_subtypes]
+[#_RelationType_get_subtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_subtypes
 
 [source,python]
@@ -189,7 +189,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 relation_type.get_subtypes(transaction, transitivity)
 ----
 
-[#_RelationType_is_relation_type]
+[#_RelationType_is_relation_type__]
 ==== is_relation_type
 
 [source,python]
@@ -210,7 +210,7 @@ Checks if the concept is a ``RelationType``.
 relation_type.is_relation_type()
 ----
 
-[#_RelationType_set_relates]
+[#_RelationType_set_relates__transaction_TypeDBTransaction__role_label_str__overridden_label_str__None]
 ==== set_relates
 
 [source,python]
@@ -243,7 +243,7 @@ relation_type.set_relates(transaction, role_label).resolve()
 relation_type.set_relates(transaction, role_label, overridden_label).resolve()
 ----
 
-[#_RelationType_set_supertype]
+[#_RelationType_set_supertype__transaction_TypeDBTransaction__super_relation_type_RelationType]
 ==== set_supertype
 
 [source,python]
@@ -274,7 +274,7 @@ a| `super_relation_type` a| The ``RelationType`` to set as the supertype of this
 relation_type.set_supertype(transaction, super_relation_type).resolve()
 ----
 
-[#_RelationType_unset_relates]
+[#_RelationType_unset_relates__transaction_TypeDBTransaction__role_label_str]
 ==== unset_relates
 
 [source,python]

--- a/python/docs/schema/RoleType.adoc
+++ b/python/docs/schema/RoleType.adoc
@@ -10,7 +10,7 @@ Roles are special internal types used by relations. We can not create an instanc
 Roles allow a schema to enforce logical constraints on types of role players.
 
 // tag::methods[]
-[#_RoleType_as_role_type]
+[#_RoleType_as_role_type__]
 ==== as_role_type
 
 [source,python]
@@ -31,7 +31,7 @@ Casts the concept to ``RoleType``.
 role_type.as_role_type()
 ----
 
-[#_RoleType_get_player_instances]
+[#_RoleType_get_player_instances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_player_instances
 
 [source,python]
@@ -62,7 +62,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 role_type.get_player_instances(transaction, transitivity)
 ----
 
-[#_RoleType_get_player_types]
+[#_RoleType_get_player_types__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_player_types
 
 [source,python]
@@ -93,7 +93,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect playing
 role_type.get_player_types(transaction, transitivity)
 ----
 
-[#_RoleType_get_relation_instances]
+[#_RoleType_get_relation_instances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_relation_instances
 
 [source,python]
@@ -124,7 +124,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect relatio
 role_type.get_relation_instances(transaction, transitivity)
 ----
 
-[#_RoleType_get_relation_type]
+[#_RoleType_get_relation_type__transaction_TypeDBTransaction]
 ==== get_relation_type
 
 [source,python]
@@ -154,7 +154,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 role_type.get_relation_type(transaction).resolve()
 ----
 
-[#_RoleType_get_relation_types]
+[#_RoleType_get_relation_types__transaction_TypeDBTransaction]
 ==== get_relation_types
 
 [source,python]
@@ -184,7 +184,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 role_type.get_relation_types(transaction)
 ----
 
-[#_RoleType_get_subtypes]
+[#_RoleType_get_subtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_subtypes
 
 [source,python]
@@ -215,7 +215,7 @@ a| `transitivity` a| ``Transitivity.TRANSITIVE`` for direct and indirect subtype
 role_type.get_subtypes(transaction, transitivity)
 ----
 
-[#_RoleType_get_supertype]
+[#_RoleType_get_supertype__transaction_TypeDBTransaction]
 ==== get_supertype
 
 [source,python]
@@ -245,7 +245,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 role_type.get_supertype(transaction).resolve()
 ----
 
-[#_RoleType_get_supertypes]
+[#_RoleType_get_supertypes__transaction_TypeDBTransaction]
 ==== get_supertypes
 
 [source,python]
@@ -275,7 +275,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 role_type.get_supertypes(transaction)
 ----
 
-[#_RoleType_is_role_type]
+[#_RoleType_is_role_type__]
 ==== is_role_type
 
 [source,python]

--- a/python/docs/schema/ThingType.adoc
+++ b/python/docs/schema/ThingType.adoc
@@ -6,7 +6,7 @@
 * `Type`
 
 // tag::methods[]
-[#_ThingType_get_instances]
+[#_ThingType_get_instances__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_instances
 
 [source,python]
@@ -38,7 +38,7 @@ thing_type.get_instances(transaction)
 thing_type.get_instances(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_ThingType_get_owns]
+[#_ThingType_get_owns__transaction_TypeDBTransaction__value_type_ValueType__None__transitivity_Transitivity__annotations_set_Annotation___None]
 ==== get_owns
 
 [source,python]
@@ -74,7 +74,7 @@ thing_type.get_owns(transaction, value_type,
                     annotations={Annotation.key()})
 ----
 
-[#_ThingType_get_owns_overridden]
+[#_ThingType_get_owns_overridden__transaction_TypeDBTransaction__attribute_type_AttributeType]
 ==== get_owns_overridden
 
 [source,python]
@@ -105,7 +105,7 @@ a| `attribute_type` a| The ``AttributeType`` that overrides requested ``Attribut
 thing_type.get_owns_overridden(transaction, attribute_type).resolve()
 ----
 
-[#_ThingType_get_plays]
+[#_ThingType_get_plays__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_plays
 
 [source,python]
@@ -137,7 +137,7 @@ thing_type.get_plays(transaction)
 thing_type.get_plays(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_ThingType_get_plays_overridden]
+[#_ThingType_get_plays_overridden__transaction_TypeDBTransaction__role_type_RoleType]
 ==== get_plays_overridden
 
 [source,python]
@@ -168,7 +168,7 @@ a| `role_type` a| The ``RoleType`` that overrides an inherited role a| `RoleType
 thing_type.get_plays_overridden(transaction, role_type).resolve()
 ----
 
-[#_ThingType_get_subtypes]
+[#_ThingType_get_subtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_subtypes
 
 [source,python]
@@ -200,7 +200,7 @@ thing_type.get_subtypes(transaction)
 thing_type.get_subtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_ThingType_get_supertype]
+[#_ThingType_get_supertype__transaction_TypeDBTransaction]
 ==== get_supertype
 
 [source,python]
@@ -230,7 +230,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing_type.get_supertype(transaction).resolve()
 ----
 
-[#_ThingType_get_supertypes]
+[#_ThingType_get_supertypes__transaction_TypeDBTransaction]
 ==== get_supertypes
 
 [source,python]
@@ -260,7 +260,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing_type.get_supertypes(transaction)
 ----
 
-[#_ThingType_get_syntax]
+[#_ThingType_get_syntax__transaction_TypeDBTransaction]
 ==== get_syntax
 
 [source,python]
@@ -290,7 +290,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing_type.get_syntax(transaction).resolve()
 ----
 
-[#_ThingType_is_thing_type]
+[#_ThingType_is_thing_type__]
 ==== is_thing_type
 
 [source,python]
@@ -311,7 +311,7 @@ Checks if the concept is a ``ThingType``.
 thing_type.is_thing_type()
 ----
 
-[#_ThingType_set_abstract]
+[#_ThingType_set_abstract__transaction_TypeDBTransaction]
 ==== set_abstract
 
 [source,python]
@@ -341,7 +341,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing_type.set_abstract(transaction).resolve()
 ----
 
-[#_ThingType_set_owns]
+[#_ThingType_set_owns__transaction_TypeDBTransaction__attribute_type_AttributeType__overridden_type_AttributeType__None__annotations_set_Annotation___None]
 ==== set_owns
 
 [source,python]
@@ -377,7 +377,7 @@ thing_type.set_owns(transaction, attribute_type,
                     annotations={Annotation.key()}).resolve()
 ----
 
-[#_ThingType_set_plays]
+[#_ThingType_set_plays__transaction_TypeDBTransaction__role_type_RoleType__overriden_type_RoleType__None]
 ==== set_plays
 
 [source,python]
@@ -410,7 +410,7 @@ thing_type.set_plays(transaction, role_type).resolve()
 thing_type.set_plays(transaction, role_type, overridden_type).resolve()
 ----
 
-[#_ThingType_unset_abstract]
+[#_ThingType_unset_abstract__transaction_TypeDBTransaction]
 ==== unset_abstract
 
 [source,python]
@@ -440,7 +440,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 thing_type.unset_abstract(transaction).resolve()
 ----
 
-[#_ThingType_unset_owns]
+[#_ThingType_unset_owns__transaction_TypeDBTransaction__attribute_type_AttributeType]
 ==== unset_owns
 
 [source,python]
@@ -471,7 +471,7 @@ a| `attribute_type` a| The ``AttributeType`` to not be owned by the type. a| `At
 thing_type.unset_owns(transaction, attribute_type).resolve()
 ----
 
-[#_ThingType_unset_plays]
+[#_ThingType_unset_plays__transaction_TypeDBTransaction__role_type_RoleType]
 ==== unset_plays
 
 [source,python]

--- a/python/docs/schema/Type.adoc
+++ b/python/docs/schema/Type.adoc
@@ -6,7 +6,7 @@
 * `Concept`
 
 // tag::methods[]
-[#_Type_delete]
+[#_Type_delete__transaction_TypeDBTransaction]
 ==== delete
 
 [source,python]
@@ -36,7 +36,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 type_.delete(transaction).resolve()
 ----
 
-[#_Type_get_label]
+[#_Type_get_label__]
 ==== get_label
 
 [source,python]
@@ -57,7 +57,7 @@ Retrieves the unique label of the type.
 type_.get_label()
 ----
 
-[#_Type_get_subtypes]
+[#_Type_get_subtypes__transaction_TypeDBTransaction__transitivity_Transitivity]
 ==== get_subtypes
 
 [source,python]
@@ -89,7 +89,7 @@ type_.get_subtypes(transaction)
 type_.get_subtypes(transaction, Transitivity.EXPLICIT)
 ----
 
-[#_Type_get_supertype]
+[#_Type_get_supertype__transaction_TypeDBTransaction]
 ==== get_supertype
 
 [source,python]
@@ -119,7 +119,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 type_.get_supertype(transaction).resolve()
 ----
 
-[#_Type_get_supertypes]
+[#_Type_get_supertypes__transaction_TypeDBTransaction]
 ==== get_supertypes
 
 [source,python]
@@ -149,7 +149,7 @@ a| `transaction` a| The current transaction a| `TypeDBTransaction` a|
 type_.get_supertypes(transaction)
 ----
 
-[#_Type_is_abstract]
+[#_Type_is_abstract__]
 ==== is_abstract
 
 [source,python]
@@ -170,7 +170,7 @@ Checks if the type is prevented from having data instances (i.e., ``abstract``).
 type_.is_abstract()
 ----
 
-[#_Type_is_root]
+[#_Type_is_root__]
 ==== is_root
 
 [source,python]
@@ -191,7 +191,7 @@ Checks if the type is a root type.
 type_.is_root()
 ----
 
-[#_Type_is_type]
+[#_Type_is_type__]
 ==== is_type
 
 [source,python]
@@ -212,7 +212,7 @@ Checks if the concept is a ``Type``.
 type_.is_type()
 ----
 
-[#_Type_set_label]
+[#_Type_set_label__transaction_TypeDBTransaction__new_label_str]
 ==== set_label
 
 [source,python]

--- a/python/docs/schema/ValueType.adoc
+++ b/python/docs/schema/ValueType.adoc
@@ -20,7 +20,7 @@ a| `STRING` a| `_ValueType(is_writable=True, is_keyable=True, 4)`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_ValueType_of]
+[#_ValueType_of__]
 ==== of
 
 [source,python]

--- a/python/docs/session/SessionType.adoc
+++ b/python/docs/session/SessionType.adoc
@@ -27,7 +27,7 @@ a| `SCHEMA` a| `1`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_SessionType_is_data]
+[#_SessionType_is_data__]
 ==== is_data
 
 [source,python]
@@ -41,7 +41,7 @@ is_data() -> bool
 .Returns
 `bool`
 
-[#_SessionType_is_schema]
+[#_SessionType_is_schema__]
 ==== is_schema
 
 [source,python]

--- a/python/docs/session/TypeDBSession.adoc
+++ b/python/docs/session/TypeDBSession.adoc
@@ -14,7 +14,7 @@ a| `type` a| `SessionType` a| The current session’s type (SCHEMA or DATA)
 // end::properties[]
 
 // tag::methods[]
-[#_TypeDBSession_close]
+[#_TypeDBSession_close__]
 ==== close
 
 [source,python]
@@ -35,7 +35,7 @@ Closes the session. Before opening a new session, the session currently open sho
 session.close()
 ----
 
-[#_TypeDBSession_database_name]
+[#_TypeDBSession_database_name__]
 ==== database_name
 
 [source,python]
@@ -56,7 +56,7 @@ Returns the name of the database of the session.
 session.database_name()
 ----
 
-[#_TypeDBSession_is_open]
+[#_TypeDBSession_is_open__]
 ==== is_open
 
 [source,python]
@@ -77,7 +77,7 @@ Checks whether this session is open.
 session.is_open()
 ----
 
-[#_TypeDBSession_on_close]
+[#_TypeDBSession_on_close__function_callable]
 ==== on_close
 
 [source,python]
@@ -107,7 +107,7 @@ a| `function` a| The callback function. a| `callable` a|
 session.on_close(function)
 ----
 
-[#_TypeDBSession_transaction]
+[#_TypeDBSession_transaction__transaction_type_TransactionType__options_TypeDBOptions]
 ==== transaction
 
 [source,python]

--- a/python/docs/transaction/QueryManager.adoc
+++ b/python/docs/transaction/QueryManager.adoc
@@ -4,7 +4,7 @@
 Provides methods for executing TypeQL queries in the transaction.
 
 // tag::methods[]
-[#_QueryManager_define]
+[#_QueryManager_define__query_str__options_TypeDBOptions]
 ==== define
 
 [source,python]
@@ -35,7 +35,7 @@ a| `options` a| Specify query options a| `TypeDBOptions` a| `None`
 transaction.query.define(query, options).resolve()
 ----
 
-[#_QueryManager_delete]
+[#_QueryManager_delete__query_str__options_TypeDBOptions__None]
 ==== delete
 
 [source,python]
@@ -66,7 +66,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.delete(query, options).resolve()
 ----
 
-[#_QueryManager_explain]
+[#_QueryManager_explain__explainable_ConceptMap_Explainable__options_TypeDBOptions__None]
 ==== explain
 
 [source,python]
@@ -97,7 +97,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.explain(explainable, options)
 ----
 
-[#_QueryManager_fetch]
+[#_QueryManager_fetch__query_str__options_TypeDBOptions__None]
 ==== fetch
 
 [source,python]
@@ -128,7 +128,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.fetch(query, options)
 ----
 
-[#_QueryManager_get]
+[#_QueryManager_get__query_str__options_TypeDBOptions__None]
 ==== get
 
 [source,python]
@@ -159,7 +159,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.get(query, options)
 ----
 
-[#_QueryManager_get_aggregate]
+[#_QueryManager_get_aggregate__query_str__options_TypeDBOptions__None]
 ==== get_aggregate
 
 [source,python]
@@ -190,7 +190,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.get_aggregate(query, options).resolve()
 ----
 
-[#_QueryManager_get_group]
+[#_QueryManager_get_group__query_str__options_TypeDBOptions__None]
 ==== get_group
 
 [source,python]
@@ -221,7 +221,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.get_group(query, options)
 ----
 
-[#_QueryManager_get_group_aggregate]
+[#_QueryManager_get_group_aggregate__query_str__options_TypeDBOptions__None]
 ==== get_group_aggregate
 
 [source,python]
@@ -252,7 +252,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.get_group_aggregate(query, options)
 ----
 
-[#_QueryManager_insert]
+[#_QueryManager_insert__query_str__options_TypeDBOptions__None]
 ==== insert
 
 [source,python]
@@ -283,7 +283,7 @@ a| `options` a| Specify query options a| `TypeDBOptions \| None` a| `None`
 transaction.query.insert(query, options)
 ----
 
-[#_QueryManager_undefine]
+[#_QueryManager_undefine__query_str__options_TypeDBOptions]
 ==== undefine
 
 [source,python]
@@ -314,7 +314,7 @@ a| `options` a| Specify query options a| `TypeDBOptions` a| `None`
 transaction.query.undefine(query, options).resolve()
 ----
 
-[#_QueryManager_update]
+[#_QueryManager_update__query_str__options_TypeDBOptions__None]
 ==== update
 
 [source,python]

--- a/python/docs/transaction/TransactionType.adoc
+++ b/python/docs/transaction/TransactionType.adoc
@@ -27,7 +27,7 @@ a| `WRITE` a| `1`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_TransactionType_is_read]
+[#_TransactionType_is_read__]
 ==== is_read
 
 [source,python]
@@ -41,7 +41,7 @@ is_read() -> bool
 .Returns
 `bool`
 
-[#_TransactionType_is_write]
+[#_TransactionType_is_write__]
 ==== is_write
 
 [source,python]

--- a/python/docs/transaction/TypeDBTransaction.adoc
+++ b/python/docs/transaction/TypeDBTransaction.adoc
@@ -17,7 +17,7 @@ a| `transaction_type` a| `TransactionType` a| The transaction’s type (READ or 
 // end::properties[]
 
 // tag::methods[]
-[#_TypeDBTransaction_close]
+[#_TypeDBTransaction_close__]
 ==== close
 
 [source,python]
@@ -38,7 +38,7 @@ Closes the transaction.
 transaction.close()
 ----
 
-[#_TypeDBTransaction_commit]
+[#_TypeDBTransaction_commit__]
 ==== commit
 
 [source,python]
@@ -59,7 +59,7 @@ Commits the changes made via this transaction to the TypeDB database. Whether or
 transaction.commit()
 ----
 
-[#_TypeDBTransaction_is_open]
+[#_TypeDBTransaction_is_open__]
 ==== is_open
 
 [source,python]
@@ -80,7 +80,7 @@ Checks whether this transaction is open.
 transaction.is_open()
 ----
 
-[#_TypeDBTransaction_on_close]
+[#_TypeDBTransaction_on_close__function_callable]
 ==== on_close
 
 [source,python]
@@ -110,7 +110,7 @@ a| `function` a| The callback function. a| `callable` a|
 transaction.on_close(function)
 ----
 
-[#_TypeDBTransaction_rollback]
+[#_TypeDBTransaction_rollback__]
 ==== rollback
 
 [source,python]

--- a/rust/docs/answer/ConceptMap.adoc
+++ b/rust/docs/answer/ConceptMap.adoc
@@ -26,7 +26,7 @@ a| `map` a| `HashMap<String, Concept>` a| The ``HashMap`` where keys are query v
 // end::properties[]
 
 // tag::methods[]
-[#_struct_ConceptMap_method_concepts]
+[#_struct_ConceptMap_concepts__]
 ==== concepts
 
 [source,rust]
@@ -50,7 +50,7 @@ impl Iterator<Item = &Concept>
 concept_map.concepts()
 ----
 
-[#_struct_ConceptMap_method_get]
+[#_struct_ConceptMap_get__var_name_str]
 ==== get
 
 [source,rust]

--- a/rust/docs/answer/Explainables.adoc
+++ b/rust/docs/answer/Explainables.adoc
@@ -25,7 +25,7 @@ a| `relations` a| `HashMap<String, Explainable>` a| Explainable relations
 // end::properties[]
 
 // tag::methods[]
-[#_struct_Explainables_method_is_empty]
+[#_struct_Explainables_is_empty__]
 ==== is_empty
 
 [source,rust]

--- a/rust/docs/concept/ConceptManager.adoc
+++ b/rust/docs/concept/ConceptManager.adoc
@@ -8,7 +8,7 @@
 Provides access for all Concept API methods.
 
 // tag::methods[]
-[#_struct_ConceptManager_method_get_attribute]
+[#_struct_ConceptManager_get_attribute__iid_IID]
 ==== get_attribute
 
 [source,rust]
@@ -62,7 +62,7 @@ transaction.concepts().get_attribute(iid).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_get_attribute_type]
+[#_struct_ConceptManager_get_attribute_type__label_String]
 ==== get_attribute_type
 
 [source,rust]
@@ -116,7 +116,7 @@ transaction.concepts().get_attribute_type(label).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_get_entity]
+[#_struct_ConceptManager_get_entity__iid_IID]
 ==== get_entity
 
 [source,rust]
@@ -167,7 +167,7 @@ transaction.concepts().get_entity(iid).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_get_entity_type]
+[#_struct_ConceptManager_get_entity_type__label_String]
 ==== get_entity_type
 
 [source,rust]
@@ -221,7 +221,7 @@ transaction.concepts().get_entity_type(label).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_get_relation]
+[#_struct_ConceptManager_get_relation__iid_IID]
 ==== get_relation
 
 [source,rust]
@@ -275,7 +275,7 @@ transaction.concepts().get_relation(iid).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_get_relation_type]
+[#_struct_ConceptManager_get_relation_type__label_String]
 ==== get_relation_type
 
 [source,rust]
@@ -329,7 +329,7 @@ transaction.concepts().get_relation_type(label).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_get_schema_exceptions]
+[#_struct_ConceptManager_get_schema_exceptions__]
 ==== get_schema_exceptions
 
 [source,rust]
@@ -355,7 +355,7 @@ Result<impl Stream<Item = Result<SchemaException>> + 'tx>
 transaction.concepts().get_schema_exceptions()
 ----
 
-[#_struct_ConceptManager_method_put_attribute_type]
+[#_struct_ConceptManager_put_attribute_type__label_String__value_type_ValueType]
 ==== put_attribute_type
 
 [source,rust]
@@ -411,7 +411,7 @@ transaction.concepts().put_attribute_type(label, value_type).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_put_entity_type]
+[#_struct_ConceptManager_put_entity_type__label_String]
 ==== put_entity_type
 
 [source,rust]
@@ -465,7 +465,7 @@ transaction.concepts().put_entity_type(label).resolve()
 --
 ====
 
-[#_struct_ConceptManager_method_put_relation_type]
+[#_struct_ConceptManager_put_relation_type__label_String]
 ==== put_relation_type
 
 [source,rust]

--- a/rust/docs/connection/Connection.adoc
+++ b/rust/docs/connection/Connection.adoc
@@ -7,7 +7,7 @@
 * `Debug`
 
 // tag::methods[]
-[#_struct_Connection_method_force_close]
+[#_struct_Connection_force_close__]
 ==== force_close
 
 [source,rust]
@@ -31,7 +31,7 @@ Result
 connection.force_close()
 ----
 
-[#_struct_Connection_method_is_enterprise]
+[#_struct_Connection_is_enterprise__]
 ==== is_enterprise
 
 [source,rust]
@@ -55,7 +55,7 @@ bool
 connection.is_enterprise()
 ----
 
-[#_struct_Connection_method_is_open]
+[#_struct_Connection_is_open__]
 ==== is_open
 
 [source,rust]
@@ -79,7 +79,7 @@ bool
 connection.is_open()
 ----
 
-[#_struct_Connection_method_new_core]
+[#_struct_Connection_new_core__address_impl_AsRef_str_]
 ==== new_core
 
 [source,rust]
@@ -112,7 +112,7 @@ Result<Self>
 Connection::new_core("127.0.0.1:1729")
 ----
 
-[#_struct_Connection_method_new_enterprise]
+[#_struct_Connection_new_enterprise__init_addresses__T___credential_Credential]
 ==== new_enterprise
 
 [source,rust]

--- a/rust/docs/connection/Credential.adoc
+++ b/rust/docs/connection/Credential.adoc
@@ -7,7 +7,7 @@
 * `Debug`
 
 // tag::methods[]
-[#_struct_Credential_method_is_tls_enabled]
+[#_struct_Credential_is_tls_enabled__]
 ==== is_tls_enabled
 
 [source,rust]
@@ -24,7 +24,7 @@ Retrieves whether TLS is enabled for the connection.
 bool
 ----
 
-[#_struct_Credential_method_password]
+[#_struct_Credential_password__]
 ==== password
 
 [source,rust]
@@ -41,7 +41,7 @@ Retrieves the password used.
 &str
 ----
 
-[#_struct_Credential_method_username]
+[#_struct_Credential_username__]
 ==== username
 
 [source,rust]
@@ -58,7 +58,7 @@ Retrieves the username used.
 &str
 ----
 
-[#_struct_Credential_method_with_tls]
+[#_struct_Credential_with_tls__username_str__password_str__tls_root_ca_Option_Path_]
 ==== with_tls
 
 [source,rust]
@@ -97,7 +97,7 @@ Result<Self>
 Credential::with_tls(username, password, Some(&path_to_ca));
 ----
 
-[#_struct_Credential_method_without_tls]
+[#_struct_Credential_without_tls__username_str__password_str]
 ==== without_tls
 
 [source,rust]

--- a/rust/docs/connection/Database.adoc
+++ b/rust/docs/connection/Database.adoc
@@ -6,7 +6,7 @@
 * `Debug`
 
 // tag::methods[]
-[#_struct_Database_method_delete]
+[#_struct_Database_delete__]
 ==== delete
 
 [tabs]
@@ -66,7 +66,7 @@ database.delete();
 --
 ====
 
-[#_struct_Database_method_name]
+[#_struct_Database_name__]
 ==== name
 
 [source,rust]
@@ -83,7 +83,7 @@ Retrieves the database name as a string.
 &str
 ----
 
-[#_struct_Database_method_preferred_replica_info]
+[#_struct_Database_preferred_replica_info__]
 ==== preferred_replica_info
 
 [source,rust]
@@ -107,7 +107,7 @@ Option<ReplicaInfo>
 database.preferred_replica_info();
 ----
 
-[#_struct_Database_method_primary_replica_info]
+[#_struct_Database_primary_replica_info__]
 ==== primary_replica_info
 
 [source,rust]
@@ -131,7 +131,7 @@ Option<ReplicaInfo>
 database.primary_replica_info()
 ----
 
-[#_struct_Database_method_replicas_info]
+[#_struct_Database_replicas_info__]
 ==== replicas_info
 
 [source,rust]
@@ -155,7 +155,7 @@ Vec<ReplicaInfo>
 database.replicas_info()
 ----
 
-[#_struct_Database_method_rule_schema]
+[#_struct_Database_rule_schema__]
 ==== rule_schema
 
 [tabs]
@@ -215,7 +215,7 @@ database.rule_schema();
 --
 ====
 
-[#_struct_Database_method_schema]
+[#_struct_Database_schema__]
 ==== schema
 
 [tabs]
@@ -275,7 +275,7 @@ database.schema();
 --
 ====
 
-[#_struct_Database_method_type_schema]
+[#_struct_Database_type_schema__]
 ==== type_schema
 
 [tabs]

--- a/rust/docs/connection/DatabaseManager.adoc
+++ b/rust/docs/connection/DatabaseManager.adoc
@@ -7,7 +7,7 @@
 * `Debug`
 
 // tag::methods[]
-[#_struct_DatabaseManager_method_all]
+[#_struct_DatabaseManager_all__]
 ==== all
 
 [tabs]
@@ -67,7 +67,7 @@ driver.databases().all();
 --
 ====
 
-[#_struct_DatabaseManager_method_contains]
+[#_struct_DatabaseManager_contains__name_impl_Into_String_]
 ==== contains
 
 [tabs]
@@ -136,7 +136,7 @@ driver.databases().contains(name);
 --
 ====
 
-[#_struct_DatabaseManager_method_create]
+[#_struct_DatabaseManager_create__name_impl_Into_String_]
 ==== create
 
 [tabs]
@@ -205,7 +205,7 @@ driver.databases().create(name);
 --
 ====
 
-[#_struct_DatabaseManager_method_get]
+[#_struct_DatabaseManager_get__name_impl_Into_String_]
 ==== get
 
 [tabs]

--- a/rust/docs/connection/User.adoc
+++ b/rust/docs/connection/User.adoc
@@ -21,7 +21,7 @@ a| `username` a| `String` a| Returns the name of this user.
 // end::properties[]
 
 // tag::methods[]
-[#_struct_User_method_password_update]
+[#_struct_User_password_update__connection_Connection__password_old_impl_Into_String___password_new_impl_Into_String_]
 ==== password_update
 
 [tabs]

--- a/rust/docs/connection/UserManager.adoc
+++ b/rust/docs/connection/UserManager.adoc
@@ -9,7 +9,7 @@
 Provides access to all user management methods.
 
 // tag::methods[]
-[#_struct_UserManager_method_all]
+[#_struct_UserManager_all__]
 ==== all
 
 [tabs]
@@ -51,7 +51,7 @@ Result<Vec<User>>
 driver.users.all().await;
 ----
 
-[#_struct_UserManager_method_contains]
+[#_struct_UserManager_contains__username_impl_Into_String_]
 ==== contains
 
 [tabs]
@@ -102,7 +102,7 @@ Result<bool>
 driver.users.contains(username).await;
 ----
 
-[#_struct_UserManager_method_create]
+[#_struct_UserManager_create__username_impl_Into_String___password_impl_Into_String_]
 ==== create
 
 [tabs]
@@ -162,7 +162,7 @@ Result
 driver.users.create(username, password).await;
 ----
 
-[#_struct_UserManager_method_current_user]
+[#_struct_UserManager_current_user__]
 ==== current_user
 
 [tabs]
@@ -204,7 +204,7 @@ Result<Option<User>>
 driver.users.current_user().await;
 ----
 
-[#_struct_UserManager_method_delete]
+[#_struct_UserManager_delete__username_impl_Into_String_]
 ==== delete
 
 [tabs]
@@ -255,7 +255,7 @@ Result
 driver.users.delete(username).await;
 ----
 
-[#_struct_UserManager_method_get]
+[#_struct_UserManager_get__username_impl_Into_String_]
 ==== get
 
 [tabs]
@@ -306,7 +306,7 @@ Result<Option<User>>
 driver.users.get(username).await;
 ----
 
-[#_struct_UserManager_method_set_password]
+[#_struct_UserManager_set_password__username_impl_Into_String___password_impl_Into_String_]
 ==== set_password
 
 [tabs]

--- a/rust/docs/data/Attribute.adoc
+++ b/rust/docs/data/Attribute.adoc
@@ -27,7 +27,7 @@ a| `value` a| `Value` a| The value which this Attribute instance holds.
 // end::properties[]
 
 // tag::methods[]
-[#_struct_Attribute_method_delete]
+[#_struct_Attribute_delete__]
 ==== delete
 
 [source,rust]
@@ -47,7 +47,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Attribute_method_get_has]
+[#_struct_Attribute_get_has__]
 ==== get_has
 
 [source,rust]
@@ -69,7 +69,7 @@ fn get_has<'tx>(
 Result<BoxStream<'tx, Result<Attribute>>>
 ----
 
-[#_struct_Attribute_method_get_owners]
+[#_struct_Attribute_get_owners__]
 ==== get_owners
 
 [source,rust]
@@ -90,7 +90,7 @@ fn get_owners<'tx>(
 Result<BoxStream<'tx, Result<Thing>>>
 ----
 
-[#_struct_Attribute_method_get_playing]
+[#_struct_Attribute_get_playing__]
 ==== get_playing
 
 [source,rust]
@@ -110,7 +110,7 @@ fn get_playing<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_Attribute_method_get_relations]
+[#_struct_Attribute_get_relations__]
 ==== get_relations
 
 [source,rust]
@@ -131,7 +131,7 @@ fn get_relations<'tx>(
 Result<BoxStream<'tx, Result<Relation>>>
 ----
 
-[#_struct_Attribute_tymethod_iid]
+[#_struct_Attribute_iid__]
 ==== iid
 
 [source,rust]
@@ -148,7 +148,7 @@ fn iid(&self) -> &IID
 &IID
 ----
 
-[#_struct_Attribute_tymethod_is_deleted]
+[#_struct_Attribute_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -168,7 +168,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_Attribute_tymethod_is_inferred]
+[#_struct_Attribute_is_inferred__]
 ==== is_inferred
 
 [source,rust]
@@ -185,7 +185,7 @@ fn is_inferred(&self) -> bool
 bool
 ----
 
-[#_struct_Attribute_method_set_has]
+[#_struct_Attribute_set_has__]
 ==== set_has
 
 [source,rust]
@@ -206,7 +206,7 @@ fn set_has<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Attribute_method_unset_has]
+[#_struct_Attribute_unset_has__]
 ==== unset_has
 
 [source,rust]

--- a/rust/docs/data/Entity.adoc
+++ b/rust/docs/data/Entity.adoc
@@ -28,7 +28,7 @@ a| `type_` a| `EntityType` a| The type which this Entity belongs to
 // end::properties[]
 
 // tag::methods[]
-[#_struct_Entity_method_delete]
+[#_struct_Entity_delete__]
 ==== delete
 
 [source,rust]
@@ -48,7 +48,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Entity_method_get_has]
+[#_struct_Entity_get_has__]
 ==== get_has
 
 [source,rust]
@@ -70,7 +70,7 @@ fn get_has<'tx>(
 Result<BoxStream<'tx, Result<Attribute>>>
 ----
 
-[#_struct_Entity_method_get_playing]
+[#_struct_Entity_get_playing__]
 ==== get_playing
 
 [source,rust]
@@ -90,7 +90,7 @@ fn get_playing<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_Entity_method_get_relations]
+[#_struct_Entity_get_relations__]
 ==== get_relations
 
 [source,rust]
@@ -111,7 +111,7 @@ fn get_relations<'tx>(
 Result<BoxStream<'tx, Result<Relation>>>
 ----
 
-[#_struct_Entity_tymethod_iid]
+[#_struct_Entity_iid__]
 ==== iid
 
 [source,rust]
@@ -128,7 +128,7 @@ fn iid(&self) -> &IID
 &IID
 ----
 
-[#_struct_Entity_tymethod_is_deleted]
+[#_struct_Entity_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -148,7 +148,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_Entity_tymethod_is_inferred]
+[#_struct_Entity_is_inferred__]
 ==== is_inferred
 
 [source,rust]
@@ -165,7 +165,7 @@ fn is_inferred(&self) -> bool
 bool
 ----
 
-[#_struct_Entity_method_set_has]
+[#_struct_Entity_set_has__]
 ==== set_has
 
 [source,rust]
@@ -186,7 +186,7 @@ fn set_has<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Entity_method_unset_has]
+[#_struct_Entity_unset_has__]
 ==== unset_has
 
 [source,rust]

--- a/rust/docs/data/Relation.adoc
+++ b/rust/docs/data/Relation.adoc
@@ -28,7 +28,7 @@ a| `type_` a| `RelationType` a| The type which this Relation belongs to
 // end::properties[]
 
 // tag::methods[]
-[#_struct_Relation_method_add_role_player]
+[#_struct_Relation_add_role_player__]
 ==== add_role_player
 
 [source,rust]
@@ -50,7 +50,7 @@ fn add_role_player<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Relation_method_delete]
+[#_struct_Relation_delete__]
 ==== delete
 
 [source,rust]
@@ -70,7 +70,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Relation_method_get_has]
+[#_struct_Relation_get_has__]
 ==== get_has
 
 [source,rust]
@@ -92,7 +92,7 @@ fn get_has<'tx>(
 Result<BoxStream<'tx, Result<Attribute>>>
 ----
 
-[#_struct_Relation_method_get_players_by_role_type]
+[#_struct_Relation_get_players_by_role_type__]
 ==== get_players_by_role_type
 
 [source,rust]
@@ -113,7 +113,7 @@ fn get_players_by_role_type<'tx>(
 Result<BoxStream<'tx, Result<Thing>>>
 ----
 
-[#_struct_Relation_method_get_playing]
+[#_struct_Relation_get_playing__]
 ==== get_playing
 
 [source,rust]
@@ -133,7 +133,7 @@ fn get_playing<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_Relation_method_get_relating]
+[#_struct_Relation_get_relating__]
 ==== get_relating
 
 [source,rust]
@@ -153,7 +153,7 @@ fn get_relating<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_Relation_method_get_relations]
+[#_struct_Relation_get_relations__]
 ==== get_relations
 
 [source,rust]
@@ -174,7 +174,7 @@ fn get_relations<'tx>(
 Result<BoxStream<'tx, Result<Relation>>>
 ----
 
-[#_struct_Relation_method_get_role_players]
+[#_struct_Relation_get_role_players__]
 ==== get_role_players
 
 [source,rust]
@@ -194,7 +194,7 @@ fn get_role_players<'tx>(
 Result<BoxStream<'tx, Result<(RoleType, Thing)>>>
 ----
 
-[#_struct_Relation_tymethod_iid]
+[#_struct_Relation_iid__]
 ==== iid
 
 [source,rust]
@@ -211,7 +211,7 @@ fn iid(&self) -> &IID
 &IID
 ----
 
-[#_struct_Relation_tymethod_is_deleted]
+[#_struct_Relation_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -231,7 +231,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_Relation_tymethod_is_inferred]
+[#_struct_Relation_is_inferred__]
 ==== is_inferred
 
 [source,rust]
@@ -248,7 +248,7 @@ fn is_inferred(&self) -> bool
 bool
 ----
 
-[#_struct_Relation_method_remove_role_player]
+[#_struct_Relation_remove_role_player__]
 ==== remove_role_player
 
 [source,rust]
@@ -270,7 +270,7 @@ fn remove_role_player<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Relation_method_set_has]
+[#_struct_Relation_set_has__]
 ==== set_has
 
 [source,rust]
@@ -291,7 +291,7 @@ fn set_has<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Relation_method_unset_has]
+[#_struct_Relation_unset_has__]
 ==== unset_has
 
 [source,rust]

--- a/rust/docs/data/Trait_AttributeAPI.adoc
+++ b/rust/docs/data/Trait_AttributeAPI.adoc
@@ -6,7 +6,7 @@
 * `Attribute`
 
 // tag::methods[]
-[#_trait_AttributeAPI_method_get_owners]
+[#_trait_AttributeAPI_get_owners__transaction_'tx_Transaction_'____owner_type]
 ==== get_owners
 
 [source,rust]

--- a/rust/docs/data/Trait_RelationAPI.adoc
+++ b/rust/docs/data/Trait_RelationAPI.adoc
@@ -6,7 +6,7 @@
 * `Relation`
 
 // tag::methods[]
-[#_trait_RelationAPI_method_add_role_player]
+[#_trait_RelationAPI_add_role_player__transaction_'tx_Transaction_'____role_type_RoleType__player_Thing]
 ==== add_role_player
 
 [source,rust]
@@ -64,7 +64,7 @@ relation.add_role_player(transaction, role_type, player).resolve();
 --
 ====
 
-[#_trait_RelationAPI_method_get_players_by_role_type]
+[#_trait_RelationAPI_get_players_by_role_type__transaction_'tx_Transaction_'____role_types_Vec_RoleType_]
 ==== get_players_by_role_type
 
 [source,rust]
@@ -102,7 +102,7 @@ Result<BoxStream<'tx, Result<Thing>>>
 relation.get_players_by_role_type(transaction, role_types);
 ----
 
-[#_trait_RelationAPI_method_get_relating]
+[#_trait_RelationAPI_get_relating__transaction_'tx_Transaction_'__]
 ==== get_relating
 
 [source,rust]
@@ -138,7 +138,7 @@ Result<BoxStream<'tx, Result<RoleType>>>
 relation.get_relating(transaction)
 ----
 
-[#_trait_RelationAPI_method_get_role_players]
+[#_trait_RelationAPI_get_role_players__transaction_'tx_Transaction_'_____-__Result_BoxStream_'tx]
 ==== get_role_players
 
 [source,rust]
@@ -175,7 +175,7 @@ Result<BoxStream<'tx, Result<(RoleType, Thing)>>>
 relation.get_role_players(transaction)
 ----
 
-[#_trait_RelationAPI_method_remove_role_player]
+[#_trait_RelationAPI_remove_role_player__transaction_'tx_Transaction_'____role_type_RoleType__player_Thing]
 ==== remove_role_player
 
 [source,rust]

--- a/rust/docs/data/Trait_ThingAPI.adoc
+++ b/rust/docs/data/Trait_ThingAPI.adoc
@@ -8,7 +8,7 @@
 * `Relation`
 
 // tag::methods[]
-[#_trait_ThingAPI_method_delete]
+[#_trait_ThingAPI_delete__transaction_'tx_Transaction_'__]
 ==== delete
 
 [source,rust]
@@ -62,7 +62,7 @@ thing.delete(transaction).resolve();
 --
 ====
 
-[#_trait_ThingAPI_method_get_has]
+[#_trait_ThingAPI_get_has__transaction_'tx_Transaction_'____attribute_type__attribute_types_Vec_AttributeType___annotations_Vec_Annotation_]
 ==== get_has
 
 [source,rust]
@@ -103,7 +103,7 @@ Result<BoxStream<'tx, Result<Attribute>>>
 thing.get_has(transaction, attribute_type, annotations=vec![Annotation::Key]);
 ----
 
-[#_trait_ThingAPI_method_get_playing]
+[#_trait_ThingAPI_get_playing__transaction_'tx_Transaction_'__]
 ==== get_playing
 
 [source,rust]
@@ -139,7 +139,7 @@ Result<BoxStream<'tx, Result<RoleType>>>
 thing.get_playing(transaction);
 ----
 
-[#_trait_ThingAPI_method_get_relations]
+[#_trait_ThingAPI_get_relations__transaction_'tx_Transaction_'____role_types_Vec_RoleType_]
 ==== get_relations
 
 [source,rust]
@@ -177,7 +177,7 @@ Result<BoxStream<'tx, Result<Relation>>>
 thing.get_relations(transaction, role_types);
 ----
 
-[#_trait_ThingAPI_tymethod_iid]
+[#_trait_ThingAPI_iid__]
 ==== iid
 
 [source,rust]
@@ -201,7 +201,7 @@ Retrieves the unique id of the ``Thing``.
 thing.iid();
 ----
 
-[#_trait_ThingAPI_tymethod_is_deleted]
+[#_trait_ThingAPI_is_deleted__transaction_'tx_Transaction_'__]
 ==== is_deleted
 
 [source,rust]
@@ -255,7 +255,7 @@ thing.is_deleted(transaction).resolve();
 --
 ====
 
-[#_trait_ThingAPI_tymethod_is_inferred]
+[#_trait_ThingAPI_is_inferred__]
 ==== is_inferred
 
 [source,rust]
@@ -279,7 +279,7 @@ bool
 thing.is_inferred();
 ----
 
-[#_trait_ThingAPI_method_set_has]
+[#_trait_ThingAPI_set_has__transaction_'tx_Transaction_'____attribute_Attribute]
 ==== set_has
 
 [source,rust]
@@ -335,7 +335,7 @@ thing.set_has(transaction, attribute).resolve();
 --
 ====
 
-[#_trait_ThingAPI_method_unset_has]
+[#_trait_ThingAPI_unset_has__transaction_'tx_Transaction_'____attribute_Attribute]
 ==== unset_has
 
 [source,rust]

--- a/rust/docs/data/Value.adoc
+++ b/rust/docs/data/Value.adoc
@@ -17,7 +17,7 @@ a| `String(String)`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_enum_Value_method_get_type]
+[#_enum_Value_get_type__]
 ==== get_type
 
 [source,rust]

--- a/rust/docs/logic/LogicManager.adoc
+++ b/rust/docs/logic/LogicManager.adoc
@@ -9,7 +9,7 @@
 Provides methods for manipulating rules in the database.
 
 // tag::methods[]
-[#_struct_LogicManager_method_get_rule]
+[#_struct_LogicManager_get_rule__label_String]
 ==== get_rule
 
 [source,rust]
@@ -60,7 +60,7 @@ transaction.logic().get_rule(label).resolve()
 --
 ====
 
-[#_struct_LogicManager_method_get_rules]
+[#_struct_LogicManager_get_rules__]
 ==== get_rules
 
 [source,rust]
@@ -84,7 +84,7 @@ Result<impl Stream<Item = Result<Rule>> + 'tx>
 transaction.logic.get_rules()
 ----
 
-[#_struct_LogicManager_method_put_rule]
+[#_struct_LogicManager_put_rule__label_String__when_Conjunction__then_Statement]
 ==== put_rule
 
 [source,rust]

--- a/rust/docs/logic/Rule.adoc
+++ b/rust/docs/logic/Rule.adoc
@@ -25,7 +25,7 @@ a| `when` a| `Conjunction` a| The statements that constitute the ‘when’ of t
 // end::properties[]
 
 // tag::methods[]
-[#_struct_Rule_tymethod_delete]
+[#_struct_Rule_delete__]
 ==== delete
 
 [source,rust]
@@ -45,7 +45,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_Rule_method_is_deleted]
+[#_struct_Rule_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -65,7 +65,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_Rule_tymethod_label]
+[#_struct_Rule_label__]
 ==== label
 
 [source,rust]
@@ -82,7 +82,7 @@ fn label(&self) -> &String
 &String
 ----
 
-[#_struct_Rule_tymethod_set_label]
+[#_struct_Rule_set_label__]
 ==== set_label
 
 [source,rust]

--- a/rust/docs/logic/Trait_RuleAPI.adoc
+++ b/rust/docs/logic/Trait_RuleAPI.adoc
@@ -6,7 +6,7 @@
 * `Rule`
 
 // tag::methods[]
-[#_trait_RuleAPI_tymethod_delete]
+[#_trait_RuleAPI_delete__transaction_'tx_Transaction_'tx_]
 ==== delete
 
 [source,rust]
@@ -60,7 +60,7 @@ rule.delete(transaction).resolve()
 --
 ====
 
-[#_trait_RuleAPI_method_is_deleted]
+[#_trait_RuleAPI_is_deleted__transaction_'tx_Transaction_'tx_]
 ==== is_deleted
 
 [source,rust]
@@ -114,7 +114,7 @@ rule.is_deleted(transaction).resolve()
 --
 ====
 
-[#_trait_RuleAPI_tymethod_label]
+[#_trait_RuleAPI_label__]
 ==== label
 
 [source,rust]
@@ -131,7 +131,7 @@ Retrieves the unique label of the rule.
 &String
 ----
 
-[#_trait_RuleAPI_tymethod_set_label]
+[#_trait_RuleAPI_set_label__transaction_'tx_Transaction_'tx___new_label_String]
 ==== set_label
 
 [source,rust]

--- a/rust/docs/schema/AttributeType.adoc
+++ b/rust/docs/schema/AttributeType.adoc
@@ -33,7 +33,7 @@ a| `value_type` a| `ValueType` a|
 // end::properties[]
 
 // tag::methods[]
-[#_struct_AttributeType_method_delete]
+[#_struct_AttributeType_delete__]
 ==== delete
 
 [source,rust]
@@ -53,7 +53,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_get]
+[#_struct_AttributeType_get__]
 ==== get
 
 [source,rust]
@@ -74,7 +74,7 @@ fn get<'tx>(
 BoxPromise<'tx, Result<Option<Attribute>>>
 ----
 
-[#_struct_AttributeType_method_get_instances]
+[#_struct_AttributeType_get_instances__]
 ==== get_instances
 
 [source,rust]
@@ -95,7 +95,7 @@ fn get_instances<'tx>(
 Result<BoxStream<'tx, Result<Attribute>>>
 ----
 
-[#_struct_AttributeType_method_get_owners]
+[#_struct_AttributeType_get_owners__]
 ==== get_owners
 
 [source,rust]
@@ -117,7 +117,7 @@ fn get_owners<'tx>(
 Result<BoxStream<'tx, Result<ThingType>>>
 ----
 
-[#_struct_AttributeType_method_get_owns]
+[#_struct_AttributeType_get_owns__]
 ==== get_owns
 
 [source,rust]
@@ -140,7 +140,7 @@ fn get_owns<'tx>(
 Result<BoxStream<'tx, Result<AttributeType>>>
 ----
 
-[#_struct_AttributeType_method_get_owns_overridden]
+[#_struct_AttributeType_get_owns_overridden__]
 ==== get_owns_overridden
 
 [source,rust]
@@ -161,7 +161,7 @@ fn get_owns_overridden<'tx>(
 BoxPromise<'tx, Result<Option<AttributeType>>>
 ----
 
-[#_struct_AttributeType_method_get_plays]
+[#_struct_AttributeType_get_plays__]
 ==== get_plays
 
 [source,rust]
@@ -182,7 +182,7 @@ fn get_plays<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_AttributeType_method_get_plays_overridden]
+[#_struct_AttributeType_get_plays_overridden__]
 ==== get_plays_overridden
 
 [source,rust]
@@ -203,7 +203,7 @@ fn get_plays_overridden<'tx>(
 BoxPromise<'tx, Result<Option<RoleType>>>
 ----
 
-[#_struct_AttributeType_method_get_regex]
+[#_struct_AttributeType_get_regex__]
 ==== get_regex
 
 [source,rust]
@@ -223,7 +223,7 @@ fn get_regex<'tx>(
 BoxPromise<'tx, Result<Option<String>>>
 ----
 
-[#_struct_AttributeType_method_get_subtypes]
+[#_struct_AttributeType_get_subtypes__]
 ==== get_subtypes
 
 [source,rust]
@@ -244,7 +244,7 @@ fn get_subtypes<'tx>(
 Result<BoxStream<'tx, Result<AttributeType>>>
 ----
 
-[#_struct_AttributeType_method_get_subtypes_with_value_type]
+[#_struct_AttributeType_get_subtypes_with_value_type__]
 ==== get_subtypes_with_value_type
 
 [source,rust]
@@ -266,7 +266,7 @@ fn get_subtypes_with_value_type<'tx>(
 Result<BoxStream<'tx, Result<AttributeType>>>
 ----
 
-[#_struct_AttributeType_method_get_supertype]
+[#_struct_AttributeType_get_supertype__]
 ==== get_supertype
 
 [source,rust]
@@ -286,7 +286,7 @@ fn get_supertype<'tx>(
 BoxPromise<'tx, Result<Option<AttributeType>>>
 ----
 
-[#_struct_AttributeType_method_get_supertypes]
+[#_struct_AttributeType_get_supertypes__]
 ==== get_supertypes
 
 [source,rust]
@@ -306,7 +306,7 @@ fn get_supertypes<'tx>(
 Result<BoxStream<'tx, Result<AttributeType>>>
 ----
 
-[#_struct_AttributeType_method_get_syntax]
+[#_struct_AttributeType_get_syntax__]
 ==== get_syntax
 
 [source,rust]
@@ -326,7 +326,7 @@ fn get_syntax<'tx>(
 BoxPromise<'tx, Result<String>>
 ----
 
-[#_struct_AttributeType_tymethod_is_abstract]
+[#_struct_AttributeType_is_abstract__]
 ==== is_abstract
 
 [source,rust]
@@ -343,7 +343,7 @@ fn is_abstract(&self) -> bool
 bool
 ----
 
-[#_struct_AttributeType_tymethod_is_deleted]
+[#_struct_AttributeType_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -363,7 +363,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_AttributeType_tymethod_is_root]
+[#_struct_AttributeType_is_root__]
 ==== is_root
 
 [source,rust]
@@ -380,7 +380,7 @@ fn is_root(&self) -> bool
 bool
 ----
 
-[#_struct_AttributeType_tymethod_label]
+[#_struct_AttributeType_label__]
 ==== label
 
 [source,rust]
@@ -397,7 +397,7 @@ fn label(&self) -> &str
 &str
 ----
 
-[#_struct_AttributeType_method_put]
+[#_struct_AttributeType_put__]
 ==== put
 
 [source,rust]
@@ -418,7 +418,7 @@ fn put<'tx>(
 BoxPromise<'tx, Result<Attribute>>
 ----
 
-[#_struct_AttributeType_method_root]
+[#_struct_AttributeType_root__]
 ==== root
 
 [source,rust]
@@ -435,7 +435,7 @@ Returns the root ``AttributeType``
 Self
 ----
 
-[#_struct_AttributeType_method_set_abstract]
+[#_struct_AttributeType_set_abstract__]
 ==== set_abstract
 
 [source,rust]
@@ -455,7 +455,7 @@ fn set_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_set_label]
+[#_struct_AttributeType_set_label__]
 ==== set_label
 
 [source,rust]
@@ -476,7 +476,7 @@ fn set_label<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_set_owns]
+[#_struct_AttributeType_set_owns__]
 ==== set_owns
 
 [source,rust]
@@ -499,7 +499,7 @@ fn set_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_set_plays]
+[#_struct_AttributeType_set_plays__]
 ==== set_plays
 
 [source,rust]
@@ -521,7 +521,7 @@ fn set_plays<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_set_regex]
+[#_struct_AttributeType_set_regex__]
 ==== set_regex
 
 [source,rust]
@@ -542,7 +542,7 @@ fn set_regex<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_set_supertype]
+[#_struct_AttributeType_set_supertype__]
 ==== set_supertype
 
 [source,rust]
@@ -563,7 +563,7 @@ fn set_supertype<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_unset_abstract]
+[#_struct_AttributeType_unset_abstract__]
 ==== unset_abstract
 
 [source,rust]
@@ -583,7 +583,7 @@ fn unset_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_unset_owns]
+[#_struct_AttributeType_unset_owns__]
 ==== unset_owns
 
 [source,rust]
@@ -604,7 +604,7 @@ fn unset_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_unset_plays]
+[#_struct_AttributeType_unset_plays__]
 ==== unset_plays
 
 [source,rust]
@@ -625,7 +625,7 @@ fn unset_plays<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_method_unset_regex]
+[#_struct_AttributeType_unset_regex__]
 ==== unset_regex
 
 [source,rust]
@@ -645,7 +645,7 @@ fn unset_regex<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_AttributeType_tymethod_value_type]
+[#_struct_AttributeType_value_type__]
 ==== value_type
 
 [source,rust]

--- a/rust/docs/schema/EntityType.adoc
+++ b/rust/docs/schema/EntityType.adoc
@@ -28,7 +28,7 @@ a| `label` a| `String` a|
 // end::properties[]
 
 // tag::methods[]
-[#_struct_EntityType_method_create]
+[#_struct_EntityType_create__]
 ==== create
 
 [source,rust]
@@ -48,7 +48,7 @@ fn create<'tx>(
 BoxPromise<'tx, Result<Entity>>
 ----
 
-[#_struct_EntityType_method_delete]
+[#_struct_EntityType_delete__]
 ==== delete
 
 [source,rust]
@@ -68,7 +68,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_get_instances]
+[#_struct_EntityType_get_instances__]
 ==== get_instances
 
 [source,rust]
@@ -89,7 +89,7 @@ fn get_instances<'tx>(
 Result<BoxStream<'tx, Result<Entity>>>
 ----
 
-[#_struct_EntityType_method_get_owns]
+[#_struct_EntityType_get_owns__]
 ==== get_owns
 
 [source,rust]
@@ -112,7 +112,7 @@ fn get_owns<'tx>(
 Result<BoxStream<'tx, Result<AttributeType>>>
 ----
 
-[#_struct_EntityType_method_get_owns_overridden]
+[#_struct_EntityType_get_owns_overridden__]
 ==== get_owns_overridden
 
 [source,rust]
@@ -133,7 +133,7 @@ fn get_owns_overridden<'tx>(
 BoxPromise<'tx, Result<Option<AttributeType>>>
 ----
 
-[#_struct_EntityType_method_get_plays]
+[#_struct_EntityType_get_plays__]
 ==== get_plays
 
 [source,rust]
@@ -154,7 +154,7 @@ fn get_plays<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_EntityType_method_get_plays_overridden]
+[#_struct_EntityType_get_plays_overridden__]
 ==== get_plays_overridden
 
 [source,rust]
@@ -175,7 +175,7 @@ fn get_plays_overridden<'tx>(
 BoxPromise<'tx, Result<Option<RoleType>>>
 ----
 
-[#_struct_EntityType_method_get_subtypes]
+[#_struct_EntityType_get_subtypes__]
 ==== get_subtypes
 
 [source,rust]
@@ -196,7 +196,7 @@ fn get_subtypes<'tx>(
 Result<BoxStream<'tx, Result<EntityType>>>
 ----
 
-[#_struct_EntityType_method_get_supertype]
+[#_struct_EntityType_get_supertype__]
 ==== get_supertype
 
 [source,rust]
@@ -216,7 +216,7 @@ fn get_supertype<'tx>(
 BoxPromise<'tx, Result<Option<EntityType>>>
 ----
 
-[#_struct_EntityType_method_get_supertypes]
+[#_struct_EntityType_get_supertypes__]
 ==== get_supertypes
 
 [source,rust]
@@ -236,7 +236,7 @@ fn get_supertypes<'tx>(
 Result<BoxStream<'tx, Result<EntityType>>>
 ----
 
-[#_struct_EntityType_method_get_syntax]
+[#_struct_EntityType_get_syntax__]
 ==== get_syntax
 
 [source,rust]
@@ -256,7 +256,7 @@ fn get_syntax<'tx>(
 BoxPromise<'tx, Result<String>>
 ----
 
-[#_struct_EntityType_tymethod_is_abstract]
+[#_struct_EntityType_is_abstract__]
 ==== is_abstract
 
 [source,rust]
@@ -273,7 +273,7 @@ fn is_abstract(&self) -> bool
 bool
 ----
 
-[#_struct_EntityType_tymethod_is_deleted]
+[#_struct_EntityType_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -293,7 +293,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_EntityType_tymethod_is_root]
+[#_struct_EntityType_is_root__]
 ==== is_root
 
 [source,rust]
@@ -310,7 +310,7 @@ fn is_root(&self) -> bool
 bool
 ----
 
-[#_struct_EntityType_tymethod_label]
+[#_struct_EntityType_label__]
 ==== label
 
 [source,rust]
@@ -327,7 +327,7 @@ fn label(&self) -> &str
 &str
 ----
 
-[#_struct_EntityType_method_root]
+[#_struct_EntityType_root__]
 ==== root
 
 [source,rust]
@@ -344,7 +344,7 @@ Returns the root ``EntityType``
 Self
 ----
 
-[#_struct_EntityType_method_set_abstract]
+[#_struct_EntityType_set_abstract__]
 ==== set_abstract
 
 [source,rust]
@@ -364,7 +364,7 @@ fn set_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_set_label]
+[#_struct_EntityType_set_label__]
 ==== set_label
 
 [source,rust]
@@ -385,7 +385,7 @@ fn set_label<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_set_owns]
+[#_struct_EntityType_set_owns__]
 ==== set_owns
 
 [source,rust]
@@ -408,7 +408,7 @@ fn set_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_set_plays]
+[#_struct_EntityType_set_plays__]
 ==== set_plays
 
 [source,rust]
@@ -430,7 +430,7 @@ fn set_plays<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_set_supertype]
+[#_struct_EntityType_set_supertype__]
 ==== set_supertype
 
 [source,rust]
@@ -451,7 +451,7 @@ fn set_supertype<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_unset_abstract]
+[#_struct_EntityType_unset_abstract__]
 ==== unset_abstract
 
 [source,rust]
@@ -471,7 +471,7 @@ fn unset_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_unset_owns]
+[#_struct_EntityType_unset_owns__]
 ==== unset_owns
 
 [source,rust]
@@ -492,7 +492,7 @@ fn unset_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_EntityType_method_unset_plays]
+[#_struct_EntityType_unset_plays__]
 ==== unset_plays
 
 [source,rust]

--- a/rust/docs/schema/RelationType.adoc
+++ b/rust/docs/schema/RelationType.adoc
@@ -32,7 +32,7 @@ a| `label` a| `String` a|
 // end::properties[]
 
 // tag::methods[]
-[#_struct_RelationType_method_create]
+[#_struct_RelationType_create__]
 ==== create
 
 [source,rust]
@@ -52,7 +52,7 @@ fn create<'tx>(
 BoxPromise<'tx, Result<Relation>>
 ----
 
-[#_struct_RelationType_method_delete]
+[#_struct_RelationType_delete__]
 ==== delete
 
 [source,rust]
@@ -72,7 +72,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_get_instances]
+[#_struct_RelationType_get_instances__]
 ==== get_instances
 
 [source,rust]
@@ -93,7 +93,7 @@ fn get_instances<'tx>(
 Result<BoxStream<'tx, Result<Relation>>>
 ----
 
-[#_struct_RelationType_method_get_owns]
+[#_struct_RelationType_get_owns__]
 ==== get_owns
 
 [source,rust]
@@ -116,7 +116,7 @@ fn get_owns<'tx>(
 Result<BoxStream<'tx, Result<AttributeType>>>
 ----
 
-[#_struct_RelationType_method_get_owns_overridden]
+[#_struct_RelationType_get_owns_overridden__]
 ==== get_owns_overridden
 
 [source,rust]
@@ -137,7 +137,7 @@ fn get_owns_overridden<'tx>(
 BoxPromise<'tx, Result<Option<AttributeType>>>
 ----
 
-[#_struct_RelationType_method_get_plays]
+[#_struct_RelationType_get_plays__]
 ==== get_plays
 
 [source,rust]
@@ -158,7 +158,7 @@ fn get_plays<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_RelationType_method_get_plays_overridden]
+[#_struct_RelationType_get_plays_overridden__]
 ==== get_plays_overridden
 
 [source,rust]
@@ -179,7 +179,7 @@ fn get_plays_overridden<'tx>(
 BoxPromise<'tx, Result<Option<RoleType>>>
 ----
 
-[#_struct_RelationType_method_get_relates]
+[#_struct_RelationType_get_relates__]
 ==== get_relates
 
 [source,rust]
@@ -200,7 +200,7 @@ fn get_relates<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_RelationType_method_get_relates_for_role_label]
+[#_struct_RelationType_get_relates_for_role_label__]
 ==== get_relates_for_role_label
 
 [source,rust]
@@ -221,7 +221,7 @@ fn get_relates_for_role_label<'tx>(
 BoxPromise<'tx, Result<Option<RoleType>>>
 ----
 
-[#_struct_RelationType_method_get_relates_overridden]
+[#_struct_RelationType_get_relates_overridden__]
 ==== get_relates_overridden
 
 [source,rust]
@@ -242,7 +242,7 @@ fn get_relates_overridden<'tx>(
 BoxPromise<'tx, Result<Option<RoleType>>>
 ----
 
-[#_struct_RelationType_method_get_subtypes]
+[#_struct_RelationType_get_subtypes__]
 ==== get_subtypes
 
 [source,rust]
@@ -263,7 +263,7 @@ fn get_subtypes<'tx>(
 Result<BoxStream<'tx, Result<RelationType>>>
 ----
 
-[#_struct_RelationType_method_get_supertype]
+[#_struct_RelationType_get_supertype__]
 ==== get_supertype
 
 [source,rust]
@@ -283,7 +283,7 @@ fn get_supertype<'tx>(
 BoxPromise<'tx, Result<Option<RelationType>>>
 ----
 
-[#_struct_RelationType_method_get_supertypes]
+[#_struct_RelationType_get_supertypes__]
 ==== get_supertypes
 
 [source,rust]
@@ -303,7 +303,7 @@ fn get_supertypes<'tx>(
 Result<BoxStream<'tx, Result<RelationType>>>
 ----
 
-[#_struct_RelationType_method_get_syntax]
+[#_struct_RelationType_get_syntax__]
 ==== get_syntax
 
 [source,rust]
@@ -323,7 +323,7 @@ fn get_syntax<'tx>(
 BoxPromise<'tx, Result<String>>
 ----
 
-[#_struct_RelationType_tymethod_is_abstract]
+[#_struct_RelationType_is_abstract__]
 ==== is_abstract
 
 [source,rust]
@@ -340,7 +340,7 @@ fn is_abstract(&self) -> bool
 bool
 ----
 
-[#_struct_RelationType_tymethod_is_deleted]
+[#_struct_RelationType_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -360,7 +360,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_RelationType_tymethod_is_root]
+[#_struct_RelationType_is_root__]
 ==== is_root
 
 [source,rust]
@@ -377,7 +377,7 @@ fn is_root(&self) -> bool
 bool
 ----
 
-[#_struct_RelationType_tymethod_label]
+[#_struct_RelationType_label__]
 ==== label
 
 [source,rust]
@@ -394,7 +394,7 @@ fn label(&self) -> &str
 &str
 ----
 
-[#_struct_RelationType_method_root]
+[#_struct_RelationType_root__]
 ==== root
 
 [source,rust]
@@ -411,7 +411,7 @@ Returns the root ``RelationType``
 Self
 ----
 
-[#_struct_RelationType_method_set_abstract]
+[#_struct_RelationType_set_abstract__]
 ==== set_abstract
 
 [source,rust]
@@ -431,7 +431,7 @@ fn set_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_set_label]
+[#_struct_RelationType_set_label__]
 ==== set_label
 
 [source,rust]
@@ -452,7 +452,7 @@ fn set_label<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_set_owns]
+[#_struct_RelationType_set_owns__]
 ==== set_owns
 
 [source,rust]
@@ -475,7 +475,7 @@ fn set_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_set_plays]
+[#_struct_RelationType_set_plays__]
 ==== set_plays
 
 [source,rust]
@@ -497,7 +497,7 @@ fn set_plays<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_set_relates]
+[#_struct_RelationType_set_relates__]
 ==== set_relates
 
 [source,rust]
@@ -519,7 +519,7 @@ fn set_relates<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_set_supertype]
+[#_struct_RelationType_set_supertype__]
 ==== set_supertype
 
 [source,rust]
@@ -540,7 +540,7 @@ fn set_supertype<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_unset_abstract]
+[#_struct_RelationType_unset_abstract__]
 ==== unset_abstract
 
 [source,rust]
@@ -560,7 +560,7 @@ fn unset_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_unset_owns]
+[#_struct_RelationType_unset_owns__]
 ==== unset_owns
 
 [source,rust]
@@ -581,7 +581,7 @@ fn unset_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_unset_plays]
+[#_struct_RelationType_unset_plays__]
 ==== unset_plays
 
 [source,rust]
@@ -602,7 +602,7 @@ fn unset_plays<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RelationType_method_unset_relates]
+[#_struct_RelationType_unset_relates__]
 ==== unset_relates
 
 [source,rust]

--- a/rust/docs/schema/RoleType.adoc
+++ b/rust/docs/schema/RoleType.adoc
@@ -29,7 +29,7 @@ a| `label` a| `ScopedLabel` a|
 // end::properties[]
 
 // tag::methods[]
-[#_struct_RoleType_method_delete]
+[#_struct_RoleType_delete__]
 ==== delete
 
 [source,rust]
@@ -49,7 +49,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RoleType_method_get_player_instances]
+[#_struct_RoleType_get_player_instances__]
 ==== get_player_instances
 
 [source,rust]
@@ -70,7 +70,7 @@ fn get_player_instances<'tx>(
 Result<BoxStream<'tx, Result<Thing>>>
 ----
 
-[#_struct_RoleType_method_get_player_types]
+[#_struct_RoleType_get_player_types__]
 ==== get_player_types
 
 [source,rust]
@@ -91,7 +91,7 @@ fn get_player_types<'tx>(
 Result<BoxStream<'tx, Result<ThingType>>>
 ----
 
-[#_struct_RoleType_method_get_relation_instances]
+[#_struct_RoleType_get_relation_instances__]
 ==== get_relation_instances
 
 [source,rust]
@@ -112,7 +112,7 @@ fn get_relation_instances<'tx>(
 Result<BoxStream<'tx, Result<Relation>>>
 ----
 
-[#_struct_RoleType_tymethod_get_relation_type]
+[#_struct_RoleType_get_relation_type__]
 ==== get_relation_type
 
 [source,rust]
@@ -132,7 +132,7 @@ fn get_relation_type<'tx>(
 BoxPromise<'tx, Result<Option<RelationType>>>
 ----
 
-[#_struct_RoleType_method_get_relation_types]
+[#_struct_RoleType_get_relation_types__]
 ==== get_relation_types
 
 [source,rust]
@@ -152,7 +152,7 @@ fn get_relation_types<'tx>(
 Result<BoxStream<'tx, Result<RelationType>>>
 ----
 
-[#_struct_RoleType_method_get_subtypes]
+[#_struct_RoleType_get_subtypes__]
 ==== get_subtypes
 
 [source,rust]
@@ -173,7 +173,7 @@ fn get_subtypes<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_RoleType_method_get_supertype]
+[#_struct_RoleType_get_supertype__]
 ==== get_supertype
 
 [source,rust]
@@ -193,7 +193,7 @@ fn get_supertype<'tx>(
 BoxPromise<'tx, Result<Option<RoleType>>>
 ----
 
-[#_struct_RoleType_method_get_supertypes]
+[#_struct_RoleType_get_supertypes__]
 ==== get_supertypes
 
 [source,rust]
@@ -213,7 +213,7 @@ fn get_supertypes<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_RoleType_tymethod_is_abstract]
+[#_struct_RoleType_is_abstract__]
 ==== is_abstract
 
 [source,rust]
@@ -230,7 +230,7 @@ fn is_abstract(&self) -> bool
 bool
 ----
 
-[#_struct_RoleType_tymethod_is_deleted]
+[#_struct_RoleType_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -250,7 +250,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_RoleType_method_set_label]
+[#_struct_RoleType_set_label__]
 ==== set_label
 
 [source,rust]

--- a/rust/docs/schema/RootThingType.adoc
+++ b/rust/docs/schema/RootThingType.adoc
@@ -12,7 +12,7 @@
 * `ThingTypeAPI`
 
 // tag::methods[]
-[#_struct_RootThingType_method_delete]
+[#_struct_RootThingType_delete__]
 ==== delete
 
 [source,rust]
@@ -32,7 +32,7 @@ fn delete<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RootThingType_method_get_owns]
+[#_struct_RootThingType_get_owns__]
 ==== get_owns
 
 [source,rust]
@@ -55,7 +55,7 @@ fn get_owns<'tx>(
 Result<BoxStream<'tx, Result<AttributeType>>>
 ----
 
-[#_struct_RootThingType_method_get_owns_overridden]
+[#_struct_RootThingType_get_owns_overridden__]
 ==== get_owns_overridden
 
 [source,rust]
@@ -76,7 +76,7 @@ fn get_owns_overridden<'tx>(
 BoxPromise<'tx, Result<Option<AttributeType>>>
 ----
 
-[#_struct_RootThingType_method_get_plays]
+[#_struct_RootThingType_get_plays__]
 ==== get_plays
 
 [source,rust]
@@ -97,7 +97,7 @@ fn get_plays<'tx>(
 Result<BoxStream<'tx, Result<RoleType>>>
 ----
 
-[#_struct_RootThingType_method_get_plays_overridden]
+[#_struct_RootThingType_get_plays_overridden__]
 ==== get_plays_overridden
 
 [source,rust]
@@ -118,7 +118,7 @@ fn get_plays_overridden<'tx>(
 BoxPromise<'tx, Result<Option<RoleType>>>
 ----
 
-[#_struct_RootThingType_method_get_syntax]
+[#_struct_RootThingType_get_syntax__]
 ==== get_syntax
 
 [source,rust]
@@ -138,7 +138,7 @@ fn get_syntax<'tx>(
 BoxPromise<'tx, Result<String>>
 ----
 
-[#_struct_RootThingType_tymethod_is_abstract]
+[#_struct_RootThingType_is_abstract__]
 ==== is_abstract
 
 [source,rust]
@@ -155,7 +155,7 @@ fn is_abstract(&self) -> bool
 bool
 ----
 
-[#_struct_RootThingType_tymethod_is_deleted]
+[#_struct_RootThingType_is_deleted__]
 ==== is_deleted
 
 [source,rust]
@@ -175,7 +175,7 @@ fn is_deleted<'tx>(
 BoxPromise<'tx, Result<bool>>
 ----
 
-[#_struct_RootThingType_tymethod_is_root]
+[#_struct_RootThingType_is_root__]
 ==== is_root
 
 [source,rust]
@@ -192,7 +192,7 @@ fn is_root(&self) -> bool
 bool
 ----
 
-[#_struct_RootThingType_tymethod_label]
+[#_struct_RootThingType_label__]
 ==== label
 
 [source,rust]
@@ -209,7 +209,7 @@ fn label(&self) -> &str
 &str
 ----
 
-[#_struct_RootThingType_method_set_abstract]
+[#_struct_RootThingType_set_abstract__]
 ==== set_abstract
 
 [source,rust]
@@ -229,7 +229,7 @@ fn set_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RootThingType_method_set_label]
+[#_struct_RootThingType_set_label__]
 ==== set_label
 
 [source,rust]
@@ -250,7 +250,7 @@ fn set_label<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RootThingType_method_set_owns]
+[#_struct_RootThingType_set_owns__]
 ==== set_owns
 
 [source,rust]
@@ -273,7 +273,7 @@ fn set_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RootThingType_method_set_plays]
+[#_struct_RootThingType_set_plays__]
 ==== set_plays
 
 [source,rust]
@@ -295,7 +295,7 @@ fn set_plays<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RootThingType_method_unset_abstract]
+[#_struct_RootThingType_unset_abstract__]
 ==== unset_abstract
 
 [source,rust]
@@ -315,7 +315,7 @@ fn unset_abstract<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RootThingType_method_unset_owns]
+[#_struct_RootThingType_unset_owns__]
 ==== unset_owns
 
 [source,rust]
@@ -336,7 +336,7 @@ fn unset_owns<'tx>(
 BoxPromise<'tx, Result>
 ----
 
-[#_struct_RootThingType_method_unset_plays]
+[#_struct_RootThingType_unset_plays__]
 ==== unset_plays
 
 [source,rust]

--- a/rust/docs/schema/ThingType.adoc
+++ b/rust/docs/schema/ThingType.adoc
@@ -16,7 +16,7 @@ a| `RootThingType(RootThingType)`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_enum_ThingType_method_label]
+[#_enum_ThingType_label__]
 ==== label
 
 [source,rust]

--- a/rust/docs/schema/Trait_AttributeTypeAPI.adoc
+++ b/rust/docs/schema/Trait_AttributeTypeAPI.adoc
@@ -6,7 +6,7 @@
 * `AttributeType`
 
 // tag::methods[]
-[#_trait_AttributeTypeAPI_method_get]
+[#_trait_AttributeTypeAPI_get__transaction_'tx_Transaction_'____value_Value]
 ==== get
 
 [source,rust]
@@ -62,7 +62,7 @@ attribute = attribute_type.get(transaction, value).resolve();
 --
 ====
 
-[#_trait_AttributeTypeAPI_method_get_instances]
+[#_trait_AttributeTypeAPI_get_instances__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_instances
 
 [source,rust]
@@ -100,7 +100,7 @@ Result<BoxStream<'tx, Result<Attribute>>>
 attribute_type.get_instances(transaction, transitivity)
 ----
 
-[#_trait_AttributeTypeAPI_method_get_owners]
+[#_trait_AttributeTypeAPI_get_owners__transaction_'tx_Transaction_'____transitivity_Transitivity__annotations_Vec_Annotation_]
 ==== get_owners
 
 [source,rust]
@@ -140,7 +140,7 @@ Result<BoxStream<'tx, Result<ThingType>>>
 attribute_type.get_owners(transaction, transitivity, annotations)
 ----
 
-[#_trait_AttributeTypeAPI_method_get_regex]
+[#_trait_AttributeTypeAPI_get_regex__transaction_'tx_Transaction_'__]
 ==== get_regex
 
 [source,rust]
@@ -194,7 +194,7 @@ attribute_type.get_regex(transaction).resolve();
 --
 ====
 
-[#_trait_AttributeTypeAPI_method_get_subtypes]
+[#_trait_AttributeTypeAPI_get_subtypes__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_subtypes
 
 [source,rust]
@@ -232,7 +232,7 @@ Result<BoxStream<'tx, Result<AttributeType>>>
 attribute_type.get_subtypes(transaction, transitivity)
 ----
 
-[#_trait_AttributeTypeAPI_method_get_subtypes_with_value_type]
+[#_trait_AttributeTypeAPI_get_subtypes_with_value_type__transaction_'tx_Transaction_'____value_type_ValueType__transitivity_Transitivity]
 ==== get_subtypes_with_value_type
 
 [source,rust]
@@ -272,7 +272,7 @@ Result<BoxStream<'tx, Result<AttributeType>>>
 attribute_type.get_subtypes_with_value_type(transaction, value_type, transitivity)
 ----
 
-[#_trait_AttributeTypeAPI_method_get_supertype]
+[#_trait_AttributeTypeAPI_get_supertype__transaction_'tx_Transaction_'__]
 ==== get_supertype
 
 [source,rust]
@@ -326,7 +326,7 @@ attribute_type.get_supertype(transaction).resolve();
 --
 ====
 
-[#_trait_AttributeTypeAPI_method_get_supertypes]
+[#_trait_AttributeTypeAPI_get_supertypes__transaction_'tx_Transaction_'__]
 ==== get_supertypes
 
 [source,rust]
@@ -362,7 +362,7 @@ Result<BoxStream<'tx, Result<AttributeType>>>
 attribute_type.get_supertypes(transaction)
 ----
 
-[#_trait_AttributeTypeAPI_method_put]
+[#_trait_AttributeTypeAPI_put__transaction_'tx_Transaction_'____value_Value]
 ==== put
 
 [source,rust]
@@ -418,7 +418,7 @@ attribute = attribute_type.put(transaction, value).resolve();
 --
 ====
 
-[#_trait_AttributeTypeAPI_method_set_regex]
+[#_trait_AttributeTypeAPI_set_regex__transaction_'tx_Transaction_'____regex_String]
 ==== set_regex
 
 [source,rust]
@@ -476,7 +476,7 @@ attribute_type.set_regex(transaction, regex).resolve();
 --
 ====
 
-[#_trait_AttributeTypeAPI_method_set_supertype]
+[#_trait_AttributeTypeAPI_set_supertype__transaction_'tx_Transaction_'____supertype_AttributeType]
 ==== set_supertype
 
 [source,rust]
@@ -532,7 +532,7 @@ attribute_type.set_supertype(transaction, supertype).resolve();
 --
 ====
 
-[#_trait_AttributeTypeAPI_method_unset_regex]
+[#_trait_AttributeTypeAPI_unset_regex__transaction_'tx_Transaction_'__]
 ==== unset_regex
 
 [source,rust]
@@ -586,7 +586,7 @@ attribute_type.unset_regex(transaction).resolve();
 --
 ====
 
-[#_trait_AttributeTypeAPI_tymethod_value_type]
+[#_trait_AttributeTypeAPI_value_type__]
 ==== value_type
 
 [source,rust]

--- a/rust/docs/schema/Trait_EntityTypeAPI.adoc
+++ b/rust/docs/schema/Trait_EntityTypeAPI.adoc
@@ -6,7 +6,7 @@
 * `EntityType`
 
 // tag::methods[]
-[#_trait_EntityTypeAPI_method_create]
+[#_trait_EntityTypeAPI_create__transaction_'tx_Transaction_'__]
 ==== create
 
 [source,rust]
@@ -60,7 +60,7 @@ entity_type.create(transaction).resolve();
 --
 ====
 
-[#_trait_EntityTypeAPI_method_get_instances]
+[#_trait_EntityTypeAPI_get_instances__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_instances
 
 [source,rust]
@@ -98,7 +98,7 @@ Result<BoxStream<'tx, Result<Entity>>>
 entity_type.get_instances(transaction, Transitivity::Explicit);
 ----
 
-[#_trait_EntityTypeAPI_method_get_subtypes]
+[#_trait_EntityTypeAPI_get_subtypes__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_subtypes
 
 [source,rust]
@@ -136,7 +136,7 @@ Result<BoxStream<'tx, Result<EntityType>>>
 entity_type.get_subtypes(transaction, Transitivity::Transitive);
 ----
 
-[#_trait_EntityTypeAPI_method_get_supertype]
+[#_trait_EntityTypeAPI_get_supertype__transaction_'tx_Transaction_'__]
 ==== get_supertype
 
 [source,rust]
@@ -190,7 +190,7 @@ entity_type.get_supertype(transaction).resolve();
 --
 ====
 
-[#_trait_EntityTypeAPI_method_get_supertypes]
+[#_trait_EntityTypeAPI_get_supertypes__transaction_'tx_Transaction_'__]
 ==== get_supertypes
 
 [source,rust]
@@ -226,7 +226,7 @@ Result<BoxStream<'tx, Result<EntityType>>>
 entity_type.get_supertypes(transaction);
 ----
 
-[#_trait_EntityTypeAPI_method_set_supertype]
+[#_trait_EntityTypeAPI_set_supertype__transaction_'tx_Transaction_'____supertype_EntityType]
 ==== set_supertype
 
 [source,rust]

--- a/rust/docs/schema/Trait_RelationTypeAPI.adoc
+++ b/rust/docs/schema/Trait_RelationTypeAPI.adoc
@@ -6,7 +6,7 @@
 * `RelationType`
 
 // tag::methods[]
-[#_trait_RelationTypeAPI_method_create]
+[#_trait_RelationTypeAPI_create__transaction_'tx_Transaction_'__]
 ==== create
 
 [source,rust]
@@ -60,7 +60,7 @@ relation_type.create(transaction).resolve();
 --
 ====
 
-[#_trait_RelationTypeAPI_method_get_instances]
+[#_trait_RelationTypeAPI_get_instances__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_instances
 
 [source,rust]
@@ -98,7 +98,7 @@ Result<BoxStream<'tx, Result<Relation>>>
 relation_type.get_instances(transaction, Transitivity::Explicit);
 ----
 
-[#_trait_RelationTypeAPI_method_get_relates]
+[#_trait_RelationTypeAPI_get_relates__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_relates
 
 [source,rust]
@@ -136,7 +136,7 @@ Result<BoxStream<'tx, Result<RoleType>>>
 relation_type.get_relates(transaction, Transitivity::Transitive);
 ----
 
-[#_trait_RelationTypeAPI_method_get_relates_for_role_label]
+[#_trait_RelationTypeAPI_get_relates_for_role_label__transaction_'tx_Transaction_'____role_label_String]
 ==== get_relates_for_role_label
 
 [source,rust]
@@ -192,7 +192,7 @@ relation_type.get_relates_for_role_label(transaction, role_label).resolve();
 --
 ====
 
-[#_trait_RelationTypeAPI_method_get_relates_overridden]
+[#_trait_RelationTypeAPI_get_relates_overridden__transaction_'tx_Transaction_'____overridden_role_label_String]
 ==== get_relates_overridden
 
 [source,rust]
@@ -248,7 +248,7 @@ relation_type.get_relates_overridden(transaction, overridden_role_label).resolve
 --
 ====
 
-[#_trait_RelationTypeAPI_method_get_subtypes]
+[#_trait_RelationTypeAPI_get_subtypes__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_subtypes
 
 [source,rust]
@@ -286,7 +286,7 @@ Result<BoxStream<'tx, Result<RelationType>>>
 relation_type.get_subtypes(transaction, Transitivity::Transitive);
 ----
 
-[#_trait_RelationTypeAPI_method_get_supertype]
+[#_trait_RelationTypeAPI_get_supertype__transaction_'tx_Transaction_'__]
 ==== get_supertype
 
 [source,rust]
@@ -340,7 +340,7 @@ relation_type.get_supertype(transaction).resolve();
 --
 ====
 
-[#_trait_RelationTypeAPI_method_get_supertypes]
+[#_trait_RelationTypeAPI_get_supertypes__transaction_'tx_Transaction_'__]
 ==== get_supertypes
 
 [source,rust]
@@ -376,7 +376,7 @@ Result<BoxStream<'tx, Result<RelationType>>>
 relation_type.get_supertypes(transaction);
 ----
 
-[#_trait_RelationTypeAPI_method_set_relates]
+[#_trait_RelationTypeAPI_set_relates__transaction_'tx_Transaction_'____role_label_String__overridden_role_label_Option_String_]
 ==== set_relates
 
 [source,rust]
@@ -434,7 +434,7 @@ relation_type.set_relates(transaction, role_label, None).resolve();
 --
 ====
 
-[#_trait_RelationTypeAPI_method_set_supertype]
+[#_trait_RelationTypeAPI_set_supertype__transaction_'tx_Transaction_'____supertype_RelationType]
 ==== set_supertype
 
 [source,rust]
@@ -490,7 +490,7 @@ relation_type.set_supertype(transaction, super_relation_type).resolve();
 --
 ====
 
-[#_trait_RelationTypeAPI_method_unset_relates]
+[#_trait_RelationTypeAPI_unset_relates__transaction_'tx_Transaction_'____role_label_String]
 ==== unset_relates
 
 [source,rust]

--- a/rust/docs/schema/Trait_RoleTypeAPI.adoc
+++ b/rust/docs/schema/Trait_RoleTypeAPI.adoc
@@ -6,7 +6,7 @@
 * `RoleType`
 
 // tag::methods[]
-[#_trait_RoleTypeAPI_method_delete]
+[#_trait_RoleTypeAPI_delete__transaction_'tx_Transaction_'__]
 ==== delete
 
 [source,rust]
@@ -60,7 +60,7 @@ role_type.delete(transaction).resolve();
 --
 ====
 
-[#_trait_RoleTypeAPI_method_get_player_instances]
+[#_trait_RoleTypeAPI_get_player_instances__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_player_instances
 
 [source,rust]
@@ -98,7 +98,7 @@ Result<BoxStream<'tx, Result<Thing>>>
 role_type.get_player_instances(transaction, transitivity)
 ----
 
-[#_trait_RoleTypeAPI_method_get_player_types]
+[#_trait_RoleTypeAPI_get_player_types__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_player_types
 
 [source,rust]
@@ -136,7 +136,7 @@ Result<BoxStream<'tx, Result<ThingType>>>
 role_type.get_player_types(transaction, transitivity)
 ----
 
-[#_trait_RoleTypeAPI_method_get_relation_instances]
+[#_trait_RoleTypeAPI_get_relation_instances__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_relation_instances
 
 [source,rust]
@@ -174,7 +174,7 @@ Result<BoxStream<'tx, Result<Relation>>>
 role_type.get_relation_instances(transaction, transitivity)
 ----
 
-[#_trait_RoleTypeAPI_tymethod_get_relation_type]
+[#_trait_RoleTypeAPI_get_relation_type__transaction_'tx_Transaction_'__]
 ==== get_relation_type
 
 [source,rust]
@@ -228,7 +228,7 @@ role_type.get_relation_type(transaction).resolve();
 --
 ====
 
-[#_trait_RoleTypeAPI_method_get_relation_types]
+[#_trait_RoleTypeAPI_get_relation_types__transaction_'tx_Transaction_'__]
 ==== get_relation_types
 
 [source,rust]
@@ -264,7 +264,7 @@ Result<BoxStream<'tx, Result<RelationType>>>
 role_type.get_relation_types(transaction)
 ----
 
-[#_trait_RoleTypeAPI_method_get_subtypes]
+[#_trait_RoleTypeAPI_get_subtypes__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_subtypes
 
 [source,rust]
@@ -302,7 +302,7 @@ Result<BoxStream<'tx, Result<RoleType>>>
 role_type.get_subtypes(transaction, transitivity)
 ----
 
-[#_trait_RoleTypeAPI_method_get_supertype]
+[#_trait_RoleTypeAPI_get_supertype__transaction_'tx_Transaction_'__]
 ==== get_supertype
 
 [source,rust]
@@ -356,7 +356,7 @@ role_type.get_supertype(transaction).resolve();
 --
 ====
 
-[#_trait_RoleTypeAPI_method_get_supertypes]
+[#_trait_RoleTypeAPI_get_supertypes__transaction_'tx_Transaction_'__]
 ==== get_supertypes
 
 [source,rust]
@@ -392,7 +392,7 @@ Result<BoxStream<'tx, Result<RoleType>>>
 role_type.get_supertypes(transaction)
 ----
 
-[#_trait_RoleTypeAPI_tymethod_is_abstract]
+[#_trait_RoleTypeAPI_is_abstract__]
 ==== is_abstract
 
 [source,rust]
@@ -416,7 +416,7 @@ bool
 role_type.is_abstract()
 ----
 
-[#_trait_RoleTypeAPI_tymethod_is_deleted]
+[#_trait_RoleTypeAPI_is_deleted__transaction_'tx_Transaction_'__]
 ==== is_deleted
 
 [source,rust]
@@ -470,7 +470,7 @@ role_type.is_deleted(transaction).resolve();
 --
 ====
 
-[#_trait_RoleTypeAPI_method_set_label]
+[#_trait_RoleTypeAPI_set_label__transaction_'tx_Transaction_'____new_label_String]
 ==== set_label
 
 [source,rust]

--- a/rust/docs/schema/Trait_ThingTypeAPI.adoc
+++ b/rust/docs/schema/Trait_ThingTypeAPI.adoc
@@ -9,7 +9,7 @@
 * `RootThingType`
 
 // tag::methods[]
-[#_trait_ThingTypeAPI_method_delete]
+[#_trait_ThingTypeAPI_delete__transaction_'tx_Transaction_'__]
 ==== delete
 
 [source,rust]
@@ -63,7 +63,7 @@ thing_type.delete(transaction).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_get_owns]
+[#_trait_ThingTypeAPI_get_owns__transaction_'tx_Transaction_'____value_type_Option_ValueType___transitivity_Transitivity__annotations_Vec_Annotation_]
 ==== get_owns
 
 [source,rust]
@@ -123,7 +123,7 @@ thing_type.get_owns(transaction, Some(value_type), Transitivity::Explicit, vec![
 --
 ====
 
-[#_trait_ThingTypeAPI_method_get_owns_overridden]
+[#_trait_ThingTypeAPI_get_owns_overridden__transaction_'tx_Transaction_'____overridden_attribute_type_AttributeType]
 ==== get_owns_overridden
 
 [source,rust]
@@ -179,7 +179,7 @@ thing_type.get_owns_overridden(transaction, attribute_type).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_get_plays]
+[#_trait_ThingTypeAPI_get_plays__transaction_'tx_Transaction_'____transitivity_Transitivity]
 ==== get_plays
 
 [source,rust]
@@ -235,7 +235,7 @@ thing_type.get_plays(transaction, Transitivity::Explicit).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_get_plays_overridden]
+[#_trait_ThingTypeAPI_get_plays_overridden__transaction_'tx_Transaction_'____overridden_role_type_RoleType]
 ==== get_plays_overridden
 
 [source,rust]
@@ -291,7 +291,7 @@ thing_type.get_plays_overridden(transaction, role_type).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_get_syntax]
+[#_trait_ThingTypeAPI_get_syntax__transaction_'tx_Transaction_'__]
 ==== get_syntax
 
 [source,rust]
@@ -345,7 +345,7 @@ thing_type.get_syntax(transaction).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_tymethod_is_abstract]
+[#_trait_ThingTypeAPI_is_abstract__]
 ==== is_abstract
 
 [source,rust]
@@ -369,7 +369,7 @@ bool
 thing_type.is_abstract();
 ----
 
-[#_trait_ThingTypeAPI_tymethod_is_deleted]
+[#_trait_ThingTypeAPI_is_deleted__transaction_'tx_Transaction_'__]
 ==== is_deleted
 
 [source,rust]
@@ -423,7 +423,7 @@ thing_type.is_deleted(transaction).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_tymethod_is_root]
+[#_trait_ThingTypeAPI_is_root__]
 ==== is_root
 
 [source,rust]
@@ -447,7 +447,7 @@ bool
 thing_type.is_root();
 ----
 
-[#_trait_ThingTypeAPI_tymethod_label]
+[#_trait_ThingTypeAPI_label__]
 ==== label
 
 [source,rust]
@@ -471,7 +471,7 @@ Retrieves the unique label of the type.
 thing_type.label();
 ----
 
-[#_trait_ThingTypeAPI_method_set_abstract]
+[#_trait_ThingTypeAPI_set_abstract__transaction_'tx_Transaction_'__]
 ==== set_abstract
 
 [source,rust]
@@ -525,7 +525,7 @@ thing_type.set_abstract(transaction).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_set_label]
+[#_trait_ThingTypeAPI_set_label__transaction_'tx_Transaction_'____new_label_String]
 ==== set_label
 
 [source,rust]
@@ -581,7 +581,7 @@ thing_type.set_label(transaction, new_label).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_set_owns]
+[#_trait_ThingTypeAPI_set_owns__transaction_'tx_Transaction_'____attribute_type_AttributeType__overridden_attribute_type_Option_AttributeType___annotations_Vec_Annotation_]
 ==== set_owns
 
 [source,rust]
@@ -641,7 +641,7 @@ thing_type.set_owns(transaction, attribute_type, Some(overridden_type), vec![Ann
 --
 ====
 
-[#_trait_ThingTypeAPI_method_set_plays]
+[#_trait_ThingTypeAPI_set_plays__transaction_'tx_Transaction_'____role_type_RoleType__overridden_role_type_Option_RoleType_]
 ==== set_plays
 
 [source,rust]
@@ -699,7 +699,7 @@ thing_type.set_plays(transaction, role_type, None).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_unset_abstract]
+[#_trait_ThingTypeAPI_unset_abstract__transaction_'tx_Transaction_'__]
 ==== unset_abstract
 
 [source,rust]
@@ -753,7 +753,7 @@ thing_type.unset_abstract(transaction).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_unset_owns]
+[#_trait_ThingTypeAPI_unset_owns__transaction_'tx_Transaction_'____attribute_type_AttributeType]
 ==== unset_owns
 
 [source,rust]
@@ -809,7 +809,7 @@ thing_type.unset_owns(transaction, attribute_type).resolve();
 --
 ====
 
-[#_trait_ThingTypeAPI_method_unset_plays]
+[#_trait_ThingTypeAPI_unset_plays__transaction_'tx_Transaction_'____role_type_RoleType]
 ==== unset_plays
 
 [source,rust]

--- a/rust/docs/session/Options.adoc
+++ b/rust/docs/session/Options.adoc
@@ -30,7 +30,7 @@ a| `transaction_timeout` a| `Option<Duration>` a| If set, specifies a timeout fo
 // end::properties[]
 
 // tag::methods[]
-[#_struct_Options_method_explain]
+[#_struct_Options_explain__]
 ==== explain
 
 [source,rust]
@@ -47,7 +47,7 @@ If set to ``True``, enables explanations for queries. Only affects read transact
 Self
 ----
 
-[#_struct_Options_method_infer]
+[#_struct_Options_infer__]
 ==== infer
 
 [source,rust]
@@ -64,7 +64,7 @@ If set to ``True``, enables inference for queries. Only settable at transaction 
 Self
 ----
 
-[#_struct_Options_method_parallel]
+[#_struct_Options_parallel__]
 ==== parallel
 
 [source,rust]
@@ -81,7 +81,7 @@ If set to ``True``, the server uses parallel instead of single-threaded executio
 Self
 ----
 
-[#_struct_Options_method_prefetch]
+[#_struct_Options_prefetch__]
 ==== prefetch
 
 [source,rust]
@@ -98,7 +98,7 @@ If set to ``True``, the first batch of answers is streamed to the driver even wi
 Self
 ----
 
-[#_struct_Options_method_prefetch_size]
+[#_struct_Options_prefetch_size__]
 ==== prefetch_size
 
 [source,rust]
@@ -115,7 +115,7 @@ If set, specifies a guideline number of answers that the server should send befo
 Self
 ----
 
-[#_struct_Options_method_read_any_replica]
+[#_struct_Options_read_any_replica__]
 ==== read_any_replica
 
 [source,rust]
@@ -132,7 +132,7 @@ If set to ``True``, enables reading data from any replica, potentially boosting 
 Self
 ----
 
-[#_struct_Options_method_schema_lock_acquire_timeout]
+[#_struct_Options_schema_lock_acquire_timeout__]
 ==== schema_lock_acquire_timeout
 
 [source,rust]
@@ -149,7 +149,7 @@ If set, specifies how long the driver should wait if opening a session or transa
 Self
 ----
 
-[#_struct_Options_method_session_idle_timeout]
+[#_struct_Options_session_idle_timeout__]
 ==== session_idle_timeout
 
 [source,rust]
@@ -166,7 +166,7 @@ If set, specifies a timeout that allows the server to close sessions if the driv
 Self
 ----
 
-[#_struct_Options_method_trace_inference]
+[#_struct_Options_trace_inference__]
 ==== trace_inference
 
 [source,rust]
@@ -183,7 +183,7 @@ If set to ``True``, reasoning tracing graphs are output in the logging directory
 Self
 ----
 
-[#_struct_Options_method_transaction_timeout]
+[#_struct_Options_transaction_timeout__]
 ==== transaction_timeout
 
 [source,rust]

--- a/rust/docs/session/Session.adoc
+++ b/rust/docs/session/Session.adoc
@@ -7,7 +7,7 @@
 * `Drop`
 
 // tag::methods[]
-[#_struct_Session_method_database_name]
+[#_struct_Session_database_name__]
 ==== database_name
 
 [source,rust]
@@ -31,7 +31,7 @@ Returns the name of the database of the session.
 session.database_name();
 ----
 
-[#_struct_Session_method_force_close]
+[#_struct_Session_force_close__]
 ==== force_close
 
 [source,rust]
@@ -55,7 +55,7 @@ Result
 session.force_close();
 ----
 
-[#_struct_Session_method_is_open]
+[#_struct_Session_is_open__]
 ==== is_open
 
 [source,rust]
@@ -79,7 +79,7 @@ bool
 session.is_open();
 ----
 
-[#_struct_Session_method_new]
+[#_struct_Session_new__]
 ==== new
 
 [tabs]
@@ -114,7 +114,7 @@ Opens a communication tunnel (session) to the given database with default option
 Result<Self>
 ----
 
-[#_struct_Session_method_new_with_options]
+[#_struct_Session_new_with_options__database_Database__session_type_SessionType__options_Options]
 ==== new_with_options
 
 [tabs]
@@ -193,7 +193,7 @@ Session::new_with_options(database, session_type, options);
 --
 ====
 
-[#_struct_Session_method_on_close]
+[#_struct_Session_on_close__function]
 ==== on_close
 
 [source,rust]
@@ -226,7 +226,7 @@ null
 session.on_close(function);
 ----
 
-[#_struct_Session_method_transaction]
+[#_struct_Session_transaction__]
 ==== transaction
 
 [tabs]
@@ -267,7 +267,7 @@ Opens a transaction to perform read or write queries on the database connected t
 Result<Transaction<'_>>
 ----
 
-[#_struct_Session_method_transaction_with_options]
+[#_struct_Session_transaction_with_options__transaction_type_TransactionType__options_Options]
 ==== transaction_with_options
 
 [tabs]
@@ -345,7 +345,7 @@ session.transaction_with_options(transaction_type, options);
 --
 ====
 
-[#_struct_Session_method_type]
+[#_struct_Session_type___]
 ==== type_
 
 [source,rust]

--- a/rust/docs/transaction/QueryManager.adoc
+++ b/rust/docs/transaction/QueryManager.adoc
@@ -8,7 +8,7 @@
 Provides methods for executing TypeQL queries in the transaction.
 
 // tag::methods[]
-[#_struct_QueryManager_method_define]
+[#_struct_QueryManager_define__]
 ==== define
 
 [source,rust]
@@ -25,7 +25,7 @@ Performs a TypeQL Define query with default options. See <<#_struct_QueryManager
 impl Promise<'tx, Result>
 ----
 
-[#_struct_QueryManager_method_define_with_options]
+[#_struct_QueryManager_define_with_options__query_str__options_Options]
 ==== define_with_options
 
 [source,rust]
@@ -81,7 +81,7 @@ transaction.query().define_with_options(query, options).resolve()
 --
 ====
 
-[#_struct_QueryManager_method_delete]
+[#_struct_QueryManager_delete__]
 ==== delete
 
 [source,rust]
@@ -98,7 +98,7 @@ Performs a TypeQL Delete query with default options. See <<#_struct_QueryManager
 impl Promise<'tx, Result>
 ----
 
-[#_struct_QueryManager_method_delete_with_options]
+[#_struct_QueryManager_delete_with_options__query_str__options_Options]
 ==== delete_with_options
 
 [source,rust]
@@ -154,7 +154,7 @@ transaction.query().delete_with_options(query, options).resolve()
 --
 ====
 
-[#_struct_QueryManager_method_explain]
+[#_struct_QueryManager_explain__]
 ==== explain
 
 [source,rust]
@@ -174,7 +174,7 @@ Performs a TypeQL Explain query in the transaction. See ``QueryManager::explain_
 Result<impl Stream<Item = Result<Explanation>> + 'tx>
 ----
 
-[#_struct_QueryManager_method_explain_with_options]
+[#_struct_QueryManager_explain_with_options__explainable_Explainable__options_Options]
 ==== explain_with_options
 
 [source,rust]
@@ -212,7 +212,7 @@ Result<impl Stream<Item = Result<Explanation>> + 'tx>
 transaction.query().explain_with_options(explainable, options)
 ----
 
-[#_struct_QueryManager_method_fetch]
+[#_struct_QueryManager_fetch__]
 ==== fetch
 
 [source,rust]
@@ -232,7 +232,7 @@ Performs a TypeQL Fetch query with default options. See <<#_struct_QueryManager_
 Result<impl Stream<Item = Result<JSON>> + 'tx>
 ----
 
-[#_struct_QueryManager_method_fetch_with_options]
+[#_struct_QueryManager_fetch_with_options__query_str__options_Options]
 ==== fetch_with_options
 
 [source,rust]
@@ -270,7 +270,7 @@ Result<impl Stream<Item = Result<JSON>> + 'tx>
 transaction.query().fetch_with_options(query, options)
 ----
 
-[#_struct_QueryManager_method_get]
+[#_struct_QueryManager_get__]
 ==== get
 
 [source,rust]
@@ -290,7 +290,7 @@ Performs a TypeQL Match (Get) query with default options. See <<#_struct_QueryMa
 Result<impl Stream<Item = Result<ConceptMap>> + 'tx>
 ----
 
-[#_struct_QueryManager_method_get_aggregate]
+[#_struct_QueryManager_get_aggregate__]
 ==== get_aggregate
 
 [source,rust]
@@ -310,7 +310,7 @@ Performs a TypeQL Match Aggregate query with default options. See <<#_struct_Que
 impl Promise<'tx, Result<Option<Value>>>
 ----
 
-[#_struct_QueryManager_method_get_aggregate_with_options]
+[#_struct_QueryManager_get_aggregate_with_options__query_str__options_Options]
 ==== get_aggregate_with_options
 
 [source,rust]
@@ -366,7 +366,7 @@ transaction.query().get_aggregate_with_options(query, options).resolve()
 --
 ====
 
-[#_struct_QueryManager_method_get_group]
+[#_struct_QueryManager_get_group__]
 ==== get_group
 
 [source,rust]
@@ -386,7 +386,7 @@ Performs a TypeQL Match Group query with default options. See <<#_struct_QueryMa
 Result<impl Stream<Item = Result<ConceptMapGroup>> + 'tx>
 ----
 
-[#_struct_QueryManager_method_get_group_aggregate]
+[#_struct_QueryManager_get_group_aggregate__]
 ==== get_group_aggregate
 
 [source,rust]
@@ -406,7 +406,7 @@ Performs a TypeQL Match Group Aggregate query with default options. See <<#_stru
 Result<impl Stream<Item = Result<ValueGroup>> + 'tx>
 ----
 
-[#_struct_QueryManager_method_get_group_aggregate_with_options]
+[#_struct_QueryManager_get_group_aggregate_with_options__query_str__options_Options]
 ==== get_group_aggregate_with_options
 
 [source,rust]
@@ -444,7 +444,7 @@ Result<impl Stream<Item = Result<ValueGroup>> + 'tx>
 transaction.query().get_group_aggregate_with_options(query, options)
 ----
 
-[#_struct_QueryManager_method_get_group_with_options]
+[#_struct_QueryManager_get_group_with_options__query_str__options_Options]
 ==== get_group_with_options
 
 [source,rust]
@@ -482,7 +482,7 @@ Result<impl Stream<Item = Result<ConceptMapGroup>> + 'tx>
 transaction.query().get_group_with_options(query, options)
 ----
 
-[#_struct_QueryManager_method_get_with_options]
+[#_struct_QueryManager_get_with_options__query_str__options_Options]
 ==== get_with_options
 
 [source,rust]
@@ -520,7 +520,7 @@ Result<impl Stream<Item = Result<ConceptMap>> + 'tx>
 transaction.query().get_with_options(query, options)
 ----
 
-[#_struct_QueryManager_method_insert]
+[#_struct_QueryManager_insert__]
 ==== insert
 
 [source,rust]
@@ -540,7 +540,7 @@ Performs a TypeQL Insert query with default options. See <<#_struct_QueryManager
 Result<impl Stream<Item = Result<ConceptMap>> + 'tx>
 ----
 
-[#_struct_QueryManager_method_insert_with_options]
+[#_struct_QueryManager_insert_with_options__query_str__options_Options]
 ==== insert_with_options
 
 [source,rust]
@@ -578,7 +578,7 @@ Result<impl Stream<Item = Result<ConceptMap>> + 'tx>
 transaction.query().insert_with_options(query, options)
 ----
 
-[#_struct_QueryManager_method_undefine]
+[#_struct_QueryManager_undefine__]
 ==== undefine
 
 [source,rust]
@@ -595,7 +595,7 @@ Performs a TypeQL Undefine query with default options See <<#_struct_QueryManage
 impl Promise<'tx, Result>
 ----
 
-[#_struct_QueryManager_method_undefine_with_options]
+[#_struct_QueryManager_undefine_with_options__query_str__options_Options]
 ==== undefine_with_options
 
 [source,rust]
@@ -651,7 +651,7 @@ transaction.query().undefine_with_options(query, options).resolve()
 --
 ====
 
-[#_struct_QueryManager_method_update]
+[#_struct_QueryManager_update__]
 ==== update
 
 [source,rust]
@@ -671,7 +671,7 @@ Performs a TypeQL Update query with default options. See <<#_struct_QueryManager
 Result<impl Stream<Item = Result<ConceptMap>> + 'tx>
 ----
 
-[#_struct_QueryManager_method_update_with_options]
+[#_struct_QueryManager_update_with_options__query_str__options_Options]
 ==== update_with_options
 
 [source,rust]

--- a/rust/docs/transaction/Transaction.adoc
+++ b/rust/docs/transaction/Transaction.adoc
@@ -6,7 +6,7 @@
 * `Debug`
 
 // tag::methods[]
-[#_struct_Transaction_method_commit]
+[#_struct_Transaction_commit__]
 ==== commit
 
 [source,rust]
@@ -48,7 +48,7 @@ transaction.commit()
 --
 ====
 
-[#_struct_Transaction_method_concept]
+[#_struct_Transaction_concept__]
 ==== concept
 
 [source,rust]
@@ -65,7 +65,7 @@ The ``ConceptManager`` for this transaction, providing access to all Concept API
 ConceptManager<'_>
 ----
 
-[#_struct_Transaction_method_force_close]
+[#_struct_Transaction_force_close__]
 ==== force_close
 
 [source,rust]
@@ -89,7 +89,7 @@ null
 transaction.force_close()
 ----
 
-[#_struct_Transaction_method_is_open]
+[#_struct_Transaction_is_open__]
 ==== is_open
 
 [source,rust]
@@ -113,7 +113,7 @@ bool
 transaction.close()
 ----
 
-[#_struct_Transaction_method_logic]
+[#_struct_Transaction_logic__]
 ==== logic
 
 [source,rust]
@@ -130,7 +130,7 @@ Retrieves the ``LogicManager`` for this Transaction, providing access to all Con
 LogicManager<'_>
 ----
 
-[#_struct_Transaction_method_on_close]
+[#_struct_Transaction_on_close__function]
 ==== on_close
 
 [source,rust]
@@ -166,7 +166,7 @@ null
 transaction.on_close(function)
 ----
 
-[#_struct_Transaction_method_query]
+[#_struct_Transaction_query__]
 ==== query
 
 [source,rust]
@@ -183,7 +183,7 @@ Retrieves the``QueryManager`` for this Transaction, from which any TypeQL query 
 QueryManager<'_>
 ----
 
-[#_struct_Transaction_method_rollback]
+[#_struct_Transaction_rollback__]
 ==== rollback
 
 [source,rust]
@@ -225,7 +225,7 @@ transaction.rollback()
 --
 ====
 
-[#_struct_Transaction_method_type]
+[#_struct_Transaction_type___]
 ==== type_
 
 [source,rust]

--- a/tool/docs/dataclasses/Variable.kt
+++ b/tool/docs/dataclasses/Variable.kt
@@ -45,4 +45,9 @@ data class Variable(
         }
         return result.toList()
     }
+
+    fun shortString(): String {
+        if (type == null) return name;
+        else return name + "_" + type;
+    }
 }

--- a/tool/docs/python/PythonDocsParser.kt
+++ b/tool/docs/python/PythonDocsParser.kt
@@ -28,6 +28,7 @@ import com.vaticle.typedb.driver.tool.docs.dataclasses.Variable
 import com.vaticle.typedb.driver.tool.docs.util.removeAllTags
 import com.vaticle.typedb.driver.tool.docs.util.replaceCodeTags
 import com.vaticle.typedb.driver.tool.docs.util.replaceEmTags
+import com.vaticle.typedb.driver.tool.docs.util.replaceSymbolsForAnchor
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import picocli.CommandLine
@@ -187,18 +188,18 @@ class PythonDocParser : Callable<Unit> {
         }
         val methodReturnDescr = element.select(".field-list > dt:contains(Returns) + dd p").text()
         val methodExamples = element.select("section:contains(Examples) .highlight").map { it.text() }
+        val methodAnchor = replaceSymbolsForAnchor("${classAnchor}_${methodName}_${methodArgs.map { it.shortString() }}")
 
         return Method(
             name = methodName,
             signature = methodSignature,
-            anchor = "${classAnchor}_$methodName",
+            anchor = methodAnchor,
             args = methodArgs,
             description = methodDescr,
             examples = methodExamples,
             returnDescription = methodReturnDescr,
             returnType = methodReturnType,
         )
-
     }
 
     private fun parseProperty(element: Element): Variable {

--- a/tool/docs/rust/RustDocsParser.kt
+++ b/tool/docs/rust/RustDocsParser.kt
@@ -209,12 +209,8 @@ class RustDocParser : Callable<Unit> {
     private fun parseMethod(element: Element, classAnchor: String, mode: String): Method {
         val methodSignature = enhanceSignature(element.selectFirst("summary section h4")!!.wholeText())
         val methodName = element.selectFirst("summary section h4 a.fn")!!.text()
-        val methodAnchor = replaceSymbolsForAnchor(
-            element.selectFirst("summary section h4 a.fn")!!.attr("href").substringAfter("#")
-        )
         val allArgs = getArgsFromSignature(methodSignature)
         val methodReturnType = if (methodSignature.contains(" -> ")) methodSignature.split(" -> ").last() else null
-
         val methodDescr = if (element.select("div.docblock p").isNotEmpty()) {
             element.select("div.docblock p").map { reformatTextWithCode(it.html()) }
         } else {
@@ -222,9 +218,7 @@ class RustDocParser : Callable<Unit> {
                 "<<#_" + getAnchorFromUrl(it.attr("href")) + ",Read more>>"
             }
         }
-
         val methodExamples = element.select("div.docblock div.example-wrap pre").map { it.text() }
-
         val methodArgs = element.select("div.docblock ul li code:eq(0)").map {
             val argName = it.text().trim()
             assert(allArgs.contains(argName))
@@ -235,18 +229,18 @@ class RustDocParser : Callable<Unit> {
                 type = allArgs[argName]?.trim(),
             )
         }
+        val methodAnchor = replaceSymbolsForAnchor("${classAnchor}_${methodName}_${methodArgs.map { it.shortString() }}")
 
         return Method(
             name = methodName,
             signature = methodSignature,
-            anchor = "${classAnchor}_$methodAnchor",
+            anchor = methodAnchor,
             args = methodArgs,
             description = methodDescr,
             examples = methodExamples,
             mode = mode,
             returnType = methodReturnType,
         )
-
     }
 
     private fun parseField(element: Element, classAnchor: String): Variable {

--- a/tool/docs/util/Util.kt
+++ b/tool/docs/util/Util.kt
@@ -43,7 +43,7 @@ fun replaceHtmlSymbols(html: String): String {
 }
 
 fun replaceSymbolsForAnchor(name: String): String {
-    return name.replace("[\\.,\\(\\)\\s#<>\\[\\]]".toRegex(), "_").removeSuffix("_")
+    return name.replace("[&{}?|;:=]".toRegex(), "").replace("[\\.,\\(\\)\\s#<>\\[\\]]".toRegex(), "_").removeSuffix("_")
 }
 
 fun escape(text: String): String {


### PR DESCRIPTION
## Release notes: usage and product changes

Documentation generation now produces strictly unique anchors, using a combination of class/struct name, method name, and arguments signature as part of the anchor. This strategies means that all overloads and variations of method, for example in Java, now have uniquely referrable links.


## Implementation
* We update the all docs anchors generation to be a concatenation of class name, method name, and signature. 
* We update the anchor sanitiser to remove further special characters
* Regenerate all docs content.