### PR TITLE
Replace all instances of 'enterprise' with 'cloud'

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -986,7 +986,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-cloud-servers.sh &&
+        source tool/test/start-cloud-servers.sh &&
           .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
@@ -1057,7 +1057,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-cloud-servers.sh &&
+        source tool/test/start-cloud-servers.sh &&
           .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
@@ -1147,7 +1147,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-cloud-servers.sh &&
+        source tool/test/start-cloud-servers.sh &&
           .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
@@ -1190,7 +1190,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-cloud-servers.sh &&
+        source tool/test/start-cloud-servers.sh &&
           .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -95,13 +95,13 @@ build:
         tool/test/stop-core-server.sh
         if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
-        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
           bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=integration::queries::enterprise \
+            --test_arg=integration::queries::cloud \
             --test_arg=integration::runtimes &&
-          export ENTERPRISE_FAILED= || export ENTERPRISE_FAILED=1
-        tool/test/stop-enterprise-servers.sh
-        if [[ -n "$ENTERPRISE_FAILED" ]]; then exit 1; fi
+          export CLOUD_FAILED= || export CLOUD_FAILED=1
+        tool/test/stop-cloud-servers.sh
+        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
 
     test-rust-behaviour-concept:
       image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
@@ -112,11 +112,11 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
           bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
             --test_arg=behaviour::concept &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-rust-behaviour-connection:
@@ -128,11 +128,11 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
           bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
             --test_arg=behaviour::connection &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-rust-behaviour-driver:
@@ -145,11 +145,11 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
           bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
             --test_arg=behaviour::driver &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-rust-behaviour-query-read:
@@ -165,7 +165,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
           bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
             --test_arg=behaviour::query::language::match_ \
             --test_arg=behaviour::query::language::get \
@@ -173,7 +173,7 @@ build:
             --test_arg=behaviour::query::language::modifiers \
             --test_arg=behaviour::query::language::expression &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-rust-behaviour-query-write:
@@ -189,7 +189,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
           bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
             --test_arg=behaviour::query::language::define \
             --test_arg=behaviour::query::language::undefine \
@@ -198,7 +198,7 @@ build:
             --test_arg=behaviour::query::language::update \
             --test_arg=behaviour::query::language::rule_validation &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-c-integration:
@@ -239,7 +239,7 @@ build:
         .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
 
-    test-java-behaviour-connection-enterprise:
+    test-java-behaviour-connection-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -248,7 +248,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-enterprise.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
     # TODO: delete --jobs=1 if we fix the issue with excess memory usage
 
     test-java-behaviour-concept-core:
@@ -262,7 +262,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
 
-    test-java-behaviour-concept-enterprise:
+    test-java-behaviour-concept-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -271,7 +271,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-enterprise.sh //java/test/behaviour/concept/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
 
     test-java-behaviour-driver-core:
       image: vaticle-ubuntu-22.04
@@ -284,7 +284,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
 
-    test-java-behaviour-driver-enterprise:
+    test-java-behaviour-driver-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -293,7 +293,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-enterprise.sh //java/test/behaviour/driver/query/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
 
     test-java-behaviour-read-core:
       image: vaticle-ubuntu-22.04
@@ -313,7 +313,7 @@ build:
         .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
         .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
 
-    test-java-behaviour-read-enterprise:
+    test-java-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -325,11 +325,11 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/match/... --test_output=errors
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/get/... --test_output=errors
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
 
     test-java-behaviour-writable-core:
       image: vaticle-ubuntu-22.04
@@ -347,7 +347,7 @@ build:
         .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
         .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
 
-    test-java-behaviour-writable-enterprise:
+    test-java-behaviour-writable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -359,9 +359,9 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/update/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
 
     test-java-behaviour-definable-core:
       image: vaticle-ubuntu-22.04
@@ -378,7 +378,7 @@ build:
         .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
         .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
 
-    test-java-behaviour-definable-enterprise:
+    test-java-behaviour-definable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -390,8 +390,8 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/define/... --test_output=errors
-        .factory/test-enterprise.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
 
 
     test-python-behaviour-connection-core:
@@ -414,7 +414,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-python-behaviour-connection-enterprise:
+    test-python-behaviour-connection-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -426,13 +426,13 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-enterprise.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-enterprise.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-enterprise.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-python-behaviour-concept-core:
@@ -456,7 +456,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-python-behaviour-concept-enterprise:
+    test-python-behaviour-concept-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -471,10 +471,10 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh &&  # use source to receive export vars
-          .factory/test-enterprise.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-python-behaviour-driver-core:
@@ -498,7 +498,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-python-behaviour-driver-enterprise:
+    test-python-behaviour-driver-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -513,10 +513,10 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-python-behaviour-read-core:
@@ -547,7 +547,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-python-behaviour-read-enterprise:
+    test-python-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -565,14 +565,14 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh &&  # use source to receive export vars
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-python-behaviour-writable-core:
@@ -601,7 +601,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-python-behaviour-writable-enterprise:
+    test-python-behaviour-writable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -619,12 +619,12 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-python-behaviour-definable-core:
@@ -652,7 +652,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-python-behaviour-definable-enterprise:
+    test-python-behaviour-definable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -670,11 +670,11 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-python-integration-core:
@@ -695,7 +695,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-#    test-python-integration-enterprise-failover:
+#    test-python-integration-cloud-failover:
 #      machine: 4-core-16-gb
 #      image: vaticle-ubuntu-22.04
 #      dependencies:
@@ -711,7 +711,7 @@ build:
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //python/tests/integration:test_enterprise_failover --test_output=errors
+#        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
 
     test-nodejs-integration:
       image: vaticle-ubuntu-22.04
@@ -732,7 +732,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-nodejs-enterprise-failover:
+    test-nodejs-cloud-failover:
       machine: 4-core-16-gb
       image: vaticle-ubuntu-22.04
       dependencies:
@@ -744,10 +744,10 @@ build:
         bazel build //nodejs/...
         cp -rL bazel-bin/nodejs/node_modules nodejs/.
         cp -rL bazel-bin/nodejs/dist nodejs/.
-        source tool/test/start-enterprise-servers.sh 3 && # use source to receive export vars
-          node nodejs/test/integration/test-enterprise-failover.js && 
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          node nodejs/test/integration/test-cloud-failover.js && 
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-nodejs-behaviour-connection-core:
@@ -766,7 +766,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-nodejs-behaviour-connection-enterprise:
+    test-nodejs-behaviour-connection-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -774,13 +774,13 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-nodejs-behaviour-concept-core:
@@ -797,7 +797,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-nodejs-behaviour-concept-enterprise:
+    test-nodejs-behaviour-concept-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -805,10 +805,10 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
     # TODO: Delete --jobs=1 once tests are parallelisable
 
@@ -826,7 +826,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-nodejs-behaviour-driver-enterprise:
+    test-nodejs-behaviour-driver-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -834,10 +834,10 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-nodejs-behaviour-read-core:
@@ -861,7 +861,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-nodejs-behaviour-read-enterprise:
+    test-nodejs-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -872,14 +872,14 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-nodejs-behaviour-writable-core:
@@ -901,7 +901,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-nodejs-behaviour-writable-enterprise:
+    test-nodejs-behaviour-writable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -912,12 +912,12 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-nodejs-behaviour-definable-core:
@@ -938,7 +938,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-nodejs-behaviour-definable-enterprise:
+    test-nodejs-behaviour-definable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -949,11 +949,11 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh && # use source to receive export vars
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-enterprise.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-cpp-behaviour-connection-core:
@@ -1241,17 +1241,17 @@ build:
       dependencies:
         - build
         - test-nodejs-integration
-        - test-nodejs-enterprise-failover
+        - test-nodejs-cloud-failover
         - test-nodejs-behaviour-connection-core
-        - test-nodejs-behaviour-connection-enterprise
+        - test-nodejs-behaviour-connection-cloud
         - test-nodejs-behaviour-concept-core
-        - test-nodejs-behaviour-concept-enterprise
+        - test-nodejs-behaviour-concept-cloud
         - test-nodejs-behaviour-read-core
-        - test-nodejs-behaviour-read-enterprise
+        - test-nodejs-behaviour-read-cloud
         - test-nodejs-behaviour-writable-core
-        - test-nodejs-behaviour-writable-enterprise
+        - test-nodejs-behaviour-writable-cloud
         - test-nodejs-behaviour-definable-core
-        - test-nodejs-behaviour-definable-enterprise
+        - test-nodejs-behaviour-definable-cloud
       command: |
         export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -976,7 +976,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-cpp-behaviour-connection-enterprise:
+    test-cpp-behaviour-connection-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -986,13 +986,13 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-enterprise-servers.sh &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+        tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-cpp-behaviour-concept-core:
@@ -1013,7 +1013,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-cpp-behaviour-concept-enterprise:
+    test-cpp-behaviour-concept-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -1023,10 +1023,10 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh &&  # use source to receive export vars
-          .factory/test-enterprise.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-cpp-behaviour-driver-core:
@@ -1047,7 +1047,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-cpp-behaviour-driver-enterprise:
+    test-cpp-behaviour-driver-cloud:
       image: vaticle-ubuntu-22.04
       dependencies:
         - build
@@ -1057,10 +1057,10 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-enterprise-servers.sh &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-cpp-behaviour-read-core:
@@ -1088,7 +1088,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-cpp-behaviour-read-enterprise:
+    test-cpp-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -1101,14 +1101,14 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-enterprise-servers.sh &&  # use source to receive export vars
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-cpp-behaviour-writable-core:
@@ -1134,7 +1134,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-cpp-behaviour-writable-enterprise:
+    test-cpp-behaviour-writable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -1147,12 +1147,12 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-enterprise-servers.sh &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-cpp-behaviour-definable-core:
@@ -1177,7 +1177,7 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    test-cpp-behaviour-definable-enterprise:
+    test-cpp-behaviour-definable-cloud:
       image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
@@ -1190,11 +1190,11 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-enterprise-servers.sh &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-enterprise.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+        tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-enterprise-servers.sh
+        tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
 
     test-cpp-integration-core:

--- a/.factory/test-cloud.sh
+++ b/.factory/test-cloud.sh
@@ -21,4 +21,4 @@
 #
 
 set -ex
-bazel test $(bazel query "filter('^.*enterprise.*$', kind(.*_test, $1))") "${@:2}"
+bazel test $(bazel query "filter('^.*cloud.*$', kind(.*_test, $1))") "${@:2}"

--- a/.factory/test-core.sh
+++ b/.factory/test-core.sh
@@ -21,4 +21,4 @@
 #
 
 set -ex
-bazel test $(bazel query "filter('^.*(?<!enterprise)$', kind(.*_test, $1))") "${@:2}"
+bazel test $(bazel query "filter('^.*(?<!cloud)$', kind(.*_test, $1))") "${@:2}"

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -12,7 +12,7 @@ assignees: ''
 
 ## Environment
 
-1. TypeDB distribution: Core/Enterprise/Cloud
+1. TypeDB distribution: Core/Cloud
 2. TypeDB version: 
 3. Environment: Linux/Mac/Windows/TypeDB Cloud/Google Cloud/AWS/Azure
 4. Studio version: 

--- a/RELEASE_NOTES_LATEST.md
+++ b/RELEASE_NOTES_LATEST.md
@@ -66,7 +66,7 @@ npm install typedb-driver@2.25.8
   **Session callbacks**
   - All drivers:
     - implement session reopen callbacks, executed when a session closed on the server side successfully reconnects;
-    - core session now attempts to reconnect if it is closed on the remote server, in line with enterprise behaviour;
+    - core session now attempts to reconnect if it is closed on the remote server, in line with cloud behaviour;
     - `Session::on_close()` callbacks are now executed each time the session closes (rather than just once);
   - NodeJS:
     - implement session and transaction callbacks (`onClose()`, `Session::onReopen()`);

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -181,9 +181,9 @@ vaticle_typedb_behaviour()
 vaticle_typedb_protocol()
 
 # Load artifacts
-load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_artifact", "vaticle_typedb_enterprise_artifact")
+load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_artifact", "vaticle_typedb_cloud_artifact")
 vaticle_typedb_artifact()
-vaticle_typedb_enterprise_artifact()
+vaticle_typedb_cloud_artifact()
 
 ####################
 # Load npm modules #

--- a/c/src/connection.rs
+++ b/c/src/connection.rs
@@ -34,12 +34,12 @@ pub extern "C" fn connection_open_core(address: *const c_char) -> *mut Connectio
 }
 
 #[no_mangle]
-pub extern "C" fn connection_open_enterprise(
+pub extern "C" fn connection_open_cloud(
     addresses: *const *const c_char,
     credential: *const Credential,
 ) -> *mut Connection {
     let addresses: Vec<&str> = string_array_view(addresses).collect();
-    try_release(Connection::new_enterprise(&addresses, borrow(credential).clone()))
+    try_release(Connection::new_cloud(&addresses, borrow(credential).clone()))
 }
 
 #[no_mangle]

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -338,7 +338,7 @@ void transaction_on_close_register(const Transaction* transaction, TransactionCa
 %newobject role_type_get_player_instances;
 
 %newobject connection_open_core;
-%newobject connection_open_enterprise;
+%newobject connection_open_cloud;
 
 %newobject credential_new;
 

--- a/cpp/include/typedb/connection/driver.hpp
+++ b/cpp/include/typedb/connection/driver.hpp
@@ -56,7 +56,7 @@ public:
     UserManager users;
 
     static Driver coreDriver(const std::string& coreAddress);
-    static Driver enterpriseDriver(const std::vector<std::string>& enterpriseAddresses, const Credential& credential);
+    static Driver cloudDriver(const std::vector<std::string>& cloudAddresses, const Credential& credential);
 
     Driver(const Driver&) = delete;
     Driver(Driver&& from) = default;

--- a/cpp/lib/connection/driver.cpp
+++ b/cpp/lib/connection/driver.cpp
@@ -46,12 +46,12 @@ Driver Driver::coreDriver(const std::string& coreAddress) {
     return Driver(p);
 }
 
-Driver Driver::enterpriseDriver(const std::vector<std::string>& enterpriseAddresses, const Credential& credential) {
+Driver Driver::cloudDriver(const std::vector<std::string>& cloudAddresses, const Credential& credential) {
     std::vector<const char*> addressesNative;
-    for (auto& addr : enterpriseAddresses)
+    for (auto& addr : cloudAddresses)
         addressesNative.push_back(addr.c_str());
     addressesNative.push_back(nullptr);
-    auto p = _native::connection_open_enterprise(addressesNative.data(), credential.getNative());
+    auto p = _native::connection_open_cloud(addressesNative.data(), credential.getNative());
     DriverException::check_and_throw();
     return Driver(p);
 }

--- a/cpp/test/behaviour/connection/user/BUILD
+++ b/cpp/test/behaviour/connection/user/BUILD
@@ -22,8 +22,8 @@ load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("//cpp/test/behaviour:tests.bzl", "typedb_behaviour_cpp_test")
 
 cc_test(
-    name = "user-test-enterprise",
-    deps = ["//cpp/test/behaviour/steps:enterprise-steps"],
+    name = "user-test-cloud",
+    deps = ["//cpp/test/behaviour/steps:cloud-steps"],
     data = ["@vaticle_typedb_behaviour//connection:user.feature", "//tool/test/resources:certificates"],
     env = {"ROOT_CA": "tool/test/resources/encryption/ext-grpc-root-ca.pem"},
     args = ["$(location @vaticle_typedb_behaviour//connection:user.feature)"]

--- a/cpp/test/behaviour/steps/BUILD
+++ b/cpp/test/behaviour/steps/BUILD
@@ -43,7 +43,7 @@ cc_library(
 )
 
 cc_library(
-    name = "enterprise-steps",
+    name = "cloud-steps",
     deps = [
         "//cpp:typedb-driver-cpp-import",
         "//cpp/test/cucumber:cucumber-cpp",
@@ -54,7 +54,7 @@ cc_library(
         "@gtest//:gtest_main",
     ],
     copts = ["-g -Iexternal/gherkin_cpp/include -std=c++17"],
-    srcs = glob(["main.cpp", "enterprise_steps.cpp", "common/**/*.cpp"]),
+    srcs = glob(["main.cpp", "cloud_steps.cpp", "common/**/*.cpp"]),
     hdrs = glob(["include/*.hpp"]),
     strip_include_prefix = "include",
     visibility = ["//cpp/test/behaviour:__subpackages__"],

--- a/cpp/test/behaviour/steps/cloud_steps.cpp
+++ b/cpp/test/behaviour/steps/cloud_steps.cpp
@@ -27,9 +27,9 @@
 
 namespace TypeDB::BDD {
 
-const std::vector<std::string> DEFAULT_ENTERPRISE_ADDRESSES = {"localhost:11729", "localhost:21729", "localhost:31729"};
-const std::string DEFAULT_ENTERPRISE_USER = "admin";
-const std::string DEFAULT_ENTERPRISE_PASSWORD = "password";
+const std::vector<std::string> DEFAULT_CLOUD_ADDRESSES = {"localhost:11729", "localhost:21729", "localhost:31729"};
+const std::string DEFAULT_CLOUD_USER = "admin";
+const std::string DEFAULT_CLOUD_PASSWORD = "password";
 
 void wipeDatabases(const TypeDB::Driver& driver) {
     DatabaseIterable dbIterable = driver.databases.all();
@@ -49,23 +49,23 @@ bool TestHooks::skipScenario(const cucumber::messages::pickle& scenario) const {
 }
 
 void TestHooks::beforeAll() const {
-    wipeDatabases(CoreOrEnterpriseConnection::connectWithAuthentication("admin", "password"));
+    wipeDatabases(CoreOrCloudConnection::connectWithAuthentication("admin", "password"));
 }
 
 void TestHooks::afterScenario(Context& context, const cucumber_bdd::Scenario<Context>* scenario) const {
     DriverException::check_and_throw();
     context.driver->close();
-    wipeDatabases(CoreOrEnterpriseConnection::connectWithAuthentication("admin", "password"));
+    wipeDatabases(CoreOrCloudConnection::connectWithAuthentication("admin", "password"));
 }
 
 const TestHooks testHooks;
 
-TypeDB::Driver CoreOrEnterpriseConnection::defaultConnection() {
-    return TypeDB::Driver::enterpriseDriver(DEFAULT_ENTERPRISE_ADDRESSES, TypeDB::Credential(DEFAULT_ENTERPRISE_USER, DEFAULT_ENTERPRISE_PASSWORD, true, std::getenv("ROOT_CA")));
+TypeDB::Driver CoreOrCloudConnection::defaultConnection() {
+    return TypeDB::Driver::cloudDriver(DEFAULT_CLOUD_ADDRESSES, TypeDB::Credential(DEFAULT_CLOUD_USER, DEFAULT_CLOUD_PASSWORD, true, std::getenv("ROOT_CA")));
 }
 
-TypeDB::Driver CoreOrEnterpriseConnection::connectWithAuthentication(const std::string& username, const std::string& password) {
-    return TypeDB::Driver::enterpriseDriver(DEFAULT_ENTERPRISE_ADDRESSES, TypeDB::Credential(username, password, true, std::getenv("ROOT_CA")));
+TypeDB::Driver CoreOrCloudConnection::connectWithAuthentication(const std::string& username, const std::string& password) {
+    return TypeDB::Driver::cloudDriver(DEFAULT_CLOUD_ADDRESSES, TypeDB::Credential(username, password, true, std::getenv("ROOT_CA")));
 }
 
 }  // namespace TypeDB::BDD

--- a/cpp/test/behaviour/steps/common/connection_steps.cpp
+++ b/cpp/test/behaviour/steps/common/connection_steps.cpp
@@ -29,11 +29,11 @@ cucumber_bdd::StepCollection<Context> connectionSteps = {
     BDD_STEP("typedb starts", {}),
 
     BDD_STEP("connection opens with default authentication", {
-        context.driver = CoreOrEnterpriseConnection::defaultConnection();
+        context.driver = CoreOrCloudConnection::defaultConnection();
     }),
 
     BDD_STEP_AND_THROWS("connection opens with authentication: (\\S+), (\\S+)", {
-        context.driver = CoreOrEnterpriseConnection::connectWithAuthentication(matches[1].str(), matches[2].str());
+        context.driver = CoreOrCloudConnection::connectWithAuthentication(matches[1].str(), matches[2].str());
     }),
 
     BDD_STEP("connection has been opened", {

--- a/cpp/test/behaviour/steps/core_steps.cpp
+++ b/cpp/test/behaviour/steps/core_steps.cpp
@@ -41,22 +41,22 @@ bool TestHooks::skipScenario(const cucumber::messages::pickle& scenario) const {
 }
 
 void TestHooks::beforeAll() const {
-    wipeDatabases(CoreOrEnterpriseConnection::defaultConnection());
+    wipeDatabases(CoreOrCloudConnection::defaultConnection());
 }
 
 void TestHooks::afterScenario(Context& context, const cucumber_bdd::Scenario<Context>* scenario) const {
     DriverException::check_and_throw();
     context.driver->close();
-    wipeDatabases(CoreOrEnterpriseConnection::defaultConnection());
+    wipeDatabases(CoreOrCloudConnection::defaultConnection());
 }
 
 const TestHooks testHooks;
 
-TypeDB::Driver CoreOrEnterpriseConnection::defaultConnection() {
+TypeDB::Driver CoreOrCloudConnection::defaultConnection() {
     return TypeDB::Driver::coreDriver(DEFAULT_CORE_ADDRESS);
 }
 
-TypeDB::Driver CoreOrEnterpriseConnection::connectWithAuthentication(const std::string&, const std::string&) {
+TypeDB::Driver CoreOrCloudConnection::connectWithAuthentication(const std::string&, const std::string&) {
     THROW_ILLEGAL_STATE("Core does not support authentication steps");
 }
 

--- a/cpp/test/behaviour/steps/include/common.hpp
+++ b/cpp/test/behaviour/steps/include/common.hpp
@@ -110,7 +110,7 @@ class TestHooks : public cucumber_bdd::TestHooks<Context> {
 };
 extern const TestHooks testHooks;
 
-struct CoreOrEnterpriseConnection {
+struct CoreOrCloudConnection {
     static TypeDB::Driver defaultConnection();
     static TypeDB::Driver connectWithAuthentication(const std::string& username, const std::string& password);
 };

--- a/cpp/test/behaviour/tests.bzl
+++ b/cpp/test/behaviour/tests.bzl
@@ -37,8 +37,8 @@ def typedb_behaviour_cpp_test(
     )
     
     native.cc_test(
-        name = name + "-enterprise",
-        deps = ["//cpp/test/behaviour/steps:enterprise-steps"] + deps,
+        name = name + "-cloud",
+        deps = ["//cpp/test/behaviour/steps:cloud-steps"] + deps,
         data = [feature, "//tool/test/resources:certificates"] + data,
         args = ["$(location " + feature + ")"] + args,
         env = {"ROOT_CA": "tool/test/resources/encryption/ext-grpc-root-ca.pem"} | env,

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "bfba9fb6d9e90e8c9001cac994b581c6ae13e54d",
+        commit = "454cd894396ee22f440b01ebbee4cc53e50f97ea",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.25.6",
+        tag = "2.25.7",
     )
 
 def vaticle_typedb_cloud_artifact():
@@ -39,5 +39,5 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "994220cb44052ba8b66c8e889f94f47ab3b15c0d",
+        commit = "bfba9fb6d9e90e8c9001cac994b581c6ae13e54d",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -32,11 +32,11 @@ def vaticle_typedb_artifact():
         tag = "2.25.6",
     )
 
-def vaticle_typedb_enterprise_artifact():
+def vaticle_typedb_cloud_artifact():
     native_artifact_files(
-        name = "vaticle_typedb_enterprise_artifact",
-        group_name = "vaticle_typedb_enterprise",
-        artifact_name = "typedb-enterprise-all-{platform}-{version}.{ext}",
+        name = "vaticle_typedb_cloud_artifact",
+        group_name = "vaticle_typedb_cloud",
+        artifact_name = "typedb-cloud-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
         commit = "994220cb44052ba8b66c8e889f94f47ab3b15c0d",

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,15 +24,15 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "38c1dc571e8d123635e609a5650b75d42f70006c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "a97958622d0df2f51350e0f43a354144b4e9d5ee", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.25.3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "40d7abaa956612addf4430b4d4685a20596333c9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,7 +32,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "40d7abaa956612addf4430b4d4685a20596333c9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "aeee242969199d2d33340288cc10aa0bf7ad857d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,8 +31,8 @@ def vaticle_dependencies():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "aeee242969199d2d33340288cc10aa0bf7ad857d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "4d2adde1cb75a40ca1629eed258d2a7dcda9f5e3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():

--- a/java/TypeDB.java
+++ b/java/TypeDB.java
@@ -47,34 +47,34 @@ public class TypeDB {
     }
 
     /**
-     * Open a TypeDB Driver to a TypeDB Enterprise server available at the provided address, using
+     * Open a TypeDB Driver to a TypeDB Cloud server available at the provided address, using
      * the provided credential.
      *
      * <h3>Examples</h3>
      * <pre>
-     * TypeDB.enterpriseDriver(address, credential);
+     * TypeDB.cloudDriver(address, credential);
      * </pre>
      *
      * @param address The address of the TypeDB server
      * @param credential The credential to connect with
      */
-    public static TypeDBDriver enterpriseDriver(String address, TypeDBCredential credential) {
-        return enterpriseDriver(set(address), credential);
+    public static TypeDBDriver cloudDriver(String address, TypeDBCredential credential) {
+        return cloudDriver(set(address), credential);
     }
 
     /**
-     * Open a TypeDB Driver to TypeDB Enterprise server(s) available at the provided addresses, using
+     * Open a TypeDB Driver to TypeDB Cloud server(s) available at the provided addresses, using
      * the provided credential.
      *
      * <h3>Examples</h3>
      * <pre>
-     * TypeDB.enterpriseDriver(addresses, credential);
+     * TypeDB.cloudDriver(addresses, credential);
      * </pre>
      *
      * @param addresses The address(es) of the TypeDB server(s)
      * @param credential The credential to connect with
      */
-    public static TypeDBDriver enterpriseDriver(Set<String> addresses, TypeDBCredential credential) {
+    public static TypeDBDriver cloudDriver(Set<String> addresses, TypeDBCredential credential) {
         return new TypeDBDriverImpl(addresses, credential);
     }
 }

--- a/java/api/TypeDBCredential.java
+++ b/java/api/TypeDBCredential.java
@@ -30,7 +30,7 @@ import java.nio.file.Path;
 import static com.vaticle.typedb.driver.jni.typedb_driver.credential_new;
 
 /**
- * User credentials and TLS encryption settings for connecting to TypeDB Enterprise.
+ * User credentials and TLS encryption settings for connecting to TypeDB Cloud.
  *
  * <h3>Examples</h3>
  * <pre>
@@ -46,7 +46,7 @@ public class TypeDBCredential extends NativeObject<com.vaticle.typedb.driver.jni
      *
      * @param username The name of the user to connect as
      * @param password The password for the user
-     * @param tlsEnabled Specify whether the connection to TypeDB Enterprise must be done over TLS
+     * @param tlsEnabled Specify whether the connection to TypeDB Cloud must be done over TLS
      */
     public TypeDBCredential(String username, String password, boolean tlsEnabled) {
         this(username, password, null, tlsEnabled);

--- a/java/api/TypeDBDriver.java
+++ b/java/api/TypeDBDriver.java
@@ -82,13 +82,13 @@ public interface TypeDBDriver extends AutoCloseable {
 
     /**
      * The <code>UserManager</code> instance for this connection, providing access to user management methods.
-     * Only for TypeDB Enterprise.
+     * Only for TypeDB Cloud.
      */
     @CheckReturnValue
     User user();
 
     /**
-     * Returns the logged-in user for the connection. Only for TypeDB Enterprise.
+     * Returns the logged-in user for the connection. Only for TypeDB Cloud.
      *
      * <h3>Examples</h3>
      * <pre>

--- a/java/api/TypeDBOptions.java
+++ b/java/api/TypeDBOptions.java
@@ -400,7 +400,7 @@ public class TypeDBOptions extends NativeObject<com.vaticle.typedb.driver.jni.Op
     /**
      * Explicitly enables or disables reading data from any replica.
      * If set to <code>True</code>, enables reading data from any replica, potentially boosting read throughput.
-     * Only settable in TypeDB Enterprise.
+     * Only settable in TypeDB Cloud.
      *
      * <h3>Examples</h3>
      * <pre>

--- a/java/api/database/Database.java
+++ b/java/api/database/Database.java
@@ -78,7 +78,7 @@ public interface Database {
 
     /**
      * Set of <code>Replica</code> instances for this database.
-     * <b>Only works in TypeDB Enterprise</b>
+     * <b>Only works in TypeDB Cloud</b>
      *
      * <h3>Examples</h3>
      * <pre>
@@ -90,7 +90,7 @@ public interface Database {
 
     /**
      * Returns the primary replica for this database.
-     * _Only works in TypeDB Enterprise_
+     * _Only works in TypeDB Cloud_
      *
      * <h3>Examples</h3>
      * <pre>
@@ -102,7 +102,7 @@ public interface Database {
 
     /**
      * Returns the preferred replica for this database. Operations which can be run on any replica will prefer to use this replica.
-     * _Only works in TypeDB Enterprise_
+     * _Only works in TypeDB Cloud_
      *
      * <h3>Examples</h3>
      * <pre>

--- a/java/api/database/DatabaseManager.java
+++ b/java/api/database/DatabaseManager.java
@@ -65,7 +65,7 @@ public interface DatabaseManager {
      *
      * @param name The name of the database to be created
      */
-    // TODO: Return type should be 'Database' but right now that would require 2 server calls in Enterprise
+    // TODO: Return type should be 'Database' but right now that would require 2 server calls in Cloud
     void create(String name);
 
     /**

--- a/java/connection/TypeDBDriverImpl.java
+++ b/java/connection/TypeDBDriverImpl.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import static com.vaticle.typedb.driver.jni.typedb_driver.connection_force_close;
 import static com.vaticle.typedb.driver.jni.typedb_driver.connection_is_open;
-import static com.vaticle.typedb.driver.jni.typedb_driver.connection_open_enterprise;
+import static com.vaticle.typedb.driver.jni.typedb_driver.connection_open_cloud;
 import static com.vaticle.typedb.driver.jni.typedb_driver.connection_open_core;
 
 public class TypeDBDriverImpl extends NativeObject<com.vaticle.typedb.driver.jni.Connection> implements TypeDBDriver {
@@ -48,7 +48,7 @@ public class TypeDBDriverImpl extends NativeObject<com.vaticle.typedb.driver.jni
     }
 
     public TypeDBDriverImpl(Set<String> initAddresses, TypeDBCredential credential) throws TypeDBDriverException {
-        this(openEnterprise(initAddresses, credential));
+        this(openCloud(initAddresses, credential));
     }
 
     private TypeDBDriverImpl(com.vaticle.typedb.driver.jni.Connection connection) {
@@ -65,9 +65,9 @@ public class TypeDBDriverImpl extends NativeObject<com.vaticle.typedb.driver.jni
         }
     }
 
-    private static com.vaticle.typedb.driver.jni.Connection openEnterprise(Set<String> initAddresses, TypeDBCredential credential) {
+    private static com.vaticle.typedb.driver.jni.Connection openCloud(Set<String> initAddresses, TypeDBCredential credential) {
         try {
-            return connection_open_enterprise(initAddresses.toArray(new String[0]), credential.nativeObject);
+            return connection_open_cloud(initAddresses.toArray(new String[0]), credential.nativeObject);
         } catch (com.vaticle.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/docs/connection/Database.adoc
+++ b/java/docs/connection/Database.adoc
@@ -50,7 +50,7 @@ The database name as a string.
 java.util.Optional<? extends Database.Replica> preferredReplica()
 ----
 
-Returns the preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Enterprise_ 
+Returns the preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Cloud_ 
 
 
 [caption=""]
@@ -73,7 +73,7 @@ database.preferredReplica()
 java.util.Optional<? extends Database.Replica> primaryReplica()
 ----
 
-Returns the primary replica for this database. _Only works in TypeDB Enterprise_ 
+Returns the primary replica for this database. _Only works in TypeDB Cloud_ 
 
 
 [caption=""]
@@ -96,7 +96,7 @@ database.primaryReplica()
 java.util.Set<? extends Database.Replica> replicas()
 ----
 
-Set of ``Replica`` instances for this database. Only works in TypeDB Enterprise
+Set of ``Replica`` instances for this database. Only works in TypeDB Cloud
 
 
 [caption=""]

--- a/java/docs/connection/TypeDB.adoc
+++ b/java/docs/connection/TypeDB.adoc
@@ -60,16 +60,16 @@ a| `address` a| The address of the TypeDB server a| `java.lang.String`
 TypeDB.coreDriver(address);
 ----
 
-[#_TypeDB_enterpriseDriver__java_lang_String__TypeDBCredential]
-==== enterpriseDriver
+[#_TypeDB_cloudDriver__java_lang_String__TypeDBCredential]
+==== cloudDriver
 
 [source,java]
 ----
-public static TypeDBDriver enterpriseDriver​(java.lang.String address,
+public static TypeDBDriver cloudDriver​(java.lang.String address,
                                             TypeDBCredential credential)
 ----
 
-Open a TypeDB Driver to a TypeDB Enterprise server available at the provided address, using the provided credential. 
+Open a TypeDB Driver to a TypeDB Cloud server available at the provided address, using the provided credential. 
 
 
 [caption=""]
@@ -90,19 +90,19 @@ a| `credential` a| The credential to connect with a| `TypeDBCredential`
 .Code examples
 [source,java]
 ----
-TypeDB.enterpriseDriver(address, credential);
+TypeDB.cloudDriver(address, credential);
 ----
 
-[#_TypeDB_enterpriseDriver__java_util_Set_java_lang_String___TypeDBCredential]
-==== enterpriseDriver
+[#_TypeDB_cloudDriver__java_util_Set_java_lang_String___TypeDBCredential]
+==== cloudDriver
 
 [source,java]
 ----
-public static TypeDBDriver enterpriseDriver​(java.util.Set<java.lang.String> addresses,
+public static TypeDBDriver cloudDriver​(java.util.Set<java.lang.String> addresses,
                                             TypeDBCredential credential)
 ----
 
-Open a TypeDB Driver to TypeDB Enterprise server(s) available at the provided addresses, using the provided credential. 
+Open a TypeDB Driver to TypeDB Cloud server(s) available at the provided addresses, using the provided credential. 
 
 
 [caption=""]
@@ -123,7 +123,7 @@ a| `credential` a| The credential to connect with a| `TypeDBCredential`
 .Code examples
 [source,java]
 ----
-TypeDB.enterpriseDriver(addresses, credential);
+TypeDB.cloudDriver(addresses, credential);
 ----
 
 // end::methods[]

--- a/java/docs/connection/TypeDB.adoc
+++ b/java/docs/connection/TypeDB.adoc
@@ -29,44 +29,13 @@ public TypeDB()
 .Returns
 `public`
 
-[#_TypeDB_coreDriver__java_lang_String]
-==== coreDriver
-
-[source,java]
-----
-public static TypeDBDriver coreDriver​(java.lang.String address)
-----
-
-Open a TypeDB Driver to a TypeDB Core server available at the provided address. 
-
-
-[caption=""]
-.Input parameters
-[cols="~,~,~"]
-[options="header"]
-|===
-|Name |Description |Type
-a| `address` a| The address of the TypeDB server a| `java.lang.String`
-|===
-
-[caption=""]
-.Returns
-`public static TypeDBDriver`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-TypeDB.coreDriver(address);
-----
-
 [#_TypeDB_cloudDriver__java_lang_String__TypeDBCredential]
 ==== cloudDriver
 
 [source,java]
 ----
 public static TypeDBDriver cloudDriver​(java.lang.String address,
-                                            TypeDBCredential credential)
+                                       TypeDBCredential credential)
 ----
 
 Open a TypeDB Driver to a TypeDB Cloud server available at the provided address, using the provided credential. 
@@ -99,7 +68,7 @@ TypeDB.cloudDriver(address, credential);
 [source,java]
 ----
 public static TypeDBDriver cloudDriver​(java.util.Set<java.lang.String> addresses,
-                                            TypeDBCredential credential)
+                                       TypeDBCredential credential)
 ----
 
 Open a TypeDB Driver to TypeDB Cloud server(s) available at the provided addresses, using the provided credential. 
@@ -124,6 +93,37 @@ a| `credential` a| The credential to connect with a| `TypeDBCredential`
 [source,java]
 ----
 TypeDB.cloudDriver(addresses, credential);
+----
+
+[#_TypeDB_coreDriver__java_lang_String]
+==== coreDriver
+
+[source,java]
+----
+public static TypeDBDriver coreDriver​(java.lang.String address)
+----
+
+Open a TypeDB Driver to a TypeDB Core server available at the provided address. 
+
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `address` a| The address of the TypeDB server a| `java.lang.String`
+|===
+
+[caption=""]
+.Returns
+`public static TypeDBDriver`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+TypeDB.coreDriver(address);
 ----
 
 // end::methods[]

--- a/java/docs/connection/TypeDBCredential.adoc
+++ b/java/docs/connection/TypeDBCredential.adoc
@@ -3,7 +3,7 @@
 
 *Package*: `com.vaticle.typedb.driver.api`
 
-User credentials and TLS encryption settings for connecting to TypeDB Enterprise. 
+User credentials and TLS encryption settings for connecting to TypeDB Cloud. 
 
 
 [caption=""]
@@ -38,7 +38,7 @@ public TypeDBCredential​(java.lang.String username,
 |Name |Description |Type
 a| `username` a| The name of the user to connect as a| `java.lang.String`
 a| `password` a| The password for the user a| `java.lang.String`
-a| `tlsEnabled` a| Specify whether the connection to TypeDB Enterprise must be done over TLS a| `boolean`
+a| `tlsEnabled` a| Specify whether the connection to TypeDB Cloud must be done over TLS a| `boolean`
 |===
 
 [caption=""]

--- a/java/docs/connection/TypeDBDriver.adoc
+++ b/java/docs/connection/TypeDBDriver.adoc
@@ -133,7 +133,7 @@ driver.session(database, sessionType, options);
 User user()
 ----
 
-The ``UserManager`` instance for this connection, providing access to user management methods. Only for TypeDB Enterprise.
+The ``UserManager`` instance for this connection, providing access to user management methods. Only for TypeDB Cloud.
 
 [caption=""]
 .Returns
@@ -148,7 +148,7 @@ The ``UserManager`` instance for this connection, providing access to user manag
 UserManager users()
 ----
 
-Returns the logged-in user for the connection. Only for TypeDB Enterprise. 
+Returns the logged-in user for the connection. Only for TypeDB Cloud. 
 
 
 [caption=""]

--- a/java/docs/session/TypeDBOptions.adoc
+++ b/java/docs/session/TypeDBOptions.adoc
@@ -329,7 +329,7 @@ options.readAnyReplica();
 public TypeDBOptions readAnyReplica​(boolean readAnyReplica)
 ----
 
-Explicitly enables or disables reading data from any replica. If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise. 
+Explicitly enables or disables reading data from any replica. If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud. 
 
 
 [caption=""]

--- a/java/test/behaviour/concept/thing/attribute/BUILD
+++ b/java/test/behaviour/concept/thing/attribute/BUILD
@@ -52,7 +52,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//concept/thing:attribute.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/concept/type/attributetype:steps",

--- a/java/test/behaviour/concept/thing/entity/BUILD
+++ b/java/test/behaviour/concept/thing/entity/BUILD
@@ -54,7 +54,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//concept/thing:entity.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/concept/thing/attribute:steps",

--- a/java/test/behaviour/concept/thing/relation/BUILD
+++ b/java/test/behaviour/concept/thing/relation/BUILD
@@ -54,7 +54,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//concept/thing:relation.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/concept/thing/attribute:steps",

--- a/java/test/behaviour/concept/type/attributetype/BUILD
+++ b/java/test/behaviour/concept/type/attributetype/BUILD
@@ -54,7 +54,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//concept/type:attributetype.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/concept/thing/attribute:steps",

--- a/java/test/behaviour/concept/type/entitytype/BUILD
+++ b/java/test/behaviour/concept/type/entitytype/BUILD
@@ -43,7 +43,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//concept/type:entitytype.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/concept/thing/entity:steps",

--- a/java/test/behaviour/concept/type/relationtype/BUILD
+++ b/java/test/behaviour/concept/type/relationtype/BUILD
@@ -53,7 +53,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//concept/type:relationtype.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/concept/thing/entity:steps",

--- a/java/test/behaviour/connection/BUILD
+++ b/java/test/behaviour/connection/BUILD
@@ -54,9 +54,9 @@ java_library(
 )
 
 java_library(
-    name = "steps-enterprise",
+    name = "steps-cloud",
     srcs = [
-        "ConnectionStepsEnterprise.java",
+        "ConnectionStepsCloud.java",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/java/test/behaviour/connection/ConnectionStepsCloud.java
+++ b/java/test/behaviour/connection/ConnectionStepsCloud.java
@@ -27,7 +27,7 @@ import com.vaticle.typedb.driver.api.TypeDBCredential;
 import com.vaticle.typedb.driver.api.TypeDBOptions;
 import com.vaticle.typedb.common.test.TypeDBRunner;
 import com.vaticle.typedb.common.test.TypeDBSingleton;
-import com.vaticle.typedb.common.test.enterprise.TypeDBEnterpriseRunner;
+import com.vaticle.typedb.common.test.cloud.TypeDBCloudRunner;
 import com.vaticle.typedb.driver.api.database.Database;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
@@ -40,14 +40,14 @@ import java.util.Map;
 
 import static com.vaticle.typedb.driver.test.behaviour.util.Util.assertThrows;
 
-public class ConnectionStepsEnterprise extends ConnectionStepsBase {
+public class ConnectionStepsCloud extends ConnectionStepsBase {
 
     @Override
     public void beforeAll() {
         super.beforeAll();
-        TypeDBEnterpriseRunner enterpriseRunner = TypeDBEnterpriseRunner.create(Paths.get("."), 1);
-        TypeDBSingleton.setTypeDBRunner(enterpriseRunner);
-        enterpriseRunner.start();
+        TypeDBCloudRunner cloudRunner = TypeDBCloudRunner.create(Paths.get("."), 1);
+        TypeDBSingleton.setTypeDBRunner(cloudRunner);
+        cloudRunner.start();
     }
 
     @Before
@@ -79,7 +79,7 @@ public class ConnectionStepsEnterprise extends ConnectionStepsBase {
     }
 
     TypeDBDriver createTypeDBDriver(String address, String username, String password, boolean tlsEnabled) {
-        return TypeDB.enterpriseDriver(address, new TypeDBCredential(username, password, tlsEnabled));
+        return TypeDB.cloudDriver(address, new TypeDBCredential(username, password, tlsEnabled));
     }
 
     @Override

--- a/java/test/behaviour/connection/database/BUILD
+++ b/java/test/behaviour/connection/database/BUILD
@@ -81,23 +81,23 @@ typedb_java_test(
 )
 
 typedb_java_test(
-    name = "test-enterprise",
+    name = "test-cloud",
     srcs = [
-        "DatabaseTestEnterprise.java",
+        "DatabaseTestCloud.java",
     ],
-    test_class = "com.vaticle.typedb.driver.test.behaviour.connection.database.DatabaseTestEnterprise",
+    test_class = "com.vaticle.typedb.driver.test.behaviour.connection.database.DatabaseTestCloud",
     data = [
         "@vaticle_typedb_behaviour//connection:database.feature",
     ],
     server_artifacts = {
-        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_enterprise_artifact_linux-arm64//file",
-        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_enterprise_artifact_linux-x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_enterprise_artifact_mac-arm64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_enterprise_artifact_mac-x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_enterprise_artifact_windows-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_cloud_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_cloud_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_cloud_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_cloud_artifact_mac-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_cloud_artifact_windows-x86_64//file",
     },
     runtime_deps = [
-        "//java/test/behaviour/connection:steps-enterprise",
+        "//java/test/behaviour/connection:steps-cloud",
 
         ":steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/connection/database/DatabaseTestCloud.java
+++ b/java/test/behaviour/connection/database/DatabaseTestCloud.java
@@ -34,18 +34,18 @@ import org.junit.runner.RunWith;
         features = "external/vaticle_typedb_behaviour/connection/database.feature",
         tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
-public class DatabaseTestEnterprise extends BehaviourTest {
+public class DatabaseTestCloud extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:
     //
     // 1) Go to 'Run'
     // 2) Select 'Edit Configurations...'
-    // 3) Select 'Bazel test DatabaseTestEnterprise'
+    // 3) Select 'Bazel test DatabaseTestCloud'
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/connection/database/DatabaseTestCore.java
+++ b/java/test/behaviour/connection/database/DatabaseTestCore.java
@@ -45,7 +45,7 @@ public class DatabaseTestCore extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/connection/session/BUILD
+++ b/java/test/behaviour/connection/session/BUILD
@@ -54,7 +54,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//connection:session.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/connection/database:steps",

--- a/java/test/behaviour/connection/session/SessionTest.java
+++ b/java/test/behaviour/connection/session/SessionTest.java
@@ -45,7 +45,7 @@ public class SessionTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/connection/transaction/BUILD
+++ b/java/test/behaviour/connection/transaction/BUILD
@@ -57,7 +57,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//connection:transaction.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         ":steps",
         "//java/test/behaviour/connection/database:steps",

--- a/java/test/behaviour/connection/transaction/TransactionTest.java
+++ b/java/test/behaviour/connection/transaction/TransactionTest.java
@@ -45,7 +45,7 @@ public class TransactionTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/connection/user/BUILD
+++ b/java/test/behaviour/connection/user/BUILD
@@ -43,26 +43,26 @@ java_library(
 )
 
 typedb_java_test(
-    name = "test-enterprise",
+    name = "test-cloud",
     size = "large",
     srcs = [
-        "UserTestEnterprise.java",
+        "UserTestCloud.java",
     ],
     data = [
         "@vaticle_typedb_behaviour//connection:user.feature",
     ],
     server_artifacts = {
-        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_enterprise_artifact_linux-arm64//file",
-        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_enterprise_artifact_linux-x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_enterprise_artifact_mac-arm64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_enterprise_artifact_mac-x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_enterprise_artifact_windows-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_cloud_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_cloud_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_cloud_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_cloud_artifact_mac-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_cloud_artifact_windows-x86_64//file",
     },
-    test_class = "com.vaticle.typedb.driver.test.behaviour.connection.user.UserTestEnterprise",
+    test_class = "com.vaticle.typedb.driver.test.behaviour.connection.user.UserTestCloud",
     runtime_deps = [
         ":steps",
         "//java/test/behaviour/config:parameters",
-        "//java/test/behaviour/connection:steps-enterprise",
+        "//java/test/behaviour/connection:steps-cloud",
         "//java/test/behaviour/connection/session:steps",
         "//java/test/behaviour/connection/transaction:steps",
         "//java/test/behaviour/query:steps",

--- a/java/test/behaviour/connection/user/UserTestCloud.java
+++ b/java/test/behaviour/connection/user/UserTestCloud.java
@@ -34,18 +34,18 @@ import org.junit.runner.RunWith;
         features = "external/vaticle_typedb_behaviour/connection/user.feature",
         tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
-public class UserTestEnterprise extends BehaviourTest {
+public class UserTestCloud extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:
     //
     // 1) Go to 'Run'
     // 2) Select 'Edit Configurations...'
-    // 3) Select 'Bazel test DatabaseTestEnterprise'
+    // 3) Select 'Bazel test DatabaseTestCloud'
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/debug/DebugTest.java
+++ b/java/test/behaviour/debug/DebugTest.java
@@ -44,7 +44,7 @@ public class DebugTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     // 1) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    // 2) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    // 2) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/driver/query/BUILD
+++ b/java/test/behaviour/driver/query/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//driver:query.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/driver/query/QueryTest.java
+++ b/java/test/behaviour/driver/query/QueryTest.java
@@ -45,7 +45,7 @@ public class QueryTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/define/BUILD
+++ b/java/test/behaviour/query/language/define/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:define.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/define/DefineTest.java
+++ b/java/test/behaviour/query/language/define/DefineTest.java
@@ -45,7 +45,7 @@ public class DefineTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/delete/BUILD
+++ b/java/test/behaviour/query/language/delete/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:delete.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/delete/DeleteTest.java
+++ b/java/test/behaviour/query/language/delete/DeleteTest.java
@@ -45,7 +45,7 @@ public class DeleteTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/expression/BUILD
+++ b/java/test/behaviour/query/language/expression/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:expression.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/expression/ExpressionTest.java
+++ b/java/test/behaviour/query/language/expression/ExpressionTest.java
@@ -45,7 +45,7 @@ public class ExpressionTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/fetch/BUILD
+++ b/java/test/behaviour/query/language/fetch/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:fetch.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/fetch/FetchTest.java
+++ b/java/test/behaviour/query/language/fetch/FetchTest.java
@@ -45,7 +45,7 @@ public class FetchTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/get/BUILD
+++ b/java/test/behaviour/query/language/get/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:get.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/get/GetTest.java
+++ b/java/test/behaviour/query/language/get/GetTest.java
@@ -45,7 +45,7 @@ public class GetTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/insert/BUILD
+++ b/java/test/behaviour/query/language/insert/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:insert.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/connection/session:steps",
         "//java/test/behaviour/query:steps",

--- a/java/test/behaviour/query/language/insert/InsertTest.java
+++ b/java/test/behaviour/query/language/insert/InsertTest.java
@@ -45,7 +45,7 @@ public class InsertTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/match/BUILD
+++ b/java/test/behaviour/query/language/match/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:match.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/match/MatchTest.java
+++ b/java/test/behaviour/query/language/match/MatchTest.java
@@ -45,7 +45,7 @@ public class MatchTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/modifiers/BUILD
+++ b/java/test/behaviour/query/language/modifiers/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:modifiers.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/modifiers/ModifiersTest.java
+++ b/java/test/behaviour/query/language/modifiers/ModifiersTest.java
@@ -45,7 +45,7 @@ public class ModifiersTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/undefine/BUILD
+++ b/java/test/behaviour/query/language/undefine/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:undefine.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/undefine/UndefineTest.java
+++ b/java/test/behaviour/query/language/undefine/UndefineTest.java
@@ -45,7 +45,7 @@ public class UndefineTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/query/language/update/BUILD
+++ b/java/test/behaviour/query/language/update/BUILD
@@ -33,7 +33,7 @@ typedb_behaviour_java_test(
         "@vaticle_typedb_behaviour//query/language:update.feature",
     ],
     connection_steps_core = "//java/test/behaviour/connection:steps-core",
-    connection_steps_enterprise = "//java/test/behaviour/connection:steps-enterprise",
+    connection_steps_cloud = "//java/test/behaviour/connection:steps-cloud",
     steps = [
         "//java/test/behaviour/query:steps",
         "//java/test/behaviour/connection/session:steps",

--- a/java/test/behaviour/query/language/update/UpdateTest.java
+++ b/java/test/behaviour/query/language/update/UpdateTest.java
@@ -45,7 +45,7 @@ public class UpdateTest extends BehaviourTest {
     //
     // 4) Ensure 'Target Expression' is set correctly:
     //    a) Use '//<this>/<package>/<name>:test-core' to test against typedb
-    //    b) Use '//<this>/<package>/<name>:test-enterprise' to test against typedb-enterprise
+    //    b) Use '//<this>/<package>/<name>:test-cloud' to test against typedb-cloud
     //
     // 5) Update 'Bazel Flags':
     //    a) Remove the line that says: '--test_filter=com.vaticle.typedb.driver.*'

--- a/java/test/behaviour/rules.bzl
+++ b/java/test/behaviour/rules.bzl
@@ -24,7 +24,7 @@ load("@vaticle_typedb_common//test:rules.bzl", "typedb_java_test")
 def typedb_behaviour_java_test(
         name,
         connection_steps_core,
-        connection_steps_enterprise,
+        connection_steps_cloud,
         steps,
         runtime_deps = [],
         **kwargs):
@@ -43,14 +43,14 @@ def typedb_behaviour_java_test(
     )
 
     typedb_java_test(
-        name = name + "-enterprise",
+        name = name + "-cloud",
         server_artifacts = {
-            "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_enterprise_artifact_linux-arm64//file",
-            "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_enterprise_artifact_linux-x86_64//file",
-            "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_enterprise_artifact_mac-arm64//file",
-            "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_enterprise_artifact_mac-x86_64//file",
-            "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_enterprise_artifact_windows-x86_64//file",
+            "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_cloud_artifact_linux-arm64//file",
+            "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_cloud_artifact_linux-x86_64//file",
+            "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_cloud_artifact_mac-arm64//file",
+            "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_cloud_artifact_mac-x86_64//file",
+            "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_cloud_artifact_windows-x86_64//file",
         },
-        runtime_deps = runtime_deps + [connection_steps_enterprise] + steps,
+        runtime_deps = runtime_deps + [connection_steps_cloud] + steps,
         **kwargs,
     )

--- a/nodejs/TypeDB.ts
+++ b/nodejs/TypeDB.ts
@@ -41,18 +41,18 @@ export namespace TypeDB {
     }
 
     /**
-     * Creates a connection to TypeDB Enterprise, authenticating with the provided credentials.
-     * @param addresses - List of addresses of the individual TypeDB Enterprise servers.
+     * Creates a connection to TypeDB Cloud, authenticating with the provided credentials.
+     * @param addresses - List of addresses of the individual TypeDB Cloud servers.
      * As long one specified address is provided, the driver will discover the other addresses from that server.
      * @param credential - The credentials to log in, and encryption settings. See <code>{@link TypeDBCredential}</code>
      *
      * ### Examples
      *
      * ```ts
-     * const driver = TypeDB.enterpriseDriver(["127.0.0.1:11729"], new TypeDBCredential(username, password));
+     * const driver = TypeDB.cloudDriver(["127.0.0.1:11729"], new TypeDBCredential(username, password));
      * ```
      */
-    export function enterpriseDriver(addresses: string | string[], credential: TypeDBCredential): Promise<TypeDBDriver> {
+    export function cloudDriver(addresses: string | string[], credential: TypeDBCredential): Promise<TypeDBDriver> {
         if (typeof addresses === 'string') addresses = [addresses];
         return new TypeDBDriverImpl(addresses, credential).open();
     }

--- a/nodejs/api/connection/TypeDBCredential.ts
+++ b/nodejs/api/connection/TypeDBCredential.ts
@@ -22,10 +22,10 @@
 import * as fs from "fs";
 import {ErrorMessage} from "../../common/errors/ErrorMessage";
 import {TypeDBDriverError} from "../../common/errors/TypeDBDriverError";
-import ENTERPRISE_INVALID_ROOT_CA_PATH = ErrorMessage.Driver.ENTERPRISE_INVALID_ROOT_CA_PATH;
+import CLOUD_INVALID_ROOT_CA_PATH = ErrorMessage.Driver.CLOUD_INVALID_ROOT_CA_PATH;
 
 /**
- * User credentials and TLS encryption settings for connecting to TypeDB Enterprise.
+ * User credentials and TLS encryption settings for connecting to TypeDB Cloud.
  *
  * ### Examples
  *
@@ -48,7 +48,7 @@ export class TypeDBCredential {
         this._password = password;
 
         if (tlsRootCAPath != null && !fs.existsSync(tlsRootCAPath)) {
-            throw new TypeDBDriverError(ENTERPRISE_INVALID_ROOT_CA_PATH.message(tlsRootCAPath));
+            throw new TypeDBDriverError(CLOUD_INVALID_ROOT_CA_PATH.message(tlsRootCAPath));
         }
         this._tlsRootCAPath = tlsRootCAPath;
     }

--- a/nodejs/api/connection/TypeDBDriver.ts
+++ b/nodejs/api/connection/TypeDBDriver.ts
@@ -55,12 +55,12 @@ export interface TypeDBDriver {
 
     /**
      * The <code>UserManager</code> instance for this connection, providing access to user management methods.
-     * Only for TypeDB Enterprise.
+     * Only for TypeDB Cloud.
      */
     readonly users: UserManager;
 
     /**
-     * Returns the logged-in user for the connection. Only for TypeDB Enterprise.
+     * Returns the logged-in user for the connection. Only for TypeDB Cloud.
      *
      * ### Examples
      *

--- a/nodejs/api/connection/TypeDBOptions.ts
+++ b/nodejs/api/connection/TypeDBOptions.ts
@@ -44,7 +44,7 @@ export interface Opts {
     transactionTimeoutMillis?: number;
     /** If set, specifies how long the driver should wait if opening a session or transaction is blocked by a schema write lock. */
     schemaLockAcquireTimeoutMillis?: number;
-    /** If set to <code>True</code>, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise. */
+    /** If set to <code>True</code>, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud. */
     readAnyReplica?: boolean;
 }
 

--- a/nodejs/api/connection/database/Database.ts
+++ b/nodejs/api/connection/database/Database.ts
@@ -25,13 +25,13 @@ export interface Database {
     /** The database name as a string. */
     readonly name: string;
 
-    /** The <code>Replica</code> instances for this database. _Only works in TypeDB Enterprise_ */
+    /** The <code>Replica</code> instances for this database. _Only works in TypeDB Cloud_ */
     readonly replicas: Replica[];
 
-    /** The primary replica for this database. _Only works in TypeDB Enterprise_*/
+    /** The primary replica for this database. _Only works in TypeDB Cloud_*/
     readonly primaryReplica: Replica;
 
-     /** The preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Enterprise_ */
+     /** The preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Cloud_ */
     readonly preferredReplica: Replica;
 
     /**

--- a/nodejs/common/errors/ErrorMessage.ts
+++ b/nodejs/common/errors/ErrorMessage.ts
@@ -94,14 +94,14 @@ export namespace ErrorMessage {
         export const UNKNOWN_STREAM_STATE = new Driver(11, (args: Stringable[]) => `RPC transaction stream response '${args[0]}' is unknown.`);
         export const MISSING_RESPONSE = new Driver(12, (args: Stringable[]) => `The required field 'res' of type '${args[0]}' was not set.`);
         export const UNKNOWN_REQUEST_ID = new Driver(13, (args: Stringable[]) => `Received a response with unknown request id '${args[0]}'.`);
-        export const ENTERPRISE_NO_PRIMARY_REPLICA_YET = new Driver(14, (args: Stringable[]) => `No replica has been marked as the primary replica for latest known term '${args[0]}'.`);
-        export const ENTERPRISE_UNABLE_TO_CONNECT = new Driver(15, (args: Stringable[]) => `Unable to connect to TypeDB Enterprise. Attempted connecting to the enterprise nodes, but none are available: '${args[1]}'.`);
-        export const ENTERPRISE_REPLICA_NOT_PRIMARY = new Driver(16, () => `The replica is not the primary replica.`);
-        export const ENTERPRISE_ALL_NODES_FAILED = new Driver(17, (args: Stringable[]) => `Attempted connecting to all enterprise nodes, but the following errors occurred: \n'${args[0]}'`);
-        export const USER_MANAGEMENT_ENTERPRISE_ONLY = new Driver(18, () => `User management is only available in TypeDB Enterprise servers.`);
-        export const ENTERPRISE_USER_DOES_NOT_EXIST = new Driver(19, (args: Stringable[]) => `The user '${args[0]}' does not exist.`);
-        export const ENTERPRISE_TOKEN_CREDENTIAL_INVALID = new Driver(20, (args: Stringable[]) => `Invalid token credential.`);
-        export const ENTERPRISE_INVALID_ROOT_CA_PATH = new Driver(21, (args: Stringable[]) => `The provided Root CA path '${args[0]}' does not exist`);
+        export const CLOUD_NO_PRIMARY_REPLICA_YET = new Driver(14, (args: Stringable[]) => `No replica has been marked as the primary replica for latest known term '${args[0]}'.`);
+        export const CLOUD_UNABLE_TO_CONNECT = new Driver(15, (args: Stringable[]) => `Unable to connect to TypeDB Cloud. Attempted connecting to the cloud nodes, but none are available: '${args[1]}'.`);
+        export const CLOUD_REPLICA_NOT_PRIMARY = new Driver(16, () => `The replica is not the primary replica.`);
+        export const CLOUD_ALL_NODES_FAILED = new Driver(17, (args: Stringable[]) => `Attempted connecting to all cloud nodes, but the following errors occurred: \n'${args[0]}'`);
+        export const USER_MANAGEMENT_CLOUD_ONLY = new Driver(18, () => `User management is only available in TypeDB Cloud servers.`);
+        export const CLOUD_USER_DOES_NOT_EXIST = new Driver(19, (args: Stringable[]) => `The user '${args[0]}' does not exist.`);
+        export const CLOUD_TOKEN_CREDENTIAL_INVALID = new Driver(20, (args: Stringable[]) => `Invalid token credential.`);
+        export const CLOUD_INVALID_ROOT_CA_PATH = new Driver(21, (args: Stringable[]) => `The provided Root CA path '${args[0]}' does not exist`);
         export const UNRECOGNISED_SESSION_TYPE = new Driver(22, (args: Stringable[]) => `Session type '${args[1]}' was not recognised.`);
     }
 

--- a/nodejs/common/errors/TypeDBDriverError.ts
+++ b/nodejs/common/errors/TypeDBDriverError.ts
@@ -22,8 +22,8 @@
 import {ServiceError} from "@grpc/grpc-js";
 import {Status} from "@grpc/grpc-js/build/src/constants";
 import {ErrorMessage} from "./ErrorMessage";
-import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTERPRISE_REPLICA_NOT_PRIMARY;
-import ENTERPRISE_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.ENTERPRISE_TOKEN_CREDENTIAL_INVALID;
+import CLOUD_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.CLOUD_REPLICA_NOT_PRIMARY;
+import CLOUD_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.CLOUD_TOKEN_CREDENTIAL_INVALID;
 import UNABLE_TO_CONNECT = ErrorMessage.Driver.UNABLE_TO_CONNECT;
 import RPC_METHOD_UNAVAILABLE = ErrorMessage.Driver.RPC_METHOD_UNAVAILABLE;
 
@@ -59,11 +59,11 @@ export class TypeDBDriverError extends Error {
                 super(UNABLE_TO_CONNECT.message());
                 this._messageTemplate = UNABLE_TO_CONNECT;
             } else if (isReplicaNotPrimaryError(error)) {
-                super(ENTERPRISE_REPLICA_NOT_PRIMARY.message());
-                this._messageTemplate = ENTERPRISE_REPLICA_NOT_PRIMARY;
+                super(CLOUD_REPLICA_NOT_PRIMARY.message());
+                this._messageTemplate = CLOUD_REPLICA_NOT_PRIMARY;
             } else if (isTokenCredentialInvalidError(error)) {
-                super(ENTERPRISE_TOKEN_CREDENTIAL_INVALID.message());
-                this._messageTemplate = ENTERPRISE_TOKEN_CREDENTIAL_INVALID;
+                super(CLOUD_TOKEN_CREDENTIAL_INVALID.message());
+                this._messageTemplate = CLOUD_TOKEN_CREDENTIAL_INVALID;
             } else if (error.code === Status.INTERNAL) super(error.details)
             else super(error.toString());
         } else super(error.toString());

--- a/nodejs/connection/TypeDBDatabaseImpl.ts
+++ b/nodejs/connection/TypeDBDatabaseImpl.ts
@@ -30,7 +30,7 @@ import {RequestBuilder} from "../common/rpc/RequestBuilder";
 import {ErrorMessage} from "../common/errors/ErrorMessage";
 import UNABLE_TO_CONNECT = ErrorMessage.Driver.UNABLE_TO_CONNECT;
 import DATABASE_DOES_NOT_EXIST = ErrorMessage.Driver.DATABASE_DOES_NOT_EXIST;
-import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTERPRISE_REPLICA_NOT_PRIMARY;
+import CLOUD_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.CLOUD_REPLICA_NOT_PRIMARY;
 
 const PRIMARY_REPLICA_TASK_MAX_RETRIES = 10;
 const FETCH_REPLICAS_MAX_RETRIES = 10;
@@ -121,7 +121,7 @@ export class TypeDBDatabaseImpl implements Database {
         try {
             return await this.runOnAnyReplica(task);
         } catch (e) {
-            if (e instanceof TypeDBDriverError && ENTERPRISE_REPLICA_NOT_PRIMARY === e.messageTemplate) {
+            if (e instanceof TypeDBDriverError && CLOUD_REPLICA_NOT_PRIMARY === e.messageTemplate) {
                 return this.runOnPrimaryReplica(task);
             } else throw e;
         }
@@ -149,7 +149,7 @@ export class TypeDBDatabaseImpl implements Database {
                 return await task(this._driver.serverDrivers.get(this.primaryReplica.address), this.primaryReplica.database);
             } catch (e) {
                 if (e instanceof TypeDBDriverError &&
-                    (UNABLE_TO_CONNECT === e.messageTemplate || ENTERPRISE_REPLICA_NOT_PRIMARY === e.messageTemplate)
+                    (UNABLE_TO_CONNECT === e.messageTemplate || CLOUD_REPLICA_NOT_PRIMARY === e.messageTemplate)
                 ) {
                     await this.waitForPrimaryReplicaSelection();
                     await this.seekPrimaryReplica();

--- a/nodejs/connection/TypeDBDatabaseManagerImpl.ts
+++ b/nodejs/connection/TypeDBDatabaseManagerImpl.ts
@@ -26,8 +26,8 @@ import {TypeDBDriverError} from "../common/errors/TypeDBDriverError";
 import {RequestBuilder} from "../common/rpc/RequestBuilder";
 import {ServerDriver, TypeDBDriverImpl} from "./TypeDBDriverImpl";
 import {TypeDBDatabaseImpl} from "./TypeDBDatabaseImpl";
-import ENTERPRISE_ALL_NODES_FAILED = ErrorMessage.Driver.ENTERPRISE_ALL_NODES_FAILED;
-import ENTERPRISE_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.ENTERPRISE_REPLICA_NOT_PRIMARY;
+import CLOUD_ALL_NODES_FAILED = ErrorMessage.Driver.CLOUD_ALL_NODES_FAILED;
+import CLOUD_REPLICA_NOT_PRIMARY = ErrorMessage.Driver.CLOUD_REPLICA_NOT_PRIMARY;
 import DB_DOES_NOT_EXIST = ErrorMessage.Driver.DATABASE_DOES_NOT_EXIST;
 
 export class TypeDBDatabaseManagerImpl implements DatabaseManager {
@@ -70,7 +70,7 @@ export class TypeDBDatabaseManagerImpl implements DatabaseManager {
                 errors += `- ${serverDriver.address}: ${e}\n`;
             }
         }
-        throw new TypeDBDriverError(ENTERPRISE_ALL_NODES_FAILED.message(errors));
+        throw new TypeDBDriverError(CLOUD_ALL_NODES_FAILED.message(errors));
     }
 
     private async runFailsafe<T>(name: string, task: (driver: ServerDriver) => Promise<T>): Promise<T> {
@@ -79,11 +79,11 @@ export class TypeDBDatabaseManagerImpl implements DatabaseManager {
             try {
                 return await task(serverDriver);
             } catch (e) {
-                if (e instanceof TypeDBDriverError && ENTERPRISE_REPLICA_NOT_PRIMARY === e.messageTemplate) {
+                if (e instanceof TypeDBDriverError && CLOUD_REPLICA_NOT_PRIMARY === e.messageTemplate) {
                     return await (await TypeDBDatabaseImpl.get(name, this._driver)).runOnPrimaryReplica(task);
                 } else errors += `- ${serverDriver.address}: ${e}\n`;
             }
         }
-        throw new TypeDBDriverError(ENTERPRISE_ALL_NODES_FAILED.message(errors));
+        throw new TypeDBDriverError(CLOUD_ALL_NODES_FAILED.message(errors));
     }
 }

--- a/nodejs/connection/TypeDBStubImpl.ts
+++ b/nodejs/connection/TypeDBStubImpl.ts
@@ -27,7 +27,7 @@ import {TypeDBStub} from "../common/rpc/TypeDBStub";
 import {RequestBuilder} from "../common/rpc/RequestBuilder";
 import {ErrorMessage} from "../common/errors/ErrorMessage";
 import {TypeDBClient as GRPCStub} from "typedb-protocol/proto/typedb-service";
-import ENTERPRISE_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.ENTERPRISE_TOKEN_CREDENTIAL_INVALID;
+import CLOUD_TOKEN_CREDENTIAL_INVALID = ErrorMessage.Driver.CLOUD_TOKEN_CREDENTIAL_INVALID;
 
 function isServiceError(e: any): e is ServiceError {
     return "code" in e;
@@ -91,7 +91,7 @@ export class TypeDBStubImpl extends TypeDBStub {
             return await fn();
         } catch (e) {
             if (!this._credential) throw e;  // core stub
-            if (e instanceof TypeDBDriverError && ENTERPRISE_TOKEN_CREDENTIAL_INVALID === e.messageTemplate) {
+            if (e instanceof TypeDBDriverError && CLOUD_TOKEN_CREDENTIAL_INVALID === e.messageTemplate) {
                 console.log(`token '${this._token}' expired. renewing...`);
                 this._token = null;
                 const req = RequestBuilder.User.tokenReq(this._credential.username);

--- a/nodejs/docs/connection/Database.adoc
+++ b/nodejs/docs/connection/Database.adoc
@@ -9,9 +9,9 @@
 |===
 |Name |Type |Description
 a| `name` a| `string` a| The database name as a string.
-a| `preferredReplica` a| `Replica` a| The preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. Only works in TypeDB Enterprise
-a| `primaryReplica` a| `Replica` a| The primary replica for this database. Only works in TypeDB Enterprise
-a| `replicas` a| `Replica` a| The Replica instances for this database. Only works in TypeDB Enterprise
+a| `preferredReplica` a| `Replica` a| The preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. Only works in TypeDB Cloud
+a| `primaryReplica` a| `Replica` a| The primary replica for this database. Only works in TypeDB Cloud
+a| `replicas` a| `Replica` a| The Replica instances for this database. Only works in TypeDB Cloud
 |===
 // end::properties[]
 

--- a/nodejs/docs/connection/TypeDB.adoc
+++ b/nodejs/docs/connection/TypeDB.adoc
@@ -13,32 +13,6 @@ a| `DEFAULT_ADDRESS`
 // end::enum_constants[]
 
 // tag::methods[]
-[#_TypeDB_coreDriver__address_string__DEFAULT_ADDRESS]
-==== coreDriver
-
-[source,nodejs]
-----
-coreDriver(address?): Promise<TypeDBDriver>
-----
-
-Creates a connection to TypeDB.
-
-[caption=""]
-.Input parameters
-[cols="~,~,~"]
-[options="header"]
-|===
-|Name |Description |Type
-a| `address` a| Address of the TypeDB server.
-Examples
-``const driver = TypeDB.coreDriver("127.0.0.1:11729");
-``Copy a| `string = DEFAULT_ADDRESS`
-|===
-
-[caption=""]
-.Returns
-`Promise<TypeDBDriver>`
-
 [#_TypeDB_cloudDriver__addresses_string__string____credential_TypeDBCredential]
 ==== cloudDriver
 
@@ -60,6 +34,32 @@ a| `credential` a| The credentials to log in, and encryption settings. See ``Typ
 Examples
 ``const driver = TypeDB.cloudDriver(["127.0.0.1:11729"], new TypeDBCredential(username, password));
 ``Copy a| `TypeDBCredential`
+|===
+
+[caption=""]
+.Returns
+`Promise<TypeDBDriver>`
+
+[#_TypeDB_coreDriver__address_string__DEFAULT_ADDRESS]
+==== coreDriver
+
+[source,nodejs]
+----
+coreDriver(address?): Promise<TypeDBDriver>
+----
+
+Creates a connection to TypeDB.
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `address` a| Address of the TypeDB server.
+Examples
+``const driver = TypeDB.coreDriver("127.0.0.1:11729");
+``Copy a| `string = DEFAULT_ADDRESS`
 |===
 
 [caption=""]

--- a/nodejs/docs/connection/TypeDB.adoc
+++ b/nodejs/docs/connection/TypeDB.adoc
@@ -39,15 +39,15 @@ Examples
 .Returns
 `Promise<TypeDBDriver>`
 
-[#_TypeDB_enterpriseDriver__addresses_string__string____credential_TypeDBCredential]
-==== enterpriseDriver
+[#_TypeDB_cloudDriver__addresses_string__string____credential_TypeDBCredential]
+==== cloudDriver
 
 [source,nodejs]
 ----
-enterpriseDriver(addresses, credential): Promise<TypeDBDriver>
+cloudDriver(addresses, credential): Promise<TypeDBDriver>
 ----
 
-Creates a connection to TypeDB Enterprise, authenticating with the provided credentials.
+Creates a connection to TypeDB Cloud, authenticating with the provided credentials.
 
 [caption=""]
 .Input parameters
@@ -55,10 +55,10 @@ Creates a connection to TypeDB Enterprise, authenticating with the provided cred
 [options="header"]
 |===
 |Name |Description |Type
-a| `addresses` a| List of addresses of the individual TypeDB Enterprise servers. As long one specified address is provided, the driver will discover the other addresses from that server. a| `string \| string[]`
+a| `addresses` a| List of addresses of the individual TypeDB Cloud servers. As long one specified address is provided, the driver will discover the other addresses from that server. a| `string \| string[]`
 a| `credential` a| The credentials to log in, and encryption settings. See ``TypeDBCredential``
 Examples
-``const driver = TypeDB.enterpriseDriver(["127.0.0.1:11729"], new TypeDBCredential(username, password));
+``const driver = TypeDB.cloudDriver(["127.0.0.1:11729"], new TypeDBCredential(username, password));
 ``Copy a| `TypeDBCredential`
 |===
 

--- a/nodejs/docs/connection/TypeDBCredential.adoc
+++ b/nodejs/docs/connection/TypeDBCredential.adoc
@@ -1,7 +1,7 @@
 [#_TypeDBCredential]
 === TypeDBCredential
 
-User credentials and TLS encryption settings for connecting to TypeDB Enterprise.
+User credentials and TLS encryption settings for connecting to TypeDB Cloud.
 
 // tag::methods[]
 [#_TypeDBCredential__password__]

--- a/nodejs/docs/connection/TypeDBDriver.adoc
+++ b/nodejs/docs/connection/TypeDBDriver.adoc
@@ -9,7 +9,7 @@
 |===
 |Name |Type |Description
 a| `databases` a| `DatabaseManager` a| The DatabaseManager for this connection, providing access to database management methods.
-a| `users` a| `UserManager` a| The UserManager instance for this connection, providing access to user management methods. Only for TypeDB Enterprise.
+a| `users` a| `UserManager` a| The UserManager instance for this connection, providing access to user management methods. Only for TypeDB Cloud.
 |===
 // end::properties[]
 
@@ -89,7 +89,7 @@ a| `options` a|  a| `TypeDBOptions`
 user(): Promise<User>
 ----
 
-Returns the logged-in user for the connection. Only for TypeDB Enterprise.
+Returns the logged-in user for the connection. Only for TypeDB Cloud.
 
 [caption=""]
 .Returns

--- a/nodejs/docs/session/Opts.adoc
+++ b/nodejs/docs/session/Opts.adoc
@@ -15,7 +15,7 @@ a| `infer` a| `boolean` a| If set to True, enables inference for queries. Only s
 a| `parallel` a| `boolean` a| If set to True, the server uses parallel instead of single-threaded execution.
 a| `prefetch` a| `boolean` a| If set to True, the first batch of answers is streamed to the driver even without an explicit request for it.
 a| `prefetchSize` a| `number` a| If set, specifies a guideline number of answers that the server should send before the driver issues a fresh request.
-a| `readAnyReplica` a| `boolean` a| If set to True, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+a| `readAnyReplica` a| `boolean` a| If set to True, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
 a| `schemaLockAcquireTimeoutMillis` a| `number` a| If set, specifies how long the driver should wait if opening a session or transaction is blocked by a schema write lock.
 a| `sessionIdleTimeoutMillis` a| `number` a| If set, specifies a timeout that allows the server to close sessions if the driver terminates or becomes unresponsive.
 a| `traceInference` a| `boolean` a| If set to True, reasoning tracing graphs are output in the logging directory. Should be used with parallel = False.

--- a/nodejs/docs/session/TypeDBOptions.adoc
+++ b/nodejs/docs/session/TypeDBOptions.adoc
@@ -152,7 +152,7 @@ If set, specifies a guideline number of answers that the server should send befo
 get readAnyReplica(): boolean
 ----
 
-If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
 
 [caption=""]
 .Returns
@@ -166,7 +166,7 @@ If set to ``True``, enables reading data from any replica, potentially boosting 
 set readAnyReplica(value): void
 ----
 
-If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
 
 [caption=""]
 .Returns

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -17,7 +17,7 @@
     "test-concept": "node test/integration/test-concept.js",
     "test-connection": "node test/integration/test-connection.js",
     "test-query": "node test/integration/test-query.js",
-    "test-enterprise-failover": "npm run build && node test/integration/test-enterprise-failover.js",
+    "test-cloud-failover": "npm run build && node test/integration/test-cloud-failover.js",
     "test-stream": "node test/integration/test-stream.js",
     "lint": "eslint . --ext .ts"
   },

--- a/nodejs/test/behaviour/connection/BUILD
+++ b/nodejs/test/behaviour/connection/BUILD
@@ -59,8 +59,8 @@ ts_project(
 )
 
 ts_project(
-    name = "steps-enterprise",
-    srcs = ["ConnectionStepsEnterprise.ts"],
+    name = "steps-cloud",
+    srcs = ["ConnectionStepsCloud.ts"],
     tsconfig = behaviour_test_ts_config(),
     declaration = True,
     deps = [

--- a/nodejs/test/behaviour/connection/ConnectionStepsCloud.ts
+++ b/nodejs/test/behaviour/connection/ConnectionStepsCloud.ts
@@ -34,10 +34,10 @@ import {
 
 BeforeAll(async () => {
     setDefaultDriverFn(async () =>
-        TypeDB.enterpriseDriver("127.0.0.1:11729", new TypeDBCredential("admin", "password", process.env.ROOT_CA))
+        TypeDB.cloudDriver("127.0.0.1:11729", new TypeDBCredential("admin", "password", process.env.ROOT_CA))
     )
     setDriverFn(async (username, password) => {
-        return TypeDB.enterpriseDriver("127.0.0.1:11729", new TypeDBCredential(username, password, process.env.ROOT_CA))
+        return TypeDB.cloudDriver("127.0.0.1:11729", new TypeDBCredential(username, password, process.env.ROOT_CA))
     });
     setSessionOptions(new TypeDBOptions({"infer": true}));
     setTransactionOptions(new TypeDBOptions({"infer": true}));

--- a/nodejs/test/behaviour/connection/user/BUILD
+++ b/nodejs/test/behaviour/connection/user/BUILD
@@ -44,8 +44,8 @@ ts_project(
 )
 
 node_cucumber_test(
-    name = "test-enterprise",
-    steps = "@//nodejs/test/behaviour/connection:steps-enterprise",
+    name = "test-cloud",
+    steps = "@//nodejs/test/behaviour/connection:steps-cloud",
     features = ["@vaticle_typedb_behaviour//connection:user.feature"],
     data = [
         ":steps",

--- a/nodejs/test/behaviour/rules.bzl
+++ b/nodejs/test/behaviour/rules.bzl
@@ -58,7 +58,7 @@ def typedb_behaviour_node_test(name, **kwargs):
     )
 
     node_cucumber_test(
-        name = name + "-enterprise",
-        steps = "//nodejs/test/behaviour/connection:steps-enterprise",
+        name = name + "-cloud",
+        steps = "//nodejs/test/behaviour/connection:steps-cloud",
         **kwargs,
     )

--- a/nodejs/test/integration/test-cloud-failover.js
+++ b/nodejs/test/integration/test-cloud-failover.js
@@ -48,7 +48,7 @@ function getServerPID(port) {
 
 function serverStart(idx) {
     const encryptionResourceDir = process.env.ROOT_CA.replace(/\/[^\/]*$/, "/");
-    let node = spawn(`./${idx}/typedb`, ["cloud",
+    let node = spawn(`./${idx}/typedb`, ["server",
         "--storage.data", "server/data",
         "--server.address", `localhost:${idx}1729`,
         "--server.internal-address.zeromq", `localhost:${idx}1730`,

--- a/nodejs/test/integration/test-cloud-failover.js
+++ b/nodejs/test/integration/test-cloud-failover.js
@@ -48,7 +48,7 @@ function getServerPID(port) {
 
 function serverStart(idx) {
     const encryptionResourceDir = process.env.ROOT_CA.replace(/\/[^\/]*$/, "/");
-    let node = spawn(`./${idx}/typedb`, ["enterprise",
+    let node = spawn(`./${idx}/typedb`, ["cloud",
         "--storage.data", "server/data",
         "--server.address", `localhost:${idx}1729`,
         "--server.internal-address.zeromq", `localhost:${idx}1730`,
@@ -86,7 +86,7 @@ function serverStart(idx) {
 
 async function run() {
     console.log("root ca path: ", process.env.ROOT_CA)
-    const driver = await TypeDB.enterpriseDriver(
+    const driver = await TypeDB.cloudDriver(
         ["localhost:11729", "localhost:21729", "localhost:31729"],
         new TypeDBCredential("admin", "password", process.env.ROOT_CA)
     );
@@ -109,7 +109,7 @@ async function run() {
         await session.close();
 
         for (let iteration = 1; iteration <= 10; iteration++) {
-            const driver = await TypeDB.enterpriseDriver(
+            const driver = await TypeDB.cloudDriver(
                 ["localhost:11729", "localhost:21729", "localhost:31729"],
                 new TypeDBCredential("admin", "password", process.env.ROOT_CA)
             );

--- a/nodejs/user/UserManagerImpl.ts
+++ b/nodejs/user/UserManagerImpl.ts
@@ -27,7 +27,7 @@ import {ServerDriver, TypeDBDriverImpl} from "../connection/TypeDBDriverImpl";
 import {TypeDBDatabaseImpl} from "../connection/TypeDBDatabaseImpl";
 import {TypeDBDriverError} from "../common/errors/TypeDBDriverError";
 import {ErrorMessage} from "../common/errors/ErrorMessage";
-import USER_MANAGEMENT_ENTERPRISE_ONLY = ErrorMessage.Driver.USER_MANAGEMENT_ENTERPRISE_ONLY;
+import USER_MANAGEMENT_CLOUD_ONLY = ErrorMessage.Driver.USER_MANAGEMENT_CLOUD_ONLY;
 
 export class UserManagerImpl implements UserManager {
     static _SYSTEM_DB = "_system";
@@ -76,7 +76,7 @@ export class UserManagerImpl implements UserManager {
     }
 
     async runFailsafe<T>(task: (driver: ServerDriver) => Promise<T>): Promise<T> {
-        if (!this._driver.isEnterprise()) throw new TypeDBDriverError(USER_MANAGEMENT_ENTERPRISE_ONLY);
+        if (!this._driver.isCloud()) throw new TypeDBDriverError(USER_MANAGEMENT_CLOUD_ONLY);
         return await (await TypeDBDatabaseImpl.get(UserManagerImpl._SYSTEM_DB, this._driver)).runOnPrimaryReplica(task);
     }
 }

--- a/python/docs/connection/Database.adoc
+++ b/python/docs/connection/Database.adoc
@@ -42,7 +42,7 @@ database.delete()
 preferred_replica() -> Replica | None
 ----
 
-Returns the preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Enterprise_
+Returns the preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Cloud_
 
 [caption=""]
 .Returns
@@ -63,7 +63,7 @@ database.preferred_replica()
 primary_replica() -> Replica | None
 ----
 
-Returns the primary replica for this database. _Only works in TypeDB Enterprise_
+Returns the primary replica for this database. _Only works in TypeDB Cloud_
 
 [caption=""]
 .Returns
@@ -84,7 +84,7 @@ database.primary_replica()
 replicas() -> Set[Replica]
 ----
 
-Set of ``Replica`` instances for this database. _Only works in TypeDB Enterprise_
+Set of ``Replica`` instances for this database. _Only works in TypeDB Cloud_
 
 [caption=""]
 .Returns

--- a/python/docs/connection/TypeDB.adoc
+++ b/python/docs/connection/TypeDB.adoc
@@ -2,29 +2,6 @@
 === TypeDB
 
 // tag::methods[]
-[#_TypeDB_core_driver__address_str]
-==== core_driver
-
-[source,python]
-----
-static core_driver(address: str) -> TypeDBDriver
-----
-
-Creates a connection to TypeDB.
-
-[caption=""]
-.Input parameters
-[cols="~,~,~,~"]
-[options="header"]
-|===
-|Name |Description |Type |Default Value
-a| `address` a| Address of the TypeDB server. a| `str` a| 
-|===
-
-[caption=""]
-.Returns
-`TypeDBDriver`
-
 [#_TypeDB_cloud_driver__addresses_Iterable_str___str__credential_TypeDBCredential]
 ==== cloud_driver
 
@@ -43,6 +20,29 @@ Creates a connection to TypeDB Cloud, authenticating with the provided credentia
 |Name |Description |Type |Default Value
 a| `addresses` a|  – a| `Iterable[str] \| str` a| 
 a| `credential` a|  – a| `TypeDBCredential` a| 
+|===
+
+[caption=""]
+.Returns
+`TypeDBDriver`
+
+[#_TypeDB_core_driver__address_str]
+==== core_driver
+
+[source,python]
+----
+static core_driver(address: str) -> TypeDBDriver
+----
+
+Creates a connection to TypeDB.
+
+[caption=""]
+.Input parameters
+[cols="~,~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type |Default Value
+a| `address` a| Address of the TypeDB server. a| `str` a| 
 |===
 
 [caption=""]

--- a/python/docs/connection/TypeDB.adoc
+++ b/python/docs/connection/TypeDB.adoc
@@ -25,15 +25,15 @@ a| `address` a| Address of the TypeDB server. a| `str` a|
 .Returns
 `TypeDBDriver`
 
-[#_TypeDB_enterprise_driver__addresses_Iterable_str___str__credential_TypeDBCredential]
-==== enterprise_driver
+[#_TypeDB_cloud_driver__addresses_Iterable_str___str__credential_TypeDBCredential]
+==== cloud_driver
 
 [source,python]
 ----
-static enterprise_driver(addresses: Iterable[str] | str, credential: TypeDBCredential) -> TypeDBDriver
+static cloud_driver(addresses: Iterable[str] | str, credential: TypeDBCredential) -> TypeDBDriver
 ----
 
-Creates a connection to TypeDB Enterprise, authenticating with the provided credentials.
+Creates a connection to TypeDB Cloud, authenticating with the provided credentials.
 
 [caption=""]
 .Input parameters

--- a/python/docs/connection/TypeDBCredential.adoc
+++ b/python/docs/connection/TypeDBCredential.adoc
@@ -1,7 +1,7 @@
 [#_TypeDBCredential]
 === TypeDBCredential
 
-User credentials and TLS encryption settings for connecting to TypeDB Enterprise.
+User credentials and TLS encryption settings for connecting to TypeDB Cloud.
 
 [caption=""]
 .Examples

--- a/python/docs/connection/TypeDBDriver.adoc
+++ b/python/docs/connection/TypeDBDriver.adoc
@@ -9,7 +9,7 @@
 |===
 |Name |Type |Description
 a| `databases` a| `DatabaseManager` a| The ``DatabaseManager`` for this connection, providing access to database management methods.
-a| `users` a| `UserManager` a| The ``UserManager`` instance for this connection, providing access to user management methods. Only for TypeDB Enterprise.
+a| `users` a| `UserManager` a| The ``UserManager`` instance for this connection, providing access to user management methods. Only for TypeDB Cloud.
 |===
 // end::properties[]
 
@@ -96,7 +96,7 @@ driver.session(database, session_type, options)
 user() -> User
 ----
 
-Returns the logged-in user for the connection. Only for TypeDB Enterprise.
+Returns the logged-in user for the connection. Only for TypeDB Cloud.
 
 [caption=""]
 .Returns

--- a/python/docs/session/TypeDBOptions.adoc
+++ b/python/docs/session/TypeDBOptions.adoc
@@ -25,7 +25,7 @@ a| `infer` a| `bool \| None` a| If set to ``True``, enables inference for querie
 a| `parallel` a| `bool \| None` a| If set to ``True``, the server uses parallel instead of single-threaded execution.
 a| `prefetch` a| `bool \| None` a| If set to ``True``, the first batch of answers is streamed to the driver even without an explicit request for it.
 a| `prefetch_size` a| `int \| None` a| If set, specifies a guideline number of answers that the server should send before the driver issues a fresh request.
-a| `read_any_replica` a| `bool \| None` a| If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+a| `read_any_replica` a| `bool \| None` a| If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
 a| `schema_lock_acquire_timeout_millis` a| `int \| None` a| If set, specifies how long the driver should wait if opening a session or transaction is blocked by a schema write lock.
 a| `session_idle_timeout_millis` a| `int \| None` a| If set, specifies a timeout that allows the server to close sessions if the driver terminates or becomes unresponsive.
 a| `trace_inference` a| `bool \| None` a| If set to ``True``, reasoning tracing graphs are output in the logging directory. Should be used with ``parallel = False``.

--- a/python/tests/behaviour/background/BUILD
+++ b/python/tests/behaviour/background/BUILD
@@ -36,8 +36,8 @@ py_library(
 )
 
 py_library(
-    name = "enterprise",
-    srcs = ["enterprise/environment.py"],
+    name = "cloud",
+    srcs = ["cloud/environment.py"],
     deps = [],
 )
 

--- a/python/tests/behaviour/background/cloud/environment.py
+++ b/python/tests/behaviour/background/cloud/environment.py
@@ -45,7 +45,7 @@ def before_scenario(context: Context, scenario):
 
 def setup_context_driver(context, username, password):
     credential = TypeDBCredential(username, password, tls_enabled=True, tls_root_ca_path=context.credential_root_ca_path)
-    context.driver = TypeDB.enterprise_driver(addresses=["localhost:" + context.config.userdata["port"]],
+    context.driver = TypeDB.cloud_driver(addresses=["localhost:" + context.config.userdata["port"]],
                                               credential=credential)
     context.session_options = TypeDBOptions(infer=True)
     context.transaction_options = TypeDBOptions(infer=True)

--- a/python/tests/behaviour/behave_rule.bzl
+++ b/python/tests/behaviour/behave_rule.bzl
@@ -57,11 +57,11 @@ def typedb_behaviour_py_test_core(name, **kwargs):
         **kwargs,
     )
 
-def typedb_behaviour_py_test_enterprise(name, **kwargs):
+def typedb_behaviour_py_test_cloud(name, **kwargs):
     py_behave_test(
-        name = name + "-enterprise",
-        background = "@//python/tests/behaviour/background:enterprise",
-        native_typedb_artifact = "@//tool/test:native-typedb-enterprise-artifact",
+        name = name + "-cloud",
+        background = "@//python/tests/behaviour/background:cloud",
+        native_typedb_artifact = "@//tool/test:native-typedb-cloud-artifact",
         toolchains = ["@rules_python//python:current_py_toolchain"],
         typedb_port = "11729",
         **kwargs,
@@ -69,4 +69,4 @@ def typedb_behaviour_py_test_enterprise(name, **kwargs):
 
 def typedb_behaviour_py_test(name, **kwargs):
     typedb_behaviour_py_test_core(name, **kwargs)
-    typedb_behaviour_py_test_enterprise(name, **kwargs)
+    typedb_behaviour_py_test_cloud(name, **kwargs)

--- a/python/tests/behaviour/connection/user/BUILD
+++ b/python/tests/behaviour/connection/user/BUILD
@@ -20,7 +20,7 @@
 #
 
 package(default_visibility = ["//python/tests/behaviour:__subpackages__"])
-load("//python/tests/behaviour:behave_rule.bzl", "typedb_behaviour_py_test_enterprise")
+load("//python/tests/behaviour:behave_rule.bzl", "typedb_behaviour_py_test_cloud")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 py_library(
@@ -29,7 +29,7 @@ py_library(
     deps = [],
 )
 
-typedb_behaviour_py_test_enterprise(
+typedb_behaviour_py_test_cloud(
     name = "test",
     feats = ["@vaticle_typedb_behaviour//connection:user.feature"],
     steps = [

--- a/python/tests/integration/BUILD
+++ b/python/tests/integration/BUILD
@@ -19,19 +19,19 @@
 # under the License.
 #
 
-load("//python/tests/integration:enterprise_test_rule.bzl", "typedb_enterprise_py_test")
+load("//python/tests/integration:cloud_test_rule.bzl", "typedb_cloud_py_test")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@rules_python//python:defs.bzl", "py_test")
 
-typedb_enterprise_py_test(
-    name = "test_enterprise_failover",
-    srcs = ["test_enterprise_failover.py"],
+typedb_cloud_py_test(
+    name = "test_cloud_failover",
+    srcs = ["test_cloud_failover.py"],
     deps = [
         "//python:driver_python",
     ],
     data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
     size = "medium",
-    native_typedb_enterprise_artifact = "//tool/test:native-typedb-enterprise-artifact",
+    native_typedb_cloud_artifact = "//tool/test:native-typedb-cloud-artifact",
 )
 
 py_test(

--- a/python/tests/integration/cloud_test_rule.bzl
+++ b/python/tests/integration/cloud_test_rule.bzl
@@ -21,19 +21,19 @@
 
 def _rule_implementation(ctx):
     """
-    Implementation of the rule typedb_enterprise_py_test.
+    Implementation of the rule typedb_cloud_py_test.
     """
 
     # Store the path of the test source file. It is recommended to only have one source file.
     test_src = ctx.files.srcs[0].path
 
-    typedb_enterprise_distro = str(ctx.files.native_typedb_enterprise_artifact[0].short_path)
+    typedb_cloud_distro = str(ctx.files.native_typedb_cloud_artifact[0].short_path)
 
     # TODO: This code is, mostly, copied from our TypeDB behave test
-    cmd = "set -xe && TYPEDB_ARCHIVE=%s" % typedb_enterprise_distro
+    cmd = "set -xe && TYPEDB_ARCHIVE=%s" % typedb_cloud_distro
     cmd += """
             function server_start() {
-              ./${1}/typedb enterprise \
+              ./${1}/typedb cloud \
                 --storage.data=server/data \
                 --server.address=localhost:${1}1729 \
                 --server.internal-address.zeromq=localhost:${1}1730 \
@@ -82,7 +82,7 @@ def _rule_implementation(ctx):
             while [[ $RETRY_NUM -lt $MAX_RETRIES ]]; do
              RETRY_NUM=$(($RETRY_NUM + 1))
              if [[ $(($RETRY_NUM % 4)) -eq 0 ]]; then
-               echo Waiting for TypeDB Enterprise servers to start \\($(($RETRY_NUM / 2))s\\)...
+               echo Waiting for TypeDB Cloud servers to start \\($(($RETRY_NUM / 2))s\\)...
              fi
              lsof -i :11729 && STARTED1=1 || STARTED1=0
              lsof -i :21729 && STARTED2=1 || STARTED2=0
@@ -93,10 +93,10 @@ def _rule_implementation(ctx):
              sleep $POLL_INTERVAL_SECS
             done
             if [[ $STARTED1 -eq 0 || $STARTED2 -eq 0 || $STARTED3 -eq 0 ]]; then
-             echo Failed to start one or more TypeDB Enterprise servers
+             echo Failed to start one or more TypeDB Cloud servers
              exit 1
             fi
-            echo 3 TypeDB Enterprise database servers started
+            echo 3 TypeDB Cloud database servers started
 
            """
 
@@ -126,7 +126,7 @@ def _rule_implementation(ctx):
     # https://bazel.build/versions/master/docs/skylark/rules.html#runfiles
     return [DefaultInfo(
         # The shell executable - the output of this rule - can use these files at runtime.
-        runfiles = ctx.runfiles(files = ctx.files.srcs + ctx.files.deps + ctx.files.data + ctx.files.native_typedb_enterprise_artifact)
+        runfiles = ctx.runfiles(files = ctx.files.srcs + ctx.files.deps + ctx.files.data + ctx.files.native_typedb_cloud_artifact)
     )]
 
 """
@@ -144,13 +144,13 @@ Args:
   deps:
     System to test.
 """
-typedb_enterprise_py_test = rule(
+typedb_cloud_py_test = rule(
     implementation=_rule_implementation,
     attrs={
         "srcs": attr.label_list(mandatory=True,allow_empty=False,allow_files=True),
         "deps": attr.label_list(mandatory=True,allow_empty=False),
         "data": attr.label_list(),
-        "native_typedb_enterprise_artifact": attr.label(mandatory=True)
+        "native_typedb_cloud_artifact": attr.label(mandatory=True)
     },
     test=True,
 )

--- a/python/tests/integration/test_cloud_failover.py
+++ b/python/tests/integration/test_cloud_failover.py
@@ -31,13 +31,13 @@ WRITE = TransactionType.WRITE
 READ = TransactionType.READ
 
 
-class TestEnterpriseFailover(TestCase):
+class TestCloudFailover(TestCase):
 
     def setUp(self):
         root_ca_path = os.environ["ROOT_CA"]
         credential = TypeDBCredential("admin", "password", tls_root_ca_path=root_ca_path)
         print("SetUp", flush=True)
-        with TypeDB.enterprise_driver(["localhost:11729", "localhost:21729", "localhost:31729"], credential) as driver:
+        with TypeDB.cloud_driver(["localhost:11729", "localhost:21729", "localhost:31729"], credential) as driver:
             if driver.databases.contains("typedb"):
                 driver.databases.get("typedb").delete()
             driver.databases.create("typedb")
@@ -45,7 +45,7 @@ class TestEnterpriseFailover(TestCase):
     @staticmethod
     def server_start(index):
         subprocess.Popen([
-            "../%s/typedb" % index, "enterprise",
+            "../%s/typedb" % index, "cloud",
             "--storage.data", "server/data",
             "--server.address", "localhost:%s1729" % index,
             "--server.internal-address.zeromq", "localhost:%s1730" % index,
@@ -80,7 +80,7 @@ class TestEnterpriseFailover(TestCase):
     def test_put_entity_type_to_crashed_primary_replica(self):
         root_ca_path = os.environ["ROOT_CA"]
         credential = TypeDBCredential("admin", "password", tls_root_ca_path=root_ca_path)
-        with TypeDB.enterprise_driver(["localhost:11729", "localhost:21729", "localhost:31729"], credential) as driver:
+        with TypeDB.cloud_driver(["localhost:11729", "localhost:21729", "localhost:31729"], credential) as driver:
             assert driver.databases.contains("typedb")
             primary_replica = self.get_primary_replica(driver.databases)
             print("Performing operations against the primary replica " + str(primary_replica))

--- a/python/typedb/api/connection/credential.py
+++ b/python/typedb/api/connection/credential.py
@@ -23,18 +23,18 @@ from typing import Optional
 
 from typedb.native_driver_wrapper import credential_new, Credential as NativeCredential
 
-from typedb.common.exception import TypeDBDriverException, ENTERPRISE_CREDENTIAL_INCONSISTENT, ILLEGAL_STATE
+from typedb.common.exception import TypeDBDriverException, CLOUD_CREDENTIAL_INCONSISTENT, ILLEGAL_STATE
 from typedb.common.native_wrapper import NativeWrapper
 
 
 class TypeDBCredential(NativeWrapper[NativeCredential]):
     """
-    User credentials and TLS encryption settings for connecting to TypeDB Enterprise.
+    User credentials and TLS encryption settings for connecting to TypeDB Cloud.
 
     :param username: The name of the user to connect as
     :param password: The password for the user
     :param tls_root_ca_path: Path to the CA certificate to use for authenticating server certificates.
-    :param tls_enabled: Specify whether the connection to TypeDB Enterprise must be done over TLS
+    :param tls_enabled: Specify whether the connection to TypeDB Cloud must be done over TLS
 
     Examples:
     --------
@@ -50,7 +50,7 @@ class TypeDBCredential(NativeWrapper[NativeCredential]):
     def __init__(self, username: str, password: str, *, tls_root_ca_path: Optional[str] = None,
                  tls_enabled: bool = False):
         if tls_root_ca_path is not None and not tls_enabled:
-            raise TypeDBDriverException(ENTERPRISE_CREDENTIAL_INCONSISTENT)
+            raise TypeDBDriverException(CLOUD_CREDENTIAL_INCONSISTENT)
         super().__init__(credential_new(username, password, tls_root_ca_path, tls_enabled))
 
     @property

--- a/python/typedb/api/connection/database.py
+++ b/python/typedb/api/connection/database.py
@@ -97,7 +97,7 @@ class Database(ABC):
     def replicas(self) -> Set[Replica]:
         """
         Set of ``Replica`` instances for this database.
-        *Only works in TypeDB Enterprise*
+        *Only works in TypeDB Cloud*
 
         :return:
 
@@ -113,7 +113,7 @@ class Database(ABC):
     def primary_replica(self) -> Optional[Replica]:
         """
         Returns the primary replica for this database.
-        *Only works in TypeDB Enterprise*
+        *Only works in TypeDB Cloud*
 
         :return:
 
@@ -130,7 +130,7 @@ class Database(ABC):
         """
         Returns the preferred replica for this database.
         Operations which can be run on any replica will prefer to use this replica.
-        *Only works in TypeDB Enterprise*
+        *Only works in TypeDB Cloud*
 
         :return:
 

--- a/python/typedb/api/connection/driver.py
+++ b/python/typedb/api/connection/driver.py
@@ -96,14 +96,14 @@ class TypeDBDriver(ABC):
     def users(self) -> UserManager:
         """
         The ``UserManager`` instance for this connection, providing access to user management methods.
-        Only for TypeDB Enterprise.
+        Only for TypeDB Cloud.
         """
         pass
 
     @abstractmethod
     def user(self) -> User:
         """
-        Returns the logged-in user for the connection. Only for TypeDB Enterprise.
+        Returns the logged-in user for the connection. Only for TypeDB Cloud.
 
         :return:
 

--- a/python/typedb/api/connection/options.py
+++ b/python/typedb/api/connection/options.py
@@ -215,7 +215,7 @@ class TypeDBOptions(NativeWrapper[NativeOptions]):
     def read_any_replica(self) -> Optional[bool]:
         """
         If set to ``True``, enables reading data from any replica, potentially boosting
-        read throughput. Only settable in TypeDB Enterprise.
+        read throughput. Only settable in TypeDB Cloud.
         """
         return options_get_read_any_replica(self.native_object) if options_has_read_any_replica(self.native_object) \
             else None

--- a/python/typedb/common/exception.py
+++ b/python/typedb/common/exception.py
@@ -95,7 +95,7 @@ TRANSACTION_CLOSED = DriverErrorMessage(3, "The transaction has been closed and 
 DATABASE_DELETED = DriverErrorMessage(4, "The database '%s' has been deleted and no further operation is allowed.")
 MISSING_DB_NAME = DriverErrorMessage(5, "Database name cannot be empty.")
 POSITIVE_VALUE_REQUIRED = DriverErrorMessage(6, "Value should be positive, was: '%d'.")
-ENTERPRISE_CREDENTIAL_INCONSISTENT = DriverErrorMessage(7, "TLS disabled but the Root CA path provided.")
+CLOUD_CREDENTIAL_INCONSISTENT = DriverErrorMessage(7, "TLS disabled but the Root CA path provided.")
 
 
 class ConceptErrorMessage(ErrorMessage):

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Optional, TYPE_CHECKING
 
-from typedb.native_driver_wrapper import connection_open_core, connection_open_enterprise, connection_is_open, \
+from typedb.native_driver_wrapper import connection_open_core, connection_open_cloud, connection_is_open, \
     connection_force_close, Connection as NativeConnection, TypeDBDriverExceptionNative
 
 from typedb.api.connection.driver import TypeDBDriver
@@ -45,7 +45,7 @@ class _Driver(TypeDBDriver, NativeWrapper[NativeConnection]):
     def __init__(self, addresses: list[str], credential: Optional[TypeDBCredential] = None):
         if credential:
             try:
-                native_connection = connection_open_enterprise(addresses, credential.native_object)
+                native_connection = connection_open_cloud(addresses, credential.native_object)
             except TypeDBDriverExceptionNative as e:
                 raise TypeDBDriverException.of(e)
         else:

--- a/python/typedb/driver.py
+++ b/python/typedb/driver.py
@@ -71,9 +71,9 @@ class TypeDB:
         return _Driver([address])
 
     @staticmethod
-    def enterprise_driver(addresses: Union[Iterable[str], str], credential: TypeDBCredential) -> TypeDBDriver:
+    def cloud_driver(addresses: Union[Iterable[str], str], credential: TypeDBCredential) -> TypeDBDriver:
         """
-        Creates a connection to TypeDB Enterprise, authenticating with the provided credentials.
+        Creates a connection to TypeDB Cloud, authenticating with the provided credentials.
 
         :param addresses:
         :param credential:

--- a/rust/docs/connection/Connection.adoc
+++ b/rust/docs/connection/Connection.adoc
@@ -31,15 +31,15 @@ Result
 connection.force_close()
 ----
 
-[#_struct_Connection_is_enterprise__]
-==== is_enterprise
+[#_struct_Connection_is_cloud__]
+==== is_cloud
 
 [source,rust]
 ----
-pub fn is_enterprise(&self) -> bool
+pub fn is_cloud(&self) -> bool
 ----
 
-Check if the connection is to an Enterprise server.
+Check if the connection is to an Cloud server.
 
 [caption=""]
 .Returns
@@ -52,7 +52,7 @@ bool
 .Code examples
 [source,rust]
 ----
-connection.is_enterprise()
+connection.is_cloud()
 ----
 
 [#_struct_Connection_is_open__]
@@ -112,18 +112,18 @@ Result<Self>
 Connection::new_core("127.0.0.1:1729")
 ----
 
-[#_struct_Connection_new_enterprise__init_addresses__T___credential_Credential]
-==== new_enterprise
+[#_struct_Connection_new_cloud__init_addresses__T___credential_Credential]
+==== new_cloud
 
 [source,rust]
 ----
-pub fn new_enterprise<T: AsRef<str> + Sync>(
+pub fn new_cloud<T: AsRef<str> + Sync>(
     init_addresses: &[T],
     credential: Credential
 ) -> Result<Self>
 ----
 
-Creates a new TypeDB Enterprise connection.
+Creates a new TypeDB Cloud connection.
 
 [caption=""]
 .Input parameters
@@ -131,7 +131,7 @@ Creates a new TypeDB Enterprise connection.
 [options="header"]
 |===
 |Name |Description |Type
-a| `init_addresses` a| Addresses (host:port) on which TypeDB Enterprise nodes are running a| `&[T]`
+a| `init_addresses` a| Addresses (host:port) on which TypeDB Cloud nodes are running a| `&[T]`
 a| `credential` a| User credential and TLS encryption setting a| `Credential`
 |===
 
@@ -146,14 +146,14 @@ Result<Self>
 .Code examples
 [source,rust]
 ----
-Connection::new_enterprise(
+Connection::new_cloud(
     &["localhost:11729", "localhost:21729", "localhost:31729"],
     Credential::with_tls(
         "admin",
         "password",
         Some(&PathBuf::from(
             std::env::var("ROOT_CA")
-                .expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
+                .expect("ROOT_CA environment variable needs to be set for cloud tests to run"),
         )),
     )?,
 )

--- a/rust/docs/connection/Connection.adoc
+++ b/rust/docs/connection/Connection.adoc
@@ -79,39 +79,6 @@ bool
 connection.is_open()
 ----
 
-[#_struct_Connection_new_core__address_impl_AsRef_str_]
-==== new_core
-
-[source,rust]
-----
-pub fn new_core(address: impl AsRef<str>) -> Result<Self>
-----
-
-Creates a new TypeDB Server connection.
-
-[caption=""]
-.Input parameters
-[cols="~,~,~"]
-[options="header"]
-|===
-|Name |Description |Type
-a| `address` a| The address (host:port) on which the TypeDB Server is running a| `impl AsRef<str>`
-|===
-
-[caption=""]
-.Returns
-[source,rust]
-----
-Result<Self>
-----
-
-[caption=""]
-.Code examples
-[source,rust]
-----
-Connection::new_core("127.0.0.1:1729")
-----
-
 [#_struct_Connection_new_cloud__init_addresses__T___credential_Credential]
 ==== new_cloud
 
@@ -157,6 +124,39 @@ Connection::new_cloud(
         )),
     )?,
 )
+----
+
+[#_struct_Connection_new_core__address_impl_AsRef_str_]
+==== new_core
+
+[source,rust]
+----
+pub fn new_core(address: impl AsRef<str>) -> Result<Self>
+----
+
+Creates a new TypeDB Server connection.
+
+[caption=""]
+.Input parameters
+[cols="~,~,~"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `address` a| The address (host:port) on which the TypeDB Server is running a| `impl AsRef<str>`
+|===
+
+[caption=""]
+.Returns
+[source,rust]
+----
+Result<Self>
+----
+
+[caption=""]
+.Code examples
+[source,rust]
+----
+Connection::new_core("127.0.0.1:1729")
 ----
 
 // end::methods[]

--- a/rust/docs/connection/Database.adoc
+++ b/rust/docs/connection/Database.adoc
@@ -91,7 +91,7 @@ Retrieves the database name as a string.
 pub fn preferred_replica_info(&self) -> Option<ReplicaInfo>
 ----
 
-Returns the preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Enterprise_
+Returns the preferred replica for this database. Operations which can be run on any replica will prefer to use this replica. _Only works in TypeDB Cloud_
 
 [caption=""]
 .Returns
@@ -115,7 +115,7 @@ database.preferred_replica_info();
 pub fn primary_replica_info(&self) -> Option<ReplicaInfo>
 ----
 
-Returns the primary replica for this database. _Only works in TypeDB Enterprise_
+Returns the primary replica for this database. _Only works in TypeDB Cloud_
 
 [caption=""]
 .Returns
@@ -139,7 +139,7 @@ database.primary_replica_info()
 pub fn replicas_info(&self) -> Vec<ReplicaInfo>
 ----
 
-Returns the ``Replica`` instances for this database. _Only works in TypeDB Enterprise_
+Returns the ``Replica`` instances for this database. _Only works in TypeDB Cloud_
 
 [caption=""]
 .Returns

--- a/rust/docs/errors/ConnectionError.adoc
+++ b/rust/docs/errors/ConnectionError.adoc
@@ -12,11 +12,11 @@ a| `BrokenPipe`
 a| `ConnectionFailed`
 a| `ConnectionIsClosed`
 a| `DatabaseDoesNotExist`
-a| `EnterpriseAllNodesFailed`
-a| `EnterpriseEndpointEncrypted`
-a| `EnterpriseReplicaNotPrimary`
-a| `EnterpriseSSLCertificateNotValidated`
-a| `EnterpriseTokenCredentialInvalid`
+a| `CloudAllNodesFailed`
+a| `CloudEndpointEncrypted`
+a| `CloudReplicaNotPrimary`
+a| `CloudSSLCertificateNotValidated`
+a| `CloudTokenCredentialInvalid`
 a| `InvalidResponseField`
 a| `MissingResponseField`
 a| `RPCMethodUnavailable`
@@ -29,7 +29,7 @@ a| `TransactionIsClosed`
 a| `TransactionIsClosedWithErrors`
 a| `UnexpectedResponse`
 a| `UnknownRequestId`
-a| `UserManagementEnterpriseOnly`
+a| `UserManagementCloudOnly`
 |===
 // end::enum_constants[]
 

--- a/rust/docs/errors/ConnectionError.adoc
+++ b/rust/docs/errors/ConnectionError.adoc
@@ -9,14 +9,14 @@
 |===
 |Variant
 a| `BrokenPipe`
-a| `ConnectionFailed`
-a| `ConnectionIsClosed`
-a| `DatabaseDoesNotExist`
 a| `CloudAllNodesFailed`
 a| `CloudEndpointEncrypted`
 a| `CloudReplicaNotPrimary`
 a| `CloudSSLCertificateNotValidated`
 a| `CloudTokenCredentialInvalid`
+a| `ConnectionFailed`
+a| `ConnectionIsClosed`
+a| `DatabaseDoesNotExist`
 a| `InvalidResponseField`
 a| `MissingResponseField`
 a| `RPCMethodUnavailable`

--- a/rust/docs/session/Options.adoc
+++ b/rust/docs/session/Options.adoc
@@ -22,7 +22,7 @@ a| `infer` a| `Option<bool>` a| If set to ``True``, enables inference for querie
 a| `parallel` a| `Option<bool>` a| If set to ``True``, the server uses parallel instead of single-threaded execution.
 a| `prefetch` a| `Option<bool>` a| If set to ``True``, the first batch of answers is streamed to the driver even without an explicit request for it.
 a| `prefetch_size` a| `Option<i32>` a| If set, specifies a guideline number of answers that the server should send before the driver issues a fresh request.
-a| `read_any_replica` a| `Option<bool>` a| If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+a| `read_any_replica` a| `Option<bool>` a| If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
 a| `schema_lock_acquire_timeout` a| `Option<Duration>` a| If set, specifies how long the driver should wait if opening a session or transaction is blocked by a schema write lock.
 a| `session_idle_timeout` a| `Option<Duration>` a| If set, specifies a timeout that allows the server to close sessions if the driver terminates or becomes unresponsive.
 a| `trace_inference` a| `Option<bool>` a| If set to ``True``, reasoning tracing graphs are output in the logging directory. Should be used with ``parallel = False``.
@@ -124,7 +124,7 @@ Self
 pub fn read_any_replica(self, read_any_replica: bool) -> Self
 ----
 
-If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+If set to ``True``, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
 
 [caption=""]
 .Returns

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -54,24 +54,24 @@ error_messages! { ConnectionError
         12: "Unable to connect to TypeDB server(s), received errors: \n{error}",
     ServerConnectionFailedStatusError { error: String } =
         13: "Unable to connect to TypeDB server(s), received network error: \n{error}",
-    UserManagementEnterpriseOnly =
-        14: "User management is only available in TypeDB Enterprise servers.",
-    EnterpriseReplicaNotPrimary =
+    UserManagementCloudOnly =
+        14: "User management is only available in TypeDB Cloud servers.",
+    CloudReplicaNotPrimary =
         15: "The replica is not the primary replica.",
-    EnterpriseAllNodesFailed { errors: String } =
-        16: "Attempted connecting to all TypeDB Enterprise servers, but the following errors occurred: \n{errors}.",
-    EnterpriseTokenCredentialInvalid =
+    CloudAllNodesFailed { errors: String } =
+        16: "Attempted connecting to all TypeDB Cloud servers, but the following errors occurred: \n{errors}.",
+    CloudTokenCredentialInvalid =
         17: "Invalid token credential.",
     SessionCloseFailed =
         18: "Failed to close session. It may still be open on the server: or it may already have been closed previously.",
-    EnterpriseEndpointEncrypted =
-        19: "Unable to connect to TypeDB Enterprise: attempting an unencrypted connection to an encrypted endpoint.",
-    EnterpriseSSLCertificateNotValidated =
-        20: "SSL handshake with TypeDB Enterprise failed: the server's identity could not be verified. Possible CA mismatch.",
+    CloudEndpointEncrypted =
+        19: "Unable to connect to TypeDB Cloud: attempting an unencrypted connection to an encrypted endpoint.",
+    CloudSSLCertificateNotValidated =
+        20: "SSL handshake with TypeDB Cloud failed: the server's identity could not be verified. Possible CA mismatch.",
     BrokenPipe =
-        21: "Stream closed because of a broken pipe. This could happen if you are attempting to connect to an unencrypted enterprise instance using a TLS-enabled credential.",
+        21: "Stream closed because of a broken pipe. This could happen if you are attempting to connect to an unencrypted cloud instance using a TLS-enabled credential.",
     ConnectionFailed =
-        22: "Connection failed. Please check the server is running and the address is accessible. Encrypted Enterprise endpoints may also have misconfigured SSL certificates.",
+        22: "Connection failed. Please check the server is running and the address is accessible. Encrypted Cloud endpoints may also have misconfigured SSL certificates.",
 }
 
 error_messages! { InternalError
@@ -119,10 +119,10 @@ impl Error {
 
     fn from_message(message: &str) -> Self {
         match message.split_ascii_whitespace().next() {
-            Some("[RPL01]") => Self::Connection(ConnectionError::EnterpriseReplicaNotPrimary),
+            Some("[RPL01]") => Self::Connection(ConnectionError::CloudReplicaNotPrimary),
             // TODO: CLS and ENT are synonyms which we can simplify on protocol change
-            Some("[CLS08]") => Self::Connection(ConnectionError::EnterpriseTokenCredentialInvalid),
-            Some("[ENT08]") => Self::Connection(ConnectionError::EnterpriseTokenCredentialInvalid),
+            Some("[CLS08]") => Self::Connection(ConnectionError::CloudTokenCredentialInvalid),
+            Some("[ENT08]") => Self::Connection(ConnectionError::CloudTokenCredentialInvalid),
             Some("[DBS06]") => Self::Connection(ConnectionError::DatabaseDoesNotExist {
                 name: message.split('\'').nth(1).unwrap_or("{unknown}").to_owned(),
             }),
@@ -134,9 +134,9 @@ impl Error {
         if status_message == "broken pipe" {
             Error::Connection(ConnectionError::BrokenPipe)
         } else if status_message.contains("received corrupt message") {
-            Error::Connection(ConnectionError::EnterpriseEndpointEncrypted)
+            Error::Connection(ConnectionError::CloudEndpointEncrypted)
         } else if status_message.contains("UnknownIssuer") {
-            Error::Connection(ConnectionError::EnterpriseSSLCertificateNotValidated)
+            Error::Connection(ConnectionError::CloudSSLCertificateNotValidated)
         } else if status_message.contains("Connection refused") {
             Error::Connection(ConnectionError::ConnectionFailed)
         } else {

--- a/rust/src/common/options.rs
+++ b/rust/src/common/options.rs
@@ -50,7 +50,7 @@ pub struct Options {
     pub transaction_timeout: Option<Duration>,
     /// If set, specifies how long the driver should wait if opening a session or transaction is blocked by a schema write lock.
     pub schema_lock_acquire_timeout: Option<Duration>,
-    /// If set to `True`, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+    /// If set to `True`, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
     pub read_any_replica: Option<bool>,
 }
 
@@ -104,7 +104,7 @@ impl Options {
         Self { schema_lock_acquire_timeout: Some(timeout), ..self }
     }
 
-    /// If set to `True`, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Enterprise.
+    /// If set to `True`, enables reading data from any replica, potentially boosting read throughput. Only settable in TypeDB Cloud.
     pub fn read_any_replica(self, read_any_replica: bool) -> Self {
         Self { read_any_replica: Some(read_any_replica), ..self }
     }

--- a/rust/src/connection/connection.rs
+++ b/rust/src/connection/connection.rs
@@ -261,11 +261,7 @@ impl ServerConnection {
         Ok(Self { address, background_runtime, open_sessions: Default::default(), request_transmitter })
     }
 
-    fn new_cloud(
-        background_runtime: Arc<BackgroundRuntime>,
-        address: Address,
-        credential: Credential,
-    ) -> Result<Self> {
+    fn new_cloud(background_runtime: Arc<BackgroundRuntime>, address: Address, credential: Credential) -> Result<Self> {
         let request_transmitter =
             Arc::new(RPCTransmitter::start_cloud(address.clone(), credential, &background_runtime)?);
         Ok(Self { address, background_runtime, open_sessions: Default::default(), request_transmitter })

--- a/rust/src/connection/connection.rs
+++ b/rust/src/connection/connection.rs
@@ -61,7 +61,7 @@ pub struct Connection {
     server_connections: HashMap<Address, ServerConnection>,
     background_runtime: Arc<BackgroundRuntime>,
     username: Option<String>,
-    is_enterprise: bool,
+    is_cloud: bool,
 }
 
 impl Connection {
@@ -91,35 +91,35 @@ impl Connection {
                 server_connections: [(address, server_connection)].into(),
                 background_runtime,
                 username: None,
-                is_enterprise: false,
+                is_cloud: false,
             }),
             Err(err) => Err(err),
         }
     }
 
-    /// Creates a new TypeDB Enterprise connection.
+    /// Creates a new TypeDB Cloud connection.
     ///
     /// # Arguments
     ///
-    /// * `init_addresses` -- Addresses (host:port) on which TypeDB Enterprise nodes are running
+    /// * `init_addresses` -- Addresses (host:port) on which TypeDB Cloud nodes are running
     /// * `credential` -- User credential and TLS encryption setting
     ///
     /// # Examples
     ///
     /// ```rust
-    /// Connection::new_enterprise(
+    /// Connection::new_cloud(
     ///     &["localhost:11729", "localhost:21729", "localhost:31729"],
     ///     Credential::with_tls(
     ///         "admin",
     ///         "password",
     ///         Some(&PathBuf::from(
     ///             std::env::var("ROOT_CA")
-    ///                 .expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
+    ///                 .expect("ROOT_CA environment variable needs to be set for cloud tests to run"),
     ///         )),
     ///     )?,
     /// )
     /// ```
-    pub fn new_enterprise<T: AsRef<str> + Sync>(init_addresses: &[T], credential: Credential) -> Result<Self> {
+    pub fn new_cloud<T: AsRef<str> + Sync>(init_addresses: &[T], credential: Credential) -> Result<Self> {
         let background_runtime = Arc::new(BackgroundRuntime::new()?);
 
         let init_addresses = init_addresses.iter().map(|addr| addr.as_ref().parse()).try_collect()?;
@@ -128,7 +128,7 @@ impl Connection {
         let server_connections: HashMap<Address, ServerConnection> = addresses
             .into_iter()
             .map(|address| {
-                ServerConnection::new_enterprise(background_runtime.clone(), address.clone(), credential.clone())
+                ServerConnection::new_cloud(background_runtime.clone(), address.clone(), credential.clone())
                     .map(|server_connection| (address, server_connection))
             })
             .try_collect()?;
@@ -136,7 +136,7 @@ impl Connection {
         let errors: Vec<Error> =
             server_connections.values().map(|conn| conn.validate()).filter_map(Result::err).collect();
         if errors.len() == server_connections.len() {
-            Err(ConnectionError::EnterpriseAllNodesFailed {
+            Err(ConnectionError::CloudAllNodesFailed {
                 errors: errors.into_iter().map(|err| err.to_string()).collect::<Vec<_>>().join("\n"),
             })?
         } else {
@@ -144,7 +144,7 @@ impl Connection {
                 server_connections,
                 background_runtime,
                 username: Some(credential.username().to_string()),
-                is_enterprise: true,
+                is_cloud: true,
             })
         }
     }
@@ -156,7 +156,7 @@ impl Connection {
     ) -> Result<HashSet<Address>> {
         for address in &addresses {
             let server_connection =
-                ServerConnection::new_enterprise(background_runtime.clone(), address.clone(), credential.clone());
+                ServerConnection::new_cloud(background_runtime.clone(), address.clone(), credential.clone());
             match server_connection {
                 Ok(server_connection) => match server_connection.servers_all() {
                     Ok(servers) => return Ok(servers.into_iter().collect()),
@@ -188,15 +188,15 @@ impl Connection {
         self.background_runtime.is_open()
     }
 
-    /// Check if the connection is to an Enterprise server.
+    /// Check if the connection is to an Cloud server.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// connection.is_enterprise()
+    /// connection.is_cloud()
     /// ```
-    pub fn is_enterprise(&self) -> bool {
-        self.is_enterprise
+    pub fn is_cloud(&self) -> bool {
+        self.is_cloud
     }
 
     /// Closes this connection.
@@ -261,13 +261,13 @@ impl ServerConnection {
         Ok(Self { address, background_runtime, open_sessions: Default::default(), request_transmitter })
     }
 
-    fn new_enterprise(
+    fn new_cloud(
         background_runtime: Arc<BackgroundRuntime>,
         address: Address,
         credential: Credential,
     ) -> Result<Self> {
         let request_transmitter =
-            Arc::new(RPCTransmitter::start_enterprise(address.clone(), credential, &background_runtime)?);
+            Arc::new(RPCTransmitter::start_cloud(address.clone(), credential, &background_runtime)?);
         Ok(Self { address, background_runtime, open_sessions: Default::default(), request_transmitter })
     }
 

--- a/rust/src/connection/credential.rs
+++ b/rust/src/connection/credential.rs
@@ -33,7 +33,7 @@ pub struct Credential {
     tls_config: Option<ClientTlsConfig>,
 }
 
-/// User credentials and TLS encryption settings for connecting to TypeDB Enterprise.
+/// User credentials and TLS encryption settings for connecting to TypeDB Cloud.
 impl Credential {
     /// Creates a credential with username and password. Specifies the connection must use TLS
     ///

--- a/rust/src/connection/network/stub.rs
+++ b/rust/src/connection/network/stub.rs
@@ -56,7 +56,7 @@ impl<Channel: GRPCChannel> RPCStub<Channel> {
         for<'a> F: Fn(&'a mut Self) -> BoxFuture<'a, Result<R>>,
     {
         match call(self).await {
-            Err(Error::Connection(ConnectionError::EnterpriseTokenCredentialInvalid)) => {
+            Err(Error::Connection(ConnectionError::CloudTokenCredentialInvalid)) => {
                 debug!("Request rejected because token credential was invalid. Renewing token...");
                 self.renew_token().await?;
                 call(self).await

--- a/rust/src/connection/network/transmitter/rpc.rs
+++ b/rust/src/connection/network/transmitter/rpc.rs
@@ -60,7 +60,7 @@ impl RPCTransmitter {
         Ok(Self { request_sink, shutdown_sink })
     }
 
-    pub(in crate::connection) fn start_enterprise(
+    pub(in crate::connection) fn start_cloud(
         address: Address,
         credential: Credential,
         runtime: &BackgroundRuntime,

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -69,7 +69,7 @@ impl Database {
     }
 
     /// Returns the `Replica` instances for this database.
-    /// _Only works in TypeDB Enterprise_
+    /// _Only works in TypeDB Cloud_
     ///
     /// # Examples
     ///
@@ -81,7 +81,7 @@ impl Database {
     }
 
     /// Returns the primary replica for this database.
-    /// _Only works in TypeDB Enterprise_
+    /// _Only works in TypeDB Cloud_
     ///
     /// # Examples
     ///
@@ -94,7 +94,7 @@ impl Database {
 
     /// Returns the preferred replica for this database.
     /// Operations which can be run on any replica will prefer to use this replica.
-    /// _Only works in TypeDB Enterprise_
+    /// _Only works in TypeDB Cloud_
     ///
     /// # Examples
     ///
@@ -168,7 +168,7 @@ impl Database {
         P: Future<Output = Result<R>>,
     {
         match self.run_on_any_replica(&task).await {
-            Err(Error::Connection(ConnectionError::EnterpriseReplicaNotPrimary)) => {
+            Err(Error::Connection(ConnectionError::CloudReplicaNotPrimary)) => {
                 debug!("Attempted to run on a non-primary replica, retrying on primary...");
                 self.run_on_primary_replica(&task).await
             }
@@ -210,7 +210,7 @@ impl Database {
                 .await
             {
                 Err(Error::Connection(
-                    ConnectionError::EnterpriseReplicaNotPrimary
+                    ConnectionError::CloudReplicaNotPrimary
                     | ConnectionError::ServerConnectionFailedStatusError { .. }
                     | ConnectionError::ConnectionFailed,
                 )) => {

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -131,7 +131,7 @@ impl DatabaseManager {
         for server_connection in self.connection.connections() {
             match task(server_connection.clone(), name.clone()).await {
                 Ok(res) => return Ok(res),
-                Err(Error::Connection(ConnectionError::EnterpriseReplicaNotPrimary)) => {
+                Err(Error::Connection(ConnectionError::CloudReplicaNotPrimary)) => {
                     return Database::get(name, self.connection.clone())
                         .await?
                         .run_on_primary_replica(|database, server_connection| {

--- a/rust/src/user/user.rs
+++ b/rust/src/user/user.rs
@@ -63,6 +63,6 @@ impl User {
                 Err(err) => error_buffer.push(format!("- {}: {}", server_connection.address(), err)),
             }
         }
-        Err(ConnectionError::EnterpriseAllNodesFailed { errors: error_buffer.join("\n") })?
+        Err(ConnectionError::CloudAllNodesFailed { errors: error_buffer.join("\n") })?
     }
 }

--- a/rust/src/user/user_manager.rs
+++ b/rust/src/user/user_manager.rs
@@ -186,8 +186,8 @@ impl UserManager {
         F: Fn(ServerConnection) -> P,
         P: Future<Output = Result<R>>,
     {
-        if !self.connection.is_enterprise() {
-            Err(Error::Connection(ConnectionError::UserManagementEnterpriseOnly))
+        if !self.connection.is_cloud() {
+            Err(Error::Connection(ConnectionError::UserManagementCloudOnly))
         } else {
             DatabaseManager::new(self.connection.clone())
                 .get(Self::SYSTEM_DB)

--- a/rust/tests/behaviour/connection/steps.rs
+++ b/rust/tests/behaviour/connection/steps.rs
@@ -34,7 +34,7 @@ generic_step_impl! {
 
     #[step(expr = "connection opens with authentication: {word}, {word}")]
     async fn connection_opens_with_authentication(context: &mut Context, login: String, password: String) {
-        let connection = Connection::new_enterprise(
+        let connection = Connection::new_cloud(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
             Credential::with_tls(
                 &login,

--- a/rust/tests/behaviour/mod.rs
+++ b/rust/tests/behaviour/mod.rs
@@ -100,7 +100,7 @@ impl Context {
         sleep(Context::STEP_REATTEMPT_SLEEP).await;
         self.session_options = Options::new();
         self.transaction_options = Options::new().infer(true);
-        self.set_connection(Connection::new_enterprise(
+        self.set_connection(Connection::new_cloud(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
             Credential::with_tls(Context::ADMIN_USERNAME, Context::ADMIN_PASSWORD, Some(&self.tls_root_ca))?,
         )?);
@@ -222,11 +222,11 @@ impl Context {
 impl Default for Context {
     fn default() -> Self {
         let tls_root_ca = PathBuf::from(
-            std::env::var("ROOT_CA").expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
+            std::env::var("ROOT_CA").expect("ROOT_CA environment variable needs to be set for cloud tests to run"),
         );
         let session_options = Options::new();
         let transaction_options = Options::new().infer(true);
-        let connection = Connection::new_enterprise(
+        let connection = Connection::new_cloud(
             &["localhost:11729", "localhost:21729", "localhost:31729"],
             Credential::with_tls(Context::ADMIN_USERNAME, Context::ADMIN_PASSWORD, Some(&tls_root_ca)).unwrap(),
         )

--- a/rust/tests/integration/common.rs
+++ b/rust/tests/integration/common.rs
@@ -39,8 +39,7 @@ pub fn new_cloud_connection() -> typedb_driver::Result<Connection> {
             "admin",
             "password",
             Some(&PathBuf::from(
-                std::env::var("ROOT_CA")
-                    .expect("ROOT_CA environment variable needs to be set for cloud tests to run"),
+                std::env::var("ROOT_CA").expect("ROOT_CA environment variable needs to be set for cloud tests to run"),
             )),
         )?,
     )

--- a/rust/tests/integration/common.rs
+++ b/rust/tests/integration/common.rs
@@ -32,15 +32,15 @@ pub fn new_core_connection() -> typedb_driver::Result<Connection> {
     Connection::new_core("0.0.0.0:1729")
 }
 
-pub fn new_enterprise_connection() -> typedb_driver::Result<Connection> {
-    Connection::new_enterprise(
+pub fn new_cloud_connection() -> typedb_driver::Result<Connection> {
+    Connection::new_cloud(
         &["localhost:11729", "localhost:21729", "localhost:31729"],
         Credential::with_tls(
             "admin",
             "password",
             Some(&PathBuf::from(
                 std::env::var("ROOT_CA")
-                    .expect("ROOT_CA environment variable needs to be set for enterprise tests to run"),
+                    .expect("ROOT_CA environment variable needs to be set for cloud tests to run"),
             )),
         )?,
     )

--- a/rust/tests/integration/logic.rs
+++ b/rust/tests/integration/logic.rs
@@ -40,7 +40,7 @@ use crate::test_for_each_arg;
 test_for_each_arg! {
     {
         core => common::new_core_connection().unwrap(),
-        enterprise => common::new_enterprise_connection().unwrap(),
+        cloud => common::new_cloud_connection().unwrap(),
     }
 
     async fn test_disjunction_explainable(connection: Connection) -> TypeDBResult {

--- a/rust/tests/integration/queries.rs
+++ b/rust/tests/integration/queries.rs
@@ -39,7 +39,7 @@ use crate::test_for_each_arg;
 test_for_each_arg! {
     {
         core => common::new_core_connection().unwrap(),
-        enterprise => common::new_enterprise_connection().unwrap(),
+        cloud => common::new_cloud_connection().unwrap(),
     }
 
     async fn basic(connection: Connection) -> typedb_driver::Result {

--- a/rust/tests/integration/runtimes.rs
+++ b/rust/tests/integration/runtimes.rs
@@ -29,7 +29,7 @@ use super::common;
 #[serial]
 fn basic_async_std() {
     async_std::task::block_on(async {
-        let connection = common::new_enterprise_connection()?;
+        let connection = common::new_cloud_connection()?;
         common::create_test_database_with_schema(connection.clone(), "define person sub entity;").await?;
         let databases = DatabaseManager::new(connection);
         assert!(databases.contains(common::TEST_DATABASE).await?);
@@ -50,7 +50,7 @@ fn basic_async_std() {
 #[serial]
 fn basic_smol() {
     smol::block_on(async {
-        let connection = common::new_enterprise_connection()?;
+        let connection = common::new_cloud_connection()?;
         common::create_test_database_with_schema(connection.clone(), "define person sub entity;").await?;
         let databases = DatabaseManager::new(connection);
         assert!(databases.contains(common::TEST_DATABASE).await?);
@@ -71,7 +71,7 @@ fn basic_smol() {
 #[serial]
 fn basic_futures() {
     futures::executor::block_on(async {
-        let connection = common::new_enterprise_connection()?;
+        let connection = common::new_cloud_connection()?;
         common::create_test_database_with_schema(connection.clone(), "define person sub entity;").await?;
         let databases = DatabaseManager::new(connection);
         assert!(databases.contains(common::TEST_DATABASE).await?);

--- a/tool/docs/nodejs/NodejsDocsParser.kt
+++ b/tool/docs/nodejs/NodejsDocsParser.kt
@@ -70,7 +70,7 @@ class NodejsDocParser : Callable<Unit> {
         val namespaceFunctions: HashMap<String, MutableList<Method>> = hashMapOf()
 
         // special case for namespace functions that we should parse
-        val namespaceFunctionsFilter = Regex(".*/functions/.*(coreDriver|enterpriseDriver).*")
+        val namespaceFunctionsFilter = Regex(".*/functions/.*(coreDriver|cloudDriver).*")
         File(inputDirectoryName).walkTopDown().filter {
             (it.toString().contains("/classes/") || it.toString().contains("/interfaces/")
                     || it.toString().contains("/modules/") || namespaceFunctionsFilter.matches(it.toString()))

--- a/tool/test/BUILD
+++ b/tool/test/BUILD
@@ -51,15 +51,15 @@ native_typedb_artifact(
 )
 
 native_typedb_artifact(
-    name = "native-typedb-enterprise-artifact",
+    name = "native-typedb-cloud-artifact",
     native_artifacts = {
-        "@vaticle_bazel_distribution//platform:is_linux_arm64": ["@vaticle_typedb_enterprise_artifact_linux-arm64//file"],
-        "@vaticle_bazel_distribution//platform:is_linux_x86_64": ["@vaticle_typedb_enterprise_artifact_linux-x86_64//file"],
-        "@vaticle_bazel_distribution//platform:is_mac_arm64": ["@vaticle_typedb_enterprise_artifact_mac-arm64//file"],
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64": ["@vaticle_typedb_enterprise_artifact_mac-x86_64//file"],
-        "@vaticle_bazel_distribution//platform:is_windows_x86_64": ["@vaticle_typedb_enterprise_artifact_windows-x86_64//file"],
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": ["@vaticle_typedb_cloud_artifact_linux-arm64//file"],
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": ["@vaticle_typedb_cloud_artifact_linux-x86_64//file"],
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": ["@vaticle_typedb_cloud_artifact_mac-arm64//file"],
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": ["@vaticle_typedb_cloud_artifact_mac-x86_64//file"],
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": ["@vaticle_typedb_cloud_artifact_windows-x86_64//file"],
     },
-    output = "typedb-enterprise-artifact.tar.gz",
+    output = "typedb-cloud-artifact.tar.gz",
     visibility = ["//visibility:public"],
 )
 
@@ -69,6 +69,6 @@ artifact_extractor(
 )
 
 artifact_extractor(
-    name = "typedb-enterprise-extractor",
-    artifact = ":native-typedb-enterprise-artifact",
+    name = "typedb-cloud-extractor",
+    artifact = ":native-typedb-cloud-artifact",
 )

--- a/tool/test/start-cloud-servers.sh
+++ b/tool/test/start-cloud-servers.sh
@@ -33,7 +33,7 @@ for i in $(seq 1 $NODE_COUNT); do
 done
 
 function server_start() {
-  JAVA_HOME=$BAZEL_JAVA_HOME ./${1}/typedb enterprise \
+  JAVA_HOME=$BAZEL_JAVA_HOME ./${1}/typedb server \
     --storage.data=server/data \
     --server.address=localhost:${1}1729 \
     --server.internal-address.zeromq=localhost:${1}1730 \
@@ -51,14 +51,14 @@ function server_start() {
     --server.encryption.file.internal-zmq.public-key=`realpath tool/test/resources/encryption/int-zmq-public-key`
 }
 
-rm -rf $(seq 1 $NODE_COUNT) typedb-enterprise-all
+rm -rf $(seq 1 $NODE_COUNT) typedb-cloud-all
 
-bazel run //tool/test:typedb-enterprise-extractor -- typedb-enterprise-all
+bazel run //tool/test:typedb-cloud-extractor -- typedb-cloud-all
 echo Successfully unarchived TypeDB distribution. Creating $NODE_COUNT copies.
 for i in $(seq 1 $NODE_COUNT); do
-  cp -r typedb-enterprise-all $i || exit 1
+  cp -r typedb-cloud-all $i || exit 1
 done
-echo Starting a enterprise consisting of $NODE_COUNT servers...
+echo Starting a cloud consisting of $NODE_COUNT servers...
 for i in $(seq 1 $NODE_COUNT); do
   server_start $i &
 done
@@ -72,7 +72,7 @@ RETRY_NUM=0
 while [[ $RETRY_NUM -lt $MAX_RETRIES ]]; do
   RETRY_NUM=$(($RETRY_NUM + 1))
   if [[ $(($RETRY_NUM % 4)) -eq 0 ]]; then
-    echo Waiting for TypeDB Enterprise servers to start \($(($RETRY_NUM / 2))s\)...
+    echo Waiting for TypeDB Cloud servers to start \($(($RETRY_NUM / 2))s\)...
   fi
   ALL_STARTED=1
   for i in $(seq 1 $NODE_COUNT); do
@@ -84,7 +84,7 @@ while [[ $RETRY_NUM -lt $MAX_RETRIES ]]; do
   sleep $POLL_INTERVAL_SECS
 done
 if (( ! $ALL_STARTED )); then
-  echo Failed to start one or more TypeDB Enterprise servers
+  echo Failed to start one or more TypeDB Cloud servers
   exit 1
 fi
-echo $NODE_COUNT TypeDB Enterprise database servers started
+echo $NODE_COUNT TypeDB Cloud database servers started

--- a/tool/test/stop-cloud-servers.sh
+++ b/tool/test/stop-cloud-servers.sh
@@ -22,7 +22,7 @@
 
 set -e
 
-procs=$(ps aux | awk '/TypeDBEnterpriseServe[r]/ {print $2}' | paste -sd " " -)
+procs=$(ps aux | awk '/TypeDBCloudServe[r]/ {print $2}' | paste -sd " " -)
 echo $procs
 if [ -n "$procs" ]; then
     kill $procs


### PR DESCRIPTION
## Usage and product changes

We replace the term 'enterprise' with 'cloud', to reflect the new consistent terminology used throughout Vaticle.
