### PR TITLE
Java JNI library loading: fallback when platform not specified

### DIFF
--- a/java/common/Loader.java
+++ b/java/common/Loader.java
@@ -32,7 +32,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -75,15 +74,24 @@ public class Loader {
         }
         String platformString = DRIVER_JNI_JAR_NAME.get(platform);
         ClassLoader loader = Loader.class.getClassLoader();
-        URL jniURL = null;
         Iterator<URL> resourceIterator = loader.getResources(DRIVER_JNI_LIBRARY_NAME).asIterator();
+
+        URL jniURL = null;
+        boolean isValid = true;
+
         while (resourceIterator.hasNext()) {
             URL resource = resourceIterator.next();
+
+            if (jniURL == null) jniURL = resource;
+            else isValid = false; // encountered more than one: not valid...
+
             if (resource.getPath().contains(platformString)) {
+                isValid = true; // ... unless it explicitly includes the platform string
                 jniURL = resource;
+                break;
             }
         }
-        assert jniURL != null;
+        assert jniURL != null && isValid;
         try {
             return unpackNativeResources(jniURL.toURI());
         } catch (URISyntaxException e) {

--- a/java/common/exception/ErrorMessage.java
+++ b/java/common/exception/ErrorMessage.java
@@ -34,20 +34,24 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Driver(2, "The architecture '%s' is not recognised.");
         public static final Driver UNRECOGNISED_OS_ARCH =
                 new Driver(3, "The platform os '%s' and architecture '%s' are not supported by this driver.");
+        public static final Driver JNI_LIBRARY_NOT_FOUND =
+                new Driver(4, "Native JNI library not found (searching for '%s').");
+        public static final Driver JNI_PLATFORM_LIBRARY_NOT_FOUND =
+                new Driver(5, "Found multiple JNI libraries in classpath, could not select one for target platform (searching for '%s' for platform '%s').");
         public static final Driver DRIVER_CLOSED =
-                new Driver(4, "The driver has been closed and no further operation is allowed.");
+                new Driver(6, "The driver has been closed and no further operation is allowed.");
         public static final Driver SESSION_CLOSED =
-                new Driver(5, "The session has been closed and no further operation is allowed.");
+                new Driver(7, "The session has been closed and no further operation is allowed.");
         public static final Driver TRANSACTION_CLOSED =
-                new Driver(6, "The transaction has been closed and no further operation is allowed.");
+                new Driver(8, "The transaction has been closed and no further operation is allowed.");
         public static final Driver TRANSACTION_CLOSED_WITH_ERRORS =
-                new Driver(7, "The transaction has been closed with error(s): \n%s.");
+                new Driver(9, "The transaction has been closed with error(s): \n%s.");
         public static final Driver DATABASE_DELETED =
-                new Driver(8, "The database has been deleted and no further operation is allowed.");
+                new Driver(10, "The database has been deleted and no further operation is allowed.");
         public static final Driver POSITIVE_VALUE_REQUIRED =
-                new Driver(9, "Value cannot be less than 1, was: '%d'.");
+                new Driver(11, "Value cannot be less than 1, was: '%d'.");
         public static final Driver MISSING_DB_NAME =
-                new Driver(10, "Database name cannot be null.");
+                new Driver(12, "Database name cannot be null.");
 
         private static final String codePrefix = "JCL";
         private static final String messagePrefix = "Driver Error";


### PR DESCRIPTION
## Usage and product changes

Previously, the JNI library would be selected based on if the containing JAR contains the expected platform string. When TypeDB Driver Java is repackaged by the end user, the JNI library is relocated and is likely missing the platform specification in its path. Now, if only one native library candidate is found in classpath, we attempt to use that rather than fail.
