### PR TITLE
C++ driver UX improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,14 +328,14 @@ commands:
           export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib
-          ( 
-            cd test_assembly_clib &&
+           
+          cd test_assembly_clib &&
             cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
             cmake --build . --config release
-          )       
+
           tool/test/start-core-server.sh
           sleep 3
-          (cd test_assembly_clib && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
+          cd test_assembly_clib && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
           tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
@@ -350,14 +350,14 @@ commands:
           export ASSEMBLY=typedb-driver-clib-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.zip --directory test_assembly_clib
-          ( 
-            cd test_assembly_clib &&
+
+          cd test_assembly_clib &&
             cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY  -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
             cmake --build . --config release
-          )
+          
           tool/test/start-core-server.sh
           sleep 3
-          (cd test_assembly_clib && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
+          cd test_assembly_clib && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
           tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
@@ -431,14 +431,14 @@ commands:
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.tar.gz --directory test_assembly_cpp
-          (
-            cd test_assembly_cpp &&
+          
+          cd test_assembly_cpp &&
             cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY && 
             cmake --build . --config release
-          )
+          
           tool/test/start-core-server.sh
           sleep 3
-          ( cd test_assembly_cpp && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
+          cd test_assembly_cpp && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
           tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
@@ -453,14 +453,14 @@ commands:
           export ASSEMBLY=typedb-driver-cpp-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.zip --directory test_assembly_cpp
-          (
-            cd test_assembly_cpp &&
+          
+          cd test_assembly_cpp &&
             cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
             cmake --build . --config release
-          )
+          
           tool/test/start-core-server.sh
           sleep 3
-          (cd test_assembly_cpp && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
+          cd test_assembly_cpp && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
           tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,7 +460,7 @@ commands:
           )
           tool/test/start-core-server.sh
           sleep 3
-          (cd test_assembly_cpp && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
+          (cd test_assembly_cpp && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
           tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,11 +328,9 @@ commands:
           export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib
-           
           cd test_assembly_clib &&
             cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
             cmake --build . --config release
-
           tool/test/start-core-server.sh
           sleep 3
           cd test_assembly_clib && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -350,11 +348,9 @@ commands:
           export ASSEMBLY=typedb-driver-clib-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.zip --directory test_assembly_clib
-
           cd test_assembly_clib &&
             cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY  -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
             cmake --build . --config release
-          
           tool/test/start-core-server.sh
           sleep 3
           cd test_assembly_clib && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -431,11 +427,9 @@ commands:
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.tar.gz --directory test_assembly_cpp
-          
           cd test_assembly_cpp &&
             cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY && 
             cmake --build . --config release
-          
           tool/test/start-core-server.sh
           sleep 3
           cd test_assembly_cpp && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
@@ -453,11 +447,9 @@ commands:
           export ASSEMBLY=typedb-driver-cpp-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.zip --directory test_assembly_cpp
-          
           cd test_assembly_cpp &&
             cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
             cmake --build . --config release
-          
           tool/test/start-core-server.sh
           sleep 3
           cd test_assembly_cpp && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1

--- a/c/src/answer.rs
+++ b/c/src/answer.rs
@@ -205,7 +205,7 @@ pub extern "C" fn concept_map_group_get_concept_maps(
 }
 
 #[no_mangle]
-pub extern "C" fn concept_map_group_to_string(concept_map_group: *const ConceptMapGroup) -> *const c_char {
+pub extern "C" fn concept_map_group_to_string(concept_map_group: *const ConceptMapGroup) -> *mut c_char {
     release_string(format!("{:?}", borrow(concept_map_group)))
 }
 
@@ -220,7 +220,7 @@ pub extern "C" fn value_group_drop(value_group: *mut ValueGroup) {
 }
 
 #[no_mangle]
-pub extern "C" fn value_group_to_string(value_group: *const ValueGroup) -> *const c_char {
+pub extern "C" fn value_group_to_string(value_group: *const ValueGroup) -> *mut c_char {
     release_string(format!("{:?}", borrow(value_group)))
 }
 

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -235,9 +235,11 @@ void transaction_on_close_register(const Transaction* transaction, TransactionCa
 
 %newobject concept_map_group_get_owner;
 %newobject concept_map_group_get_concept_maps;
+%newobject concept_map_group_to_string;
 
 %newobject value_group_get_owner;
 %newobject value_group_get_value;
+%newobject value_group_to_string;
 
 %newobject string_iterator_next;
 

--- a/cpp/include/typedb/answer/concept_map.hpp
+++ b/cpp/include/typedb/answer/concept_map.hpp
@@ -44,6 +44,7 @@ public:
     std::map<std::string, std::unique_ptr<Concept>> map();
     Explainables explainables();
     std::unique_ptr<Concept> get(const std::string& variableName);
+    std::string toString();
 
 private:
     NativePointer<_native::ConceptMap> conceptMapNative;

--- a/cpp/include/typedb/answer/concept_map_group.hpp
+++ b/cpp/include/typedb/answer/concept_map_group.hpp
@@ -39,6 +39,7 @@ public:
 
     std::unique_ptr<Concept> owner();
     ConceptMapIterable conceptMaps();
+    std::string toString();
 
 private:
     NativePointer<_native::ConceptMapGroup> conceptMapGroupNative;

--- a/cpp/include/typedb/answer/value_group.hpp
+++ b/cpp/include/typedb/answer/value_group.hpp
@@ -39,6 +39,7 @@ public:
 
     std::unique_ptr<Concept> owner();
     AggregateResult value();
+    std::string toString();
 
 private:
     NativePointer<_native::ValueGroup> valueGroupNative;

--- a/cpp/include/typedb/common/iterator.hpp
+++ b/cpp/include/typedb/common/iterator.hpp
@@ -41,6 +41,13 @@ class Iterator {  // Does not support range-based for loops yet.
     using SELF = Iterator<NATIVE_ITER, NATIVE_T, T>;
 
 public:
+
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using reference = T&;
+    using iterator_category = std::input_iterator_tag;
+
     Iterator(NATIVE_ITER* iteratorNative)
         : iteratorNative(iteratorNative, &HELPER::nativeIterDrop),
           obj() {}

--- a/cpp/include/typedb/concept/concept.hpp
+++ b/cpp/include/typedb/concept/concept.hpp
@@ -35,6 +35,7 @@ public:
     ~Annotation() = default;
     static Annotation key();
     static Annotation unique();
+    std::string toString();
 
     static const std::vector<Annotation> NONE;
 
@@ -137,6 +138,7 @@ public:
 
     Value* asValue();
 
+    std::string toString();
     bool operator==(const Concept& other);
     static bool equals(Concept* first, Concept* second);
 

--- a/cpp/include/typedb/concept/thing/thing.hpp
+++ b/cpp/include/typedb/concept/thing/thing.hpp
@@ -36,7 +36,7 @@ public:
     [[nodiscard]] VoidFuture setHas(Transaction& transaction, Attribute* attribute);
     [[nodiscard]] VoidFuture unsetHas(Transaction& transaction, Attribute* attribute);
 
-    ConceptIterable<Attribute> getHas(Transaction& transaction);
+    ConceptIterable<Attribute> getHas(Transaction& transaction, const std::initializer_list<Annotation>& annotations = {});
     ConceptIterable<Attribute> getHas(Transaction& transaction, const AttributeType* attribute);
     ConceptIterable<Attribute> getHas(Transaction& transaction, const std::vector<std::unique_ptr<AttributeType>>& attributeTypes);
     ConceptIterable<Attribute> getHas(Transaction& transaction, const std::vector<const AttributeType*>& attributeTypes);

--- a/cpp/include/typedb/concept/thing/thing.hpp
+++ b/cpp/include/typedb/concept/thing/thing.hpp
@@ -31,7 +31,7 @@ public:
     std::unique_ptr<ThingType> getType();
     bool isInferred();
     BoolFuture isDeleted(Transaction& transaction);
-    VoidFuture drop(Transaction& transaction);
+    VoidFuture deleteThing(Transaction& transaction);
 
     [[nodiscard]] VoidFuture setHas(Transaction& transaction, Attribute* attribute);
     [[nodiscard]] VoidFuture unsetHas(Transaction& transaction, Attribute* attribute);

--- a/cpp/include/typedb/concept/type/attribute_type.hpp
+++ b/cpp/include/typedb/concept/type/attribute_type.hpp
@@ -53,19 +53,15 @@ public:
     ConceptPtrFuture<Attribute> get(Transaction& transaction, DateTime value);
     OptionalStringFuture getRegex(Transaction& transaction);
 
-    ConceptIterable<AttributeType> getSubtypes(Transaction& transaction, ValueType valueType, Transitivity transitivity = Transitivity::TRANSITIVE);
     ConceptIterable<AttributeType> getSubtypes(Transaction& transaction, Transitivity transitivity = Transitivity::TRANSITIVE);  // Mimic overriding from Type
+    ConceptIterable<AttributeType> getSubtypes(Transaction& transaction, ValueType valueType, Transitivity transitivity = Transitivity::TRANSITIVE);
     ConceptIterable<Attribute> getInstances(Transaction& transaction, Transitivity transitivity = Transitivity::TRANSITIVE);
     ConceptIterable<ThingType> getOwners(Transaction& transaction, Transitivity transitivity = Transitivity::TRANSITIVE);
+    ConceptIterable<ThingType> getOwners(Transaction& transaction, const std::initializer_list<Annotation>& annotations, Transitivity transitivity = Transitivity::TRANSITIVE);
     ConceptIterable<ThingType> getOwners(Transaction& transaction, const std::vector<Annotation>& annotations, Transitivity transitivity = Transitivity::TRANSITIVE);
 
 private:
     AttributeType(_native::Concept* conceptNative);
-
-    ConceptPtrFuture<Attribute> putNative(Transaction& transaction, _native::Concept* valueNative);
-    ConceptPtrFuture<Attribute> putNativeAndFree(Transaction& transaction, _native::Concept* valueNative);
-    ConceptPtrFuture<Attribute> getNative(Transaction& transaction, _native::Concept* valueNative);
-    ConceptPtrFuture<Attribute> getNativeAndFree(Transaction& transaction, _native::Concept* valueNative);
 
     friend class ConceptFactory;
 };

--- a/cpp/include/typedb/concept/type/role_type.hpp
+++ b/cpp/include/typedb/concept/type/role_type.hpp
@@ -34,7 +34,7 @@ public:
     [[nodiscard]] virtual VoidFuture setLabel(Transaction& transaction, const std::string& newLabel) override;
     virtual bool isAbstract() override;
 
-    [[nodiscard]] virtual VoidFuture drop(Transaction& transaction) override;
+    [[nodiscard]] virtual VoidFuture deleteType(Transaction& transaction) override;
     [[nodiscard]] virtual BoolFuture isDeleted(Transaction& transaction) override;
 
     // Mimic overriding from Type

--- a/cpp/include/typedb/concept/type/thing_type.hpp
+++ b/cpp/include/typedb/concept/type/thing_type.hpp
@@ -32,7 +32,7 @@ public:
     bool isRoot();
     virtual bool isAbstract() override;
     virtual BoolFuture isDeleted(Transaction& transaction) override;
-    [[nodiscard]] virtual VoidFuture drop(Transaction& transaction) override;
+    [[nodiscard]] virtual VoidFuture deleteType(Transaction& transaction) override;
 
     [[nodiscard]] VoidFuture setAbstract(Transaction& transaction);
     [[nodiscard]] VoidFuture unsetAbstract(Transaction& transaction);

--- a/cpp/include/typedb/concept/type/thing_type.hpp
+++ b/cpp/include/typedb/concept/type/thing_type.hpp
@@ -37,9 +37,9 @@ public:
     [[nodiscard]] VoidFuture setAbstract(Transaction& transaction);
     [[nodiscard]] VoidFuture unsetAbstract(Transaction& transaction);
 
-    [[nodiscard]] VoidFuture setOwns(Transaction& transaction, AttributeType* attributeType);
+    [[nodiscard]] VoidFuture setOwns(Transaction& transaction, AttributeType* attributeType, const std::initializer_list<Annotation>& annotations = {});
     [[nodiscard]] VoidFuture setOwns(Transaction& transaction, AttributeType* attributeType, const std::vector<Annotation>& annotations);
-    [[nodiscard]] VoidFuture setOwns(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType);
+    [[nodiscard]] VoidFuture setOwns(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType, const std::initializer_list<Annotation>& annotations = {});
     [[nodiscard]] VoidFuture setOwns(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType, const std::vector<Annotation>& annotations);
     [[nodiscard]] VoidFuture unsetOwns(Transaction& transaction, AttributeType* attributeType);
 
@@ -51,8 +51,10 @@ public:
     ConceptPtrFuture<RoleType> getPlaysOverridden(Transaction& transaction, RoleType* roleType);
 
     ConceptIterable<AttributeType> getOwns(Transaction& transaction, Transitivity transitivity = Transitivity::TRANSITIVE);
-    ConceptIterable<AttributeType> getOwns(Transaction& transaction, ValueType valueType, Transitivity transitivity = Transitivity::TRANSITIVE);
+    ConceptIterable<AttributeType> getOwns(Transaction& transaction, const std::initializer_list<Annotation>& annotations, Transitivity transitivity = Transitivity::TRANSITIVE);
     ConceptIterable<AttributeType> getOwns(Transaction& transaction, const std::vector<Annotation>& annotations, Transitivity transitivity = Transitivity::TRANSITIVE);
+    ConceptIterable<AttributeType> getOwns(Transaction& transaction, ValueType valueType, Transitivity transitivity = Transitivity::TRANSITIVE);
+    ConceptIterable<AttributeType> getOwns(Transaction& transaction, ValueType valueType, const std::initializer_list<Annotation>& annotations, Transitivity transitivity = Transitivity::TRANSITIVE);
     ConceptIterable<AttributeType> getOwns(Transaction& transaction, ValueType valueType, const std::vector<Annotation>& annotations, Transitivity transitivity = Transitivity::TRANSITIVE);
     ConceptPtrFuture<AttributeType> getOwnsOverridden(Transaction& transaction, AttributeType* attributeType);
 
@@ -65,10 +67,6 @@ public:
 
 protected:
     ThingType(ConceptType conceptType, _native::Concept* conceptNative);
-
-private:
-    VoidFuture setOwnsNative(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenTypeNative, const std::vector<Annotation>& annotations);
-    ConceptIterable<AttributeType> getOwnsNative(Transaction& transaction, ValueType* valueType, const std::vector<Annotation>& annotations, Transitivity transitivity);
 
     friend class ConceptFactory;
 };

--- a/cpp/include/typedb/concept/type/type.hpp
+++ b/cpp/include/typedb/concept/type/type.hpp
@@ -36,7 +36,7 @@ public:
     [[nodiscard]] virtual VoidFuture setLabel(Transaction& transaction, const std::string& newLabel) = 0;
 
     virtual BoolFuture isDeleted(Transaction& transaction) = 0;
-    [[nodiscard]] virtual VoidFuture drop(Transaction& transaction) = 0;
+    [[nodiscard]] virtual VoidFuture deleteType(Transaction& transaction) = 0;
 
 protected:
     Type(ConceptType conceptType, _native::Concept* conceptNative);

--- a/cpp/include/typedb/connection/driver.hpp
+++ b/cpp/include/typedb/connection/driver.hpp
@@ -55,6 +55,7 @@ public:
     DatabaseManager databases;
     UserManager users;
 
+    static void initLogging();
     static Driver coreDriver(const std::string& coreAddress);
     static Driver cloudDriver(const std::vector<std::string>& cloudAddresses, const Credential& credential);
 

--- a/cpp/include/typedb/database/database.hpp
+++ b/cpp/include/typedb/database/database.hpp
@@ -62,7 +62,7 @@ public:
 
     std::string name() const;
     ReplicaInfoIterable replicas();
-    void drop();
+    void deleteDatabase();
 
 private:
     NativePointer<_native::Database> databaseNative;

--- a/cpp/include/typedb/logic/explainable.hpp
+++ b/cpp/include/typedb/logic/explainable.hpp
@@ -81,7 +81,7 @@ public:
     StringIterable relations();
     StringIterable attributes();
     OwnerAttributePairIterable ownerships();
-
+    std::string toString();
 
 private:
     NativePointer<_native::Explainables> explainablesNative;

--- a/cpp/include/typedb/logic/explanation.hpp
+++ b/cpp/include/typedb/logic/explanation.hpp
@@ -35,6 +35,7 @@ public:
     Rule rule();
     ConceptMap conclusion();
     ConceptMap condition();
+    std::string toString();
 
 private:
     Explanation(_native::Explanation*);

--- a/cpp/include/typedb/logic/rule.hpp
+++ b/cpp/include/typedb/logic/rule.hpp
@@ -46,6 +46,7 @@ public:
     std::string label();
     std::string when();
     std::string then();
+    std::string toString();
 
 private:
     Rule(_native::Rule*);

--- a/cpp/include/typedb/query/query_manager.hpp
+++ b/cpp/include/typedb/query/query_manager.hpp
@@ -43,30 +43,17 @@ class Transaction;
 class QueryManager {
 public:
     ~QueryManager() = default;
-
-    [[nodiscard]] VoidFuture define(const std::string& query) const;
-    [[nodiscard]] VoidFuture undefine(const std::string& query) const;
-    [[nodiscard]] ConceptMapIterable get(const std::string& query) const;
-    [[nodiscard]] JSONIterable fetch(const std::string& query) const;
-    [[nodiscard]] ConceptMapIterable insert(const std::string& query) const;
-    [[nodiscard]] VoidFuture matchDelete(const std::string& query) const;
-    [[nodiscard]] ConceptMapIterable update(const std::string& query) const;
-    [[nodiscard]] AggregateFuture getAggregate(const std::string& query) const;
-    [[nodiscard]] ConceptMapGroupIterable getGroup(const std::string& query) const;
-    [[nodiscard]] ValueGroupIterable getGroupAggregate(const std::string& query) const;
-    [[nodiscard]] ExplanationIterable explain(const Explainable& explainable) const;
-
-    [[nodiscard]] VoidFuture define(const std::string& query, const Options& options) const;
-    [[nodiscard]] VoidFuture undefine(const std::string& query, const Options& options) const;
-    [[nodiscard]] ConceptMapIterable get(const std::string& query, const Options& options) const;
-    [[nodiscard]] JSONIterable fetch(const std::string& query, const Options& options) const;
-    [[nodiscard]] ConceptMapIterable insert(const std::string& query, const Options& options) const;
-    [[nodiscard]] VoidFuture matchDelete(const std::string& query, const Options& options) const;
-    [[nodiscard]] ConceptMapIterable update(const std::string& query, const Options& options) const;
-    [[nodiscard]] AggregateFuture getAggregate(const std::string& query, const Options& options) const;
-    [[nodiscard]] ConceptMapGroupIterable getGroup(const std::string& query, const Options& options) const;
-    [[nodiscard]] ValueGroupIterable getGroupAggregate(const std::string& query, const Options& options) const;
-    [[nodiscard]] ExplanationIterable explain(const Explainable& explainable, const Options& options) const;
+    [[nodiscard]] VoidFuture define(const std::string& query, const Options& options = Options()) const;
+    [[nodiscard]] VoidFuture undefine(const std::string& query, const Options& options = Options()) const;
+    [[nodiscard]] ConceptMapIterable get(const std::string& query, const Options& options = Options()) const;
+    [[nodiscard]] JSONIterable fetch(const std::string& query, const Options& options = Options()) const;
+    [[nodiscard]] ConceptMapIterable insert(const std::string& query, const Options& options = Options()) const;
+    [[nodiscard]] VoidFuture matchDelete(const std::string& query, const Options& options = Options()) const;
+    [[nodiscard]] ConceptMapIterable update(const std::string& query, const Options&  = Options()) const;
+    [[nodiscard]] AggregateFuture getAggregate(const std::string& query, const Options&  = Options()) const;
+    [[nodiscard]] ConceptMapGroupIterable getGroup(const std::string& query, const Options&  = Options()) const;
+    [[nodiscard]] ValueGroupIterable getGroupAggregate(const std::string& query, const Options&  = Options()) const;
+    [[nodiscard]] ExplanationIterable explain(const Explainable& explainable, const Options&  = Options()) const;
 
 private:
     TypeDB::Transaction* const transaction;

--- a/cpp/include/typedb/query/query_manager.hpp
+++ b/cpp/include/typedb/query/query_manager.hpp
@@ -49,11 +49,11 @@ public:
     [[nodiscard]] JSONIterable fetch(const std::string& query, const Options& options = Options()) const;
     [[nodiscard]] ConceptMapIterable insert(const std::string& query, const Options& options = Options()) const;
     [[nodiscard]] VoidFuture matchDelete(const std::string& query, const Options& options = Options()) const;
-    [[nodiscard]] ConceptMapIterable update(const std::string& query, const Options&  = Options()) const;
-    [[nodiscard]] AggregateFuture getAggregate(const std::string& query, const Options&  = Options()) const;
-    [[nodiscard]] ConceptMapGroupIterable getGroup(const std::string& query, const Options&  = Options()) const;
-    [[nodiscard]] ValueGroupIterable getGroupAggregate(const std::string& query, const Options&  = Options()) const;
-    [[nodiscard]] ExplanationIterable explain(const Explainable& explainable, const Options&  = Options()) const;
+    [[nodiscard]] ConceptMapIterable update(const std::string& query, const Options& = Options()) const;
+    [[nodiscard]] AggregateFuture getAggregate(const std::string& query, const Options& = Options()) const;
+    [[nodiscard]] ConceptMapGroupIterable getGroup(const std::string& query, const Options& = Options()) const;
+    [[nodiscard]] ValueGroupIterable getGroupAggregate(const std::string& query, const Options& = Options()) const;
+    [[nodiscard]] ExplanationIterable explain(const Explainable& explainable, const Options& = Options()) const;
 
 private:
     TypeDB::Transaction* const transaction;

--- a/cpp/include/typedb/query/query_manager.hpp
+++ b/cpp/include/typedb/query/query_manager.hpp
@@ -44,6 +44,18 @@ class QueryManager {
 public:
     ~QueryManager() = default;
 
+    [[nodiscard]] VoidFuture define(const std::string& query) const;
+    [[nodiscard]] VoidFuture undefine(const std::string& query) const;
+    [[nodiscard]] ConceptMapIterable get(const std::string& query) const;
+    [[nodiscard]] JSONIterable fetch(const std::string& query) const;
+    [[nodiscard]] ConceptMapIterable insert(const std::string& query) const;
+    [[nodiscard]] VoidFuture matchDelete(const std::string& query) const;
+    [[nodiscard]] ConceptMapIterable update(const std::string& query) const;
+    [[nodiscard]] AggregateFuture getAggregate(const std::string& query) const;
+    [[nodiscard]] ConceptMapGroupIterable getGroup(const std::string& query) const;
+    [[nodiscard]] ValueGroupIterable getGroupAggregate(const std::string& query) const;
+    [[nodiscard]] ExplanationIterable explain(const Explainable& explainable) const;
+
     [[nodiscard]] VoidFuture define(const std::string& query, const Options& options) const;
     [[nodiscard]] VoidFuture undefine(const std::string& query, const Options& options) const;
     [[nodiscard]] ConceptMapIterable get(const std::string& query, const Options& options) const;

--- a/cpp/include/typedb/user/user_manager.hpp
+++ b/cpp/include/typedb/user/user_manager.hpp
@@ -36,7 +36,7 @@ public:
 
     bool contains(const std::string& username) const;
     void create(const std::string& username, const std::string& password) const;
-    void drop(const std::string& username) const;
+    void deleteUser(const std::string& username) const;
     UserIterable all() const;
     std::unique_ptr<User> get(const std::string& username) const;
     void passwordSet(const std::string& username, const std::string& password) const;

--- a/cpp/lib/answer/concept_map.cpp
+++ b/cpp/lib/answer/concept_map.cpp
@@ -66,6 +66,10 @@ std::unique_ptr<Concept> ConceptMap::get(const std::string& variableName) {
     return ConceptFactory::ofNative(p);
 }
 
+std::string ConceptMap::toString() {
+    TO_STRING(conceptMapNative, _native::concept_map_to_string);
+}
+
 // ConceptMapIterator
 TYPEDB_ITERATOR_HELPER(
     _native::ConceptMapIterator,

--- a/cpp/lib/answer/concept_map_group.cpp
+++ b/cpp/lib/answer/concept_map_group.cpp
@@ -41,6 +41,10 @@ ConceptMapIterable ConceptMapGroup::conceptMaps() {
     WRAPPED_NATIVE_CALL(ConceptMapIterable, _native::concept_map_group_get_concept_maps(conceptMapGroupNative.get()));
 }
 
+std::string ConceptMapGroup::toString() {
+    TO_STRING(conceptMapGroupNative, _native::concept_map_group_to_string);
+}
+
 // For ConceptMapGroupIterator
 TYPEDB_ITERATOR_HELPER(
     _native::ConceptMapGroupIterator,

--- a/cpp/lib/answer/value_group.cpp
+++ b/cpp/lib/answer/value_group.cpp
@@ -47,6 +47,10 @@ AggregateResult ValueGroup::value() {
     }
 }
 
+std::string ValueGroup::toString() {
+    TO_STRING(valueGroupNative, _native::value_group_to_string);
+}
+
 // For ValueGroupIterator
 TYPEDB_ITERATOR_HELPER(
     _native::ValueGroupIterator,

--- a/cpp/lib/common/macros.hpp
+++ b/cpp/lib/common/macros.hpp
@@ -90,4 +90,8 @@
 
 #define CONCEPTAPI_ITER(RET_TYPE, NATIVE_CALL) CONCEPTAPI_CALL(ConceptIterable<RET_TYPE>, new ConceptIteratorWrapperSimple(NATIVE_CALL))
 
-#define TO_STRING(NATIVE_PTR, NATIVE_FN) { CHECK_NATIVE(NATIVE_PTR); return Utils::stringFromNative(NATIVE_FN(NATIVE_PTR.get())); }
+#define TO_STRING(NATIVE_PTR, NATIVE_FN)                             \
+    {                                                                \
+        CHECK_NATIVE(NATIVE_PTR);                                    \
+        return Utils::stringFromNative(NATIVE_FN(NATIVE_PTR.get())); \
+    }

--- a/cpp/lib/common/macros.hpp
+++ b/cpp/lib/common/macros.hpp
@@ -89,3 +89,5 @@
 #define CONCEPTAPI_FUTURE(RET_TYPE, NATIVE_CALL) CONCEPTAPI_CALL(ConceptPtrFuture<RET_TYPE>, new ConceptFutureWrapperSimple(NATIVE_CALL))
 
 #define CONCEPTAPI_ITER(RET_TYPE, NATIVE_CALL) CONCEPTAPI_CALL(ConceptIterable<RET_TYPE>, new ConceptIteratorWrapperSimple(NATIVE_CALL))
+
+#define TO_STRING(NATIVE_PTR, NATIVE_FN) { CHECK_NATIVE(NATIVE_PTR); return Utils::stringFromNative(NATIVE_FN(NATIVE_PTR.get())); }

--- a/cpp/lib/common/utils.cpp
+++ b/cpp/lib/common/utils.cpp
@@ -27,7 +27,7 @@
 namespace TypeDB {
 namespace Utils {
 
-std::string stringFromNative(char* c) {
+std::string stringFromNative(const char* c) {
     std::string s(c);
     _native::string_free(c);
     return s;

--- a/cpp/lib/common/utils.cpp
+++ b/cpp/lib/common/utils.cpp
@@ -27,7 +27,7 @@
 namespace TypeDB {
 namespace Utils {
 
-std::string stringFromNative(const char* c) {
+std::string stringFromNative(char* c) {
     std::string s(c);
     _native::string_free(c);
     return s;

--- a/cpp/lib/common/utils.hpp
+++ b/cpp/lib/common/utils.hpp
@@ -28,7 +28,7 @@
 namespace TypeDB {
 namespace Utils {
 
-std::string stringFromNative(char* c);
+std::string stringFromNative(const char* c);
 
 template <class... Args>
 DriverException exception(const ErrorMessage& errMsg, Args... args) {

--- a/cpp/lib/common/utils.hpp
+++ b/cpp/lib/common/utils.hpp
@@ -28,7 +28,7 @@
 namespace TypeDB {
 namespace Utils {
 
-std::string stringFromNative(const char* c);
+std::string stringFromNative(char* c);
 
 template <class... Args>
 DriverException exception(const ErrorMessage& errMsg, Args... args) {
@@ -39,7 +39,6 @@ DriverException exception(const ErrorMessage& errMsg, Args... args) {
     delete[] buffer;
     return exception;
 }
-
 
 }  // namespace Utils
 }  // namespace TypeDB

--- a/cpp/lib/concept/concept.cpp
+++ b/cpp/lib/concept/concept.cpp
@@ -22,6 +22,7 @@
 #include "typedb/concept/concept.hpp"
 #include "typedb/common/exception.hpp"
 
+#include "../common/macros.hpp"
 #include "../common/native.hpp"
 #include "../common/utils.hpp"
 #include "./concept_factory.hpp"
@@ -62,6 +63,10 @@ Annotation Annotation::key() {
 }
 Annotation Annotation::unique() {
     return Annotation(_native::annotation_new_unique());
+}
+
+std::string Annotation::toString() {
+    TO_STRING(annotationNative, _native::annotation_to_string);
 }
 
 const std::vector<Annotation> Annotation::NONE = {};
@@ -184,6 +189,10 @@ Relation* Concept::asRelation() {
 Value* Concept::asValue() {
     if (!isValue()) throw Utils::exception(ConceptError::INVALID_CONCEPT_CASTING, ConceptTypeNames[(int)conceptType], ConceptTypeNames[(int)ConceptType::VALUE]);
     return dynamic_cast<Value*>(this);
+}
+
+std::string Concept::toString() {
+    TO_STRING(conceptNative, _native::concept_to_string);
 }
 
 bool Concept::operator==(const Concept& other) {

--- a/cpp/lib/concept/concept.cpp
+++ b/cpp/lib/concept/concept.cpp
@@ -69,8 +69,6 @@ std::string Annotation::toString() {
     TO_STRING(annotationNative, _native::annotation_to_string);
 }
 
-const std::vector<Annotation> Annotation::NONE = {};
-
 std::unique_ptr<Concept> Concept::ofNative(_native::Concept* conceptNative) {
     return ConceptFactory::ofNative(conceptNative);
 }

--- a/cpp/lib/concept/concept_factory.cpp
+++ b/cpp/lib/concept/concept_factory.cpp
@@ -60,16 +60,25 @@ _native::Concept* ConceptFactory::getNative(const Concept* concept) {
     return concept->conceptNative.get();
 }
 
-_native::Annotation* ConceptFactory::getNative(const Annotation& annotation) {
-    CHECK_NATIVE(annotation.annotationNative);
-    return annotation.annotationNative.get();
+_native::Annotation* ConceptFactory::getNative(const Annotation* annotation) {
+    CHECK_NATIVE(annotation->annotationNative);
+    return annotation->annotationNative.get();
 }
 
-std::vector<const _native::Annotation*> ConceptFactory::toNativeArray(const std::vector<Annotation>& annotations) {
+std::vector<const _native::Annotation*> ConceptFactory::nativeAnnotationArray(const std::vector<Annotation>* annotations) {
     std::vector<const _native::Annotation*> nativeAnnotations;
-    nativeAnnotations.reserve(annotations.size() + 1);
-    for (auto& annotation : annotations)
-        nativeAnnotations.push_back(ConceptFactory::getNative(annotation));
+    nativeAnnotations.reserve(annotations->size() + 1);
+    for (auto& annotation : *annotations)
+        nativeAnnotations.push_back(ConceptFactory::getNative(&annotation));
+    nativeAnnotations.push_back(nullptr);
+    return nativeAnnotations;
+}
+
+std::vector<const _native::Annotation*> ConceptFactory::nativeAnnotationArray(const std::initializer_list<Annotation>* annotations) {
+    std::vector<const _native::Annotation*> nativeAnnotations;
+    nativeAnnotations.reserve(annotations->size() + 1);
+    for (auto& annotation : *annotations)
+        nativeAnnotations.push_back(ConceptFactory::getNative(&annotation));
     nativeAnnotations.push_back(nullptr);
     return nativeAnnotations;
 }

--- a/cpp/lib/concept/concept_factory.hpp
+++ b/cpp/lib/concept/concept_factory.hpp
@@ -52,11 +52,12 @@ public:
     // for concept api methods.
     static _native::Transaction* getNative(Transaction&);
     static _native::Concept* getNative(const Concept*);
-    static _native::Annotation* getNative(const Annotation& annotation);
-    static std::vector<const _native::Annotation*> toNativeArray(const std::vector<Annotation>& annotations);
+    static _native::Annotation* getNative(const Annotation* annotation);
+    static std::vector<const _native::Annotation*> nativeAnnotationArray(const std::vector<Annotation>* annotations);
+    static std::vector<const _native::Annotation*> nativeAnnotationArray(const std::initializer_list<Annotation>* annotations);
 
     template <typename T>
-    static std::vector<_native::Concept*> toNativeArray(const std::vector<T*>& concepts) {
+    static std::vector<_native::Concept*> nativeConceptArray(const std::vector<T*>& concepts) {
         std::vector<_native::Concept*> v;
         v.reserve(concepts.size() + 1);
         for (auto& c : concepts)
@@ -66,7 +67,7 @@ public:
     }
 
     template <typename T>
-    static std::vector<_native::Concept*> toNativeArray(const std::vector<std::unique_ptr<T>>& concepts) {
+    static std::vector<_native::Concept*> nativeConceptArray(const std::vector<std::unique_ptr<T>>& concepts) {
         std::vector<_native::Concept*> v;
         v.reserve(concepts.size() + 1);
         for (auto& c : concepts)

--- a/cpp/lib/concept/thing/relation.cpp
+++ b/cpp/lib/concept/thing/relation.cpp
@@ -57,11 +57,11 @@ VoidFuture Relation::removePlayer(Transaction& transaction, RoleType* roleType, 
 }
 
 ConceptIterable<Thing> Relation::getPlayersByRoleType(Transaction& transaction, const std::vector<RoleType*>& roleTypes) {
-    CONCEPTAPI_ITER(Thing, _native::relation_get_players_by_role_type(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::toNativeArray(roleTypes).data()));
+    CONCEPTAPI_ITER(Thing, _native::relation_get_players_by_role_type(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::nativeConceptArray(roleTypes).data()));
 }
 
 ConceptIterable<Thing> Relation::getPlayersByRoleType(Transaction& transaction, const std::vector<std::unique_ptr<RoleType>>& roleTypes) {
-    CONCEPTAPI_ITER(Thing, _native::relation_get_players_by_role_type(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::toNativeArray(roleTypes).data()));
+    CONCEPTAPI_ITER(Thing, _native::relation_get_players_by_role_type(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::nativeConceptArray(roleTypes).data()));
 }
 
 std::map<std::unique_ptr<RoleType>, std::unique_ptr<Thing>> Relation::getPlayers(Transaction& transaction) {

--- a/cpp/lib/concept/thing/thing.cpp
+++ b/cpp/lib/concept/thing/thing.cpp
@@ -47,7 +47,7 @@ bool Thing::isInferred() {
     return _native::thing_get_is_inferred(conceptNative.get());
 }
 
-VoidFuture Thing::drop(Transaction& transaction){
+VoidFuture Thing::deleteThing(Transaction& transaction){
     CONCEPTAPI_CALL(VoidFuture, _native::thing_delete(ConceptFactory::getNative(transaction), conceptNative.get()))}
 
 BoolFuture Thing::isDeleted(Transaction& transaction){

--- a/cpp/lib/concept/thing/thing.cpp
+++ b/cpp/lib/concept/thing/thing.cpp
@@ -53,8 +53,9 @@ VoidFuture Thing::deleteThing(Transaction& transaction){
 BoolFuture Thing::isDeleted(Transaction& transaction){
     CONCEPTAPI_CALL(BoolFuture, _native::thing_is_deleted(ConceptFactory::getNative(transaction), conceptNative.get()))}
 
-ConceptIterable<Attribute> Thing::getHas(Transaction& transaction) {
-    return getHas(transaction, Annotation::NONE);
+ConceptIterable<Attribute> Thing::getHas(Transaction& transaction, const std::initializer_list<Annotation>& annotations) {
+    const _native::Concept* nativeConcepts[1] = {nullptr};
+    CONCEPTAPI_ITER(Attribute, _native::thing_get_has(ConceptFactory::getNative(transaction), conceptNative.get(), nativeConcepts, ConceptFactory::nativeAnnotationArray(&annotations).data()));
 }
 
 ConceptIterable<Attribute> Thing::getHas(Transaction& transaction, const AttributeType* attribute) {
@@ -65,18 +66,17 @@ ConceptIterable<Attribute> Thing::getHas(Transaction& transaction, const Attribu
 
 ConceptIterable<Attribute> Thing::getHas(Transaction& transaction, const std::vector<const AttributeType*>& attributeTypes) {
     const _native::Annotation* nativeAnnotations[1] = {nullptr};
-    CONCEPTAPI_ITER(Attribute, _native::thing_get_has(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::toNativeArray(attributeTypes).data(), nativeAnnotations));
+    CONCEPTAPI_ITER(Attribute, _native::thing_get_has(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::nativeConceptArray(attributeTypes).data(), nativeAnnotations));
 }
 
 ConceptIterable<Attribute> Thing::getHas(Transaction& transaction, const std::vector<std::unique_ptr<AttributeType>>& attributeTypes) {
     const _native::Annotation* nativeAnnotations[1] = {nullptr};
-    CONCEPTAPI_ITER(Attribute, _native::thing_get_has(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::toNativeArray(attributeTypes).data(), nativeAnnotations));
+    CONCEPTAPI_ITER(Attribute, _native::thing_get_has(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::nativeConceptArray(attributeTypes).data(), nativeAnnotations));
 }
-
 
 ConceptIterable<Attribute> Thing::getHas(Transaction& transaction, const std::vector<Annotation>& annotations) {
     const _native::Concept* nativeConcepts[1] = {nullptr};
-    CONCEPTAPI_ITER(Attribute, _native::thing_get_has(ConceptFactory::getNative(transaction), conceptNative.get(), nativeConcepts, ConceptFactory::toNativeArray(annotations).data()));
+    CONCEPTAPI_ITER(Attribute, _native::thing_get_has(ConceptFactory::getNative(transaction), conceptNative.get(), nativeConcepts, ConceptFactory::nativeAnnotationArray(&annotations).data()));
 }
 
 VoidFuture Thing::setHas(Transaction& transaction, Attribute* attribute) {
@@ -93,11 +93,11 @@ ConceptIterable<Relation> Thing::getRelations(Transaction& transaction) {
 }
 
 ConceptIterable<Relation> Thing::getRelations(Transaction& transaction, const std::vector<RoleType*>& roleTypes) {
-    CONCEPTAPI_ITER(Relation, _native::thing_get_relations(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::toNativeArray(roleTypes).data()));
+    CONCEPTAPI_ITER(Relation, _native::thing_get_relations(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::nativeConceptArray(roleTypes).data()));
 }
 
 ConceptIterable<Relation> Thing::getRelations(Transaction& transaction, const std::vector<std::unique_ptr<RoleType>>& roleTypes) {
-    CONCEPTAPI_ITER(Relation, _native::thing_get_relations(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::toNativeArray(roleTypes).data()));
+    CONCEPTAPI_ITER(Relation, _native::thing_get_relations(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::nativeConceptArray(roleTypes).data()));
 }
 
 ConceptIterable<RoleType> Thing::getPlaying(Transaction& transaction) {

--- a/cpp/lib/concept/type/attribute_type.cpp
+++ b/cpp/lib/concept/type/attribute_type.cpp
@@ -30,6 +30,11 @@
 
 namespace TypeDB {
 
+ConceptPtrFuture<Attribute> putNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative);
+ConceptPtrFuture<Attribute> putNativeAndFree(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative);
+ConceptPtrFuture<Attribute> getNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative);
+ConceptPtrFuture<Attribute> getNativeAndFree(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative);
+
 // AttributeType
 AttributeType::AttributeType(_native::Concept* conceptNative)
     : ThingType(ConceptType::ATTRIBUTE_TYPE, conceptNative) {}
@@ -41,51 +46,51 @@ ValueType AttributeType::getValueType() {
 
 ConceptPtrFuture<Attribute> AttributeType::put(Transaction& transaction, Value* value) {
     CHECK_NATIVE(value);
-    return putNative(transaction, ConceptFactory::getNative(value));
+    return putNative(conceptNative, transaction, ConceptFactory::getNative(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::put(Transaction& transaction, const std::string& value) {
-    return putNativeAndFree(transaction, _native::value_new_string(value.c_str()));
+    return putNativeAndFree(conceptNative, transaction, _native::value_new_string(value.c_str()));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::put(Transaction& transaction, int64_t value) {
-    return putNativeAndFree(transaction, _native::value_new_long(value));
+    return putNativeAndFree(conceptNative, transaction, _native::value_new_long(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::put(Transaction& transaction, double value) {
-    return putNativeAndFree(transaction, _native::value_new_double(value));
+    return putNativeAndFree(conceptNative, transaction, _native::value_new_double(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::put(Transaction& transaction, bool value) {
-    return putNativeAndFree(transaction, _native::value_new_boolean(value));
+    return putNativeAndFree(conceptNative, transaction, _native::value_new_boolean(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::put(Transaction& transaction, DateTime value) {
-    return putNativeAndFree(transaction, _native::value_new_date_time_from_millis(value.time_since_epoch().count()));
+    return putNativeAndFree(conceptNative, transaction, _native::value_new_date_time_from_millis(value.time_since_epoch().count()));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::get(Transaction& transaction, Value* value) {
-    return getNative(transaction, ConceptFactory::getNative(value));
+    return getNative(conceptNative, transaction, ConceptFactory::getNative(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::get(Transaction& transaction, const std::string& value) {
-    return getNativeAndFree(transaction, _native::value_new_string(value.c_str()));
+    return getNativeAndFree(conceptNative, transaction, _native::value_new_string(value.c_str()));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::get(Transaction& transaction, int64_t value) {
-    return getNativeAndFree(transaction, _native::value_new_long(value));
+    return getNativeAndFree(conceptNative, transaction, _native::value_new_long(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::get(Transaction& transaction, double value) {
-    return getNativeAndFree(transaction, _native::value_new_double(value));
+    return getNativeAndFree(conceptNative, transaction, _native::value_new_double(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::get(Transaction& transaction, bool value) {
-    return getNativeAndFree(transaction, _native::value_new_boolean(value));
+    return getNativeAndFree(conceptNative, transaction, _native::value_new_boolean(value));
 }
 
 ConceptPtrFuture<Attribute> AttributeType::get(Transaction& transaction, DateTime value) {
-    return getNativeAndFree(transaction, _native::value_new_date_time_from_millis(value.time_since_epoch().count()));
+    return getNativeAndFree(conceptNative, transaction, _native::value_new_date_time_from_millis(value.time_since_epoch().count()));
 }
 
 OptionalStringFuture AttributeType::getRegex(Transaction& transaction) {
@@ -125,24 +130,29 @@ ConceptIterable<ThingType> AttributeType::getOwners(Transaction& transaction, Tr
 
 ConceptIterable<ThingType> AttributeType::getOwners(Transaction& transaction, const std::vector<Annotation>& annotations, Transitivity transitivity) {
     CONCEPTAPI_ITER(ThingType,
-                    _native::attribute_type_get_owners(ConceptFactory::getNative(transaction), conceptNative.get(), (_native::Transitivity)transitivity, ConceptFactory::toNativeArray(annotations).data()));
+                    _native::attribute_type_get_owners(ConceptFactory::getNative(transaction), conceptNative.get(), (_native::Transitivity)transitivity, ConceptFactory::nativeAnnotationArray(&annotations).data()));
 }
 
-ConceptPtrFuture<Attribute> AttributeType::putNative(Transaction& transaction, _native::Concept* valueNative) {
+ConceptIterable<ThingType> AttributeType::getOwners(Transaction& transaction, const std::initializer_list<Annotation>& annotations, Transitivity transitivity) {
+    CONCEPTAPI_ITER(ThingType,
+                    _native::attribute_type_get_owners(ConceptFactory::getNative(transaction), conceptNative.get(), (_native::Transitivity)transitivity, ConceptFactory::nativeAnnotationArray(&annotations).data()));
+}
+
+ConceptPtrFuture<Attribute> putNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative) {
     CONCEPTAPI_FUTURE(Attribute, _native::attribute_type_put(ConceptFactory::getNative(transaction), conceptNative.get(), valueNative));
 }
 
-ConceptPtrFuture<Attribute> AttributeType::putNativeAndFree(Transaction& transaction, _native::Concept* valueNative) {
-    auto ret = putNative(transaction, valueNative);
+ConceptPtrFuture<Attribute> putNativeAndFree(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative) {
+    auto ret = putNative(conceptNative, transaction, valueNative);
     _native::concept_drop(valueNative);
     return ret;
 }
-ConceptPtrFuture<Attribute> AttributeType::getNative(Transaction& transaction, _native::Concept* valueNative) {
+ConceptPtrFuture<Attribute> getNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative) {
     CONCEPTAPI_FUTURE(Attribute, _native::attribute_type_get(ConceptFactory::getNative(transaction), conceptNative.get(), valueNative));
 }
 
-ConceptPtrFuture<Attribute> AttributeType::getNativeAndFree(Transaction& transaction, _native::Concept* valueNative) {
-    auto ret = getNative(transaction, valueNative);
+ConceptPtrFuture<Attribute> getNativeAndFree(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, _native::Concept* valueNative) {
+    auto ret = getNative(conceptNative, transaction, valueNative);
     _native::concept_drop(valueNative);
     return ret;
 }

--- a/cpp/lib/concept/type/role_type.cpp
+++ b/cpp/lib/concept/type/role_type.cpp
@@ -56,7 +56,7 @@ bool RoleType::isAbstract() {
     return _native::role_type_is_abstract(conceptNative.get());
 }
 
-VoidFuture RoleType::drop(Transaction& transaction) {
+VoidFuture RoleType::deleteType(Transaction& transaction) {
     CONCEPTAPI_CALL(VoidFuture, _native::role_type_delete(ConceptFactory::getNative(transaction), conceptNative.get()));
 }
 

--- a/cpp/lib/concept/type/thing_type.cpp
+++ b/cpp/lib/concept/type/thing_type.cpp
@@ -30,6 +30,9 @@
 
 namespace TypeDB {
 
+VoidFuture setOwnsNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType, std::variant<const std::vector<Annotation>*, const std::initializer_list<Annotation>*> annotations);
+ConceptIterable<AttributeType> getOwnsNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, ValueType* valueType, std::variant<const std::vector<Annotation>*, const std::initializer_list<Annotation>*> annotations, Transitivity transitivity);
+
 ThingType::ThingType(ConceptType conceptType, _native::Concept* conceptNative)
     : Type(conceptType, conceptNative) {}
 
@@ -76,20 +79,20 @@ VoidFuture ThingType::setPlays(Transaction& transaction, RoleType* roleType, Rol
     CONCEPTAPI_CALL(VoidFuture, _native::thing_type_set_plays(ConceptFactory::getNative(transaction), conceptNative.get(), ConceptFactory::getNative(roleType), nativeOverriddenRoleType));
 }
 
-VoidFuture ThingType::setOwns(Transaction& transaction, AttributeType* attributeType) {
-    return setOwnsNative(transaction, attributeType, nullptr, Annotation::NONE);
+VoidFuture ThingType::setOwns(Transaction& transaction, AttributeType* attributeType, const std::initializer_list<Annotation>& annotations) {
+    return setOwnsNative(conceptNative, transaction, attributeType, nullptr, &annotations);
 }
 
 VoidFuture ThingType::setOwns(Transaction& transaction, AttributeType* attributeType, const std::vector<Annotation>& annotations) {
-    return setOwnsNative(transaction, attributeType, nullptr, annotations);
+    return setOwnsNative(conceptNative, transaction, attributeType, nullptr, &annotations);
 }
 
-VoidFuture ThingType::setOwns(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType) {
-    return setOwnsNative(transaction, attributeType, overriddenType, Annotation::NONE);
+VoidFuture ThingType::setOwns(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType, const std::initializer_list<Annotation>& annotations) {
+    return setOwnsNative(conceptNative, transaction, attributeType, overriddenType, &annotations);
 }
 
 VoidFuture ThingType::setOwns(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType, const std::vector<Annotation>& annotations) {
-    return setOwnsNative(transaction, attributeType, overriddenType, annotations);
+    return setOwnsNative(conceptNative, transaction, attributeType, overriddenType, &annotations);
 }
 
 ConceptIterable<RoleType> ThingType::getPlays(Transaction& transaction, Transitivity transitivity) {
@@ -101,16 +104,27 @@ ConceptPtrFuture<RoleType> ThingType::getPlaysOverridden(Transaction& transactio
 }
 
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, Transitivity transitivity) {
-    return getOwnsNative(transaction, nullptr, Annotation::NONE, transitivity);
+    return getOwnsNative(conceptNative, transaction, nullptr, {}, transitivity);
 }
+
+ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, const std::initializer_list<Annotation>& annotations, Transitivity transitivity) {
+    return getOwnsNative(conceptNative, transaction, nullptr, &annotations, transitivity);
+}
+
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, const std::vector<Annotation>& annotations, Transitivity transitivity) {
-    return getOwnsNative(transaction, nullptr, annotations, transitivity);
+    return getOwnsNative(conceptNative, transaction, nullptr, &annotations, transitivity);
 }
+
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, ValueType valueType, Transitivity transitivity) {
-    return getOwnsNative(transaction, &valueType, Annotation::NONE, transitivity);
+    return getOwnsNative(conceptNative, transaction, &valueType, {}, transitivity);
 }
+
+ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, ValueType valueType, const std::initializer_list<Annotation>& annotations, Transitivity transitivity) {
+    return getOwnsNative(conceptNative, transaction, &valueType, &annotations, transitivity);
+}
+
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, ValueType valueType, const std::vector<Annotation>& annotations, Transitivity transitivity) {
-    return getOwnsNative(transaction, &valueType, annotations, transitivity);
+    return getOwnsNative(conceptNative, transaction, &valueType, &annotations, transitivity);
 }
 
 ConceptPtrFuture<AttributeType> ThingType::getOwnsOverridden(Transaction& transaction, AttributeType* attributeType) {
@@ -140,17 +154,19 @@ ConceptIterable<ThingType> ThingType::getSubtypes(Transaction& transaction, Tran
 }
 
 // private
-VoidFuture ThingType::setOwnsNative(Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType, const std::vector<Annotation>& annotations) {
+VoidFuture setOwnsNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, AttributeType* attributeType, AttributeType* overriddenType, std::variant<const std::vector<Annotation>*, const std::initializer_list<Annotation>*> annotations) {
     auto overriddenTypeNative = overriddenType != nullptr ? ConceptFactory::getNative(overriddenType) : nullptr;
+    std::vector<const _native::Annotation*> nativeAnnotations = (0 == annotations.index()) ? ConceptFactory::nativeAnnotationArray(std::get<0>(annotations)) : ConceptFactory::nativeAnnotationArray(std::get<1>(annotations));
     CONCEPTAPI_CALL(VoidFuture, _native::thing_type_set_owns(ConceptFactory::getNative(transaction), conceptNative.get(),
-                                                             ConceptFactory::getNative(attributeType), overriddenTypeNative, ConceptFactory::toNativeArray(annotations).data()));
+                                                             ConceptFactory::getNative(attributeType), overriddenTypeNative, nativeAnnotations.data()));
 }
 
-ConceptIterable<AttributeType> ThingType::getOwnsNative(Transaction& transaction, ValueType* valueType, const std::vector<Annotation>& annotations, Transitivity transitivity) {
+ConceptIterable<AttributeType> getOwnsNative(const NativePointer<_native::Concept>& conceptNative, Transaction& transaction, ValueType* valueType, std::variant<const std::vector<Annotation>*, const std::initializer_list<Annotation>*> annotations, Transitivity transitivity) {
+    std::vector<const _native::Annotation*> nativeAnnotations = (0 == annotations.index()) ? ConceptFactory::nativeAnnotationArray(std::get<0>(annotations)) : ConceptFactory::nativeAnnotationArray(std::get<1>(annotations));
     CONCEPTAPI_ITER(
         AttributeType,
         _native::thing_type_get_owns(ConceptFactory::getNative(transaction), conceptNative.get(),
-                                     (_native::ValueType*)valueType, (_native::Transitivity)transitivity, ConceptFactory::toNativeArray(annotations).data()));
+                                     (_native::ValueType*)valueType, (_native::Transitivity)transitivity, nativeAnnotations.data()));
 }
 
 // protected

--- a/cpp/lib/concept/type/thing_type.cpp
+++ b/cpp/lib/concept/type/thing_type.cpp
@@ -19,6 +19,8 @@
  * under the License.
  */
 
+#include <variant>
+
 #include "typedb/concept/type/thing_type.hpp"
 #include "typedb/common/exception.hpp"
 #include "typedb/connection/transaction.hpp"

--- a/cpp/lib/concept/type/thing_type.cpp
+++ b/cpp/lib/concept/type/thing_type.cpp
@@ -38,7 +38,7 @@ std::string ThingType::getLabel() {
     return Utils::stringFromNative(_native::thing_type_get_label(conceptNative.get()));
 }
 
-VoidFuture ThingType::drop(Transaction& transaction) {
+VoidFuture ThingType::deleteType(Transaction& transaction) {
     CONCEPTAPI_CALL(VoidFuture, _native::thing_type_delete(ConceptFactory::getNative(transaction), conceptNative.get()));
 }
 

--- a/cpp/lib/concept/type/thing_type.cpp
+++ b/cpp/lib/concept/type/thing_type.cpp
@@ -106,7 +106,8 @@ ConceptPtrFuture<RoleType> ThingType::getPlaysOverridden(Transaction& transactio
 }
 
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, Transitivity transitivity) {
-    return getOwnsNative(conceptNative, transaction, nullptr, {}, transitivity);
+    std::initializer_list<Annotation> annotations = {};
+    return getOwnsNative(conceptNative, transaction, nullptr, &annotations, transitivity);
 }
 
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, const std::initializer_list<Annotation>& annotations, Transitivity transitivity) {
@@ -118,7 +119,8 @@ ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, cons
 }
 
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, ValueType valueType, Transitivity transitivity) {
-    return getOwnsNative(conceptNative, transaction, &valueType, {}, transitivity);
+    std::initializer_list<Annotation> annotations = {};
+    return getOwnsNative(conceptNative, transaction, &valueType, &annotations, transitivity);
 }
 
 ConceptIterable<AttributeType> ThingType::getOwns(Transaction& transaction, ValueType valueType, const std::initializer_list<Annotation>& annotations, Transitivity transitivity) {

--- a/cpp/lib/connection/driver.cpp
+++ b/cpp/lib/connection/driver.cpp
@@ -39,6 +39,9 @@ _native::Credential* Credential::getNative() const {
     return credentialNative.get();
 }
 
+void Driver::initLogging() {
+    _native::init_logging();
+}
 
 Driver Driver::coreDriver(const std::string& coreAddress) {
     auto p = _native::connection_open_core(coreAddress.c_str());

--- a/cpp/lib/database/database.cpp
+++ b/cpp/lib/database/database.cpp
@@ -70,7 +70,7 @@ ReplicaInfoIterable Database::replicas() {
     WRAPPED_NATIVE_CALL(ReplicaInfoIterable, _native::database_get_replicas_info(databaseNative.get()));
 }
 
-void Database::drop() {
+void Database::deleteDatabase() {
     CHECK_NATIVE(databaseNative);
     _native::database_delete(databaseNative.get());
     DriverException::check_and_throw();

--- a/cpp/lib/logic/explainable.cpp
+++ b/cpp/lib/logic/explainable.cpp
@@ -78,6 +78,10 @@ OwnerAttributePairIterable Explainables::ownerships() {
     WRAPPED_NATIVE_CALL(OwnerAttributePairIterable, _native::explainables_get_ownerships_keys(explainablesNative.get()));
 }
 
+std::string Explainables::toString() {
+    TO_STRING(explainablesNative, _native::explainables_to_string);
+}
+
 OwnerAttributePair::OwnerAttributePair(_native::StringPair* stringPairNative)
     : owner(std::string(stringPairNative->_0)),
       attribute(std::string(stringPairNative->_1)) {

--- a/cpp/lib/logic/explanation.cpp
+++ b/cpp/lib/logic/explanation.cpp
@@ -43,6 +43,10 @@ ConceptMap Explanation::condition() {
     WRAPPED_NATIVE_CALL(ConceptMap, _native::explanation_get_condition(explanationNative.get()));
 }
 
+std::string Explanation::toString() {
+    TO_STRING(explanationNative, _native::explanation_to_string);
+}
+
 TYPEDB_ITERATOR_HELPER(
     _native::ExplanationIterator,
     _native::Explanation,

--- a/cpp/lib/logic/rule.cpp
+++ b/cpp/lib/logic/rule.cpp
@@ -45,6 +45,10 @@ std::string Rule::then() {
     return Utils::stringFromNative(_native::rule_get_then(ruleNative.get()));
 }
 
+std::string Rule::toString() {
+    TO_STRING(ruleNative, _native::rule_to_string);
+}
+
 template <>
 std::optional<Rule> FutureHelper<std::optional<Rule>, _native::RulePromise>::resolve(_native::RulePromise* promiseNative) {
     _native::Rule* ruleNative = _native::rule_promise_resolve(promiseNative);

--- a/cpp/lib/query/query_manager.cpp
+++ b/cpp/lib/query/query_manager.cpp
@@ -40,6 +40,50 @@ namespace TypeDB {
 QueryManager::QueryManager(TypeDB::Transaction* transaction)
     : transaction(transaction) {}
 
+VoidFuture QueryManager::define(const std::string& query) const {
+    define(query, Options());
+}
+
+VoidFuture QueryManager::undefine(const std::string& query) const {
+    undefine(query, Options());
+}
+
+ConceptMapIterable QueryManager::get(const std::string& query) const {
+    get(query, Options());
+}
+
+JSONIterable QueryManager::fetch(const std::string& query) const {
+    fetch(query, Options());
+}
+
+ConceptMapIterable QueryManager::insert(const std::string& query) const {
+    insert(query, Options());
+}
+
+VoidFuture QueryManager::matchDelete(const std::string& query) const {
+    matchDelete(query, Options());
+}
+
+ConceptMapIterable QueryManager::update(const std::string& query) const {
+    update(query, Options());
+}
+
+AggregateFuture QueryManager::getAggregate(const std::string& query) const {
+    getAggregate(query, Options());
+}
+
+ConceptMapGroupIterable QueryManager::getGroup(const std::string& query) const {
+    getGroup(query, Options());
+}
+
+ValueGroupIterable QueryManager::getGroupAggregate(const std::string& query) const {
+    getGroupAggregate(query, Options());
+}
+
+ExplanationIterable QueryManager::explain(const Explainable& explainable) const {
+    explain(explainable, Options());
+}
+
 VoidFuture QueryManager::define(const std::string& query, const Options& options) const {
     CHECK_NATIVE(transaction);
     CHECK_QUERY(query);

--- a/cpp/lib/query/query_manager.cpp
+++ b/cpp/lib/query/query_manager.cpp
@@ -40,50 +40,6 @@ namespace TypeDB {
 QueryManager::QueryManager(TypeDB::Transaction* transaction)
     : transaction(transaction) {}
 
-VoidFuture QueryManager::define(const std::string& query) const {
-    define(query, Options());
-}
-
-VoidFuture QueryManager::undefine(const std::string& query) const {
-    undefine(query, Options());
-}
-
-ConceptMapIterable QueryManager::get(const std::string& query) const {
-    get(query, Options());
-}
-
-JSONIterable QueryManager::fetch(const std::string& query) const {
-    fetch(query, Options());
-}
-
-ConceptMapIterable QueryManager::insert(const std::string& query) const {
-    insert(query, Options());
-}
-
-VoidFuture QueryManager::matchDelete(const std::string& query) const {
-    matchDelete(query, Options());
-}
-
-ConceptMapIterable QueryManager::update(const std::string& query) const {
-    update(query, Options());
-}
-
-AggregateFuture QueryManager::getAggregate(const std::string& query) const {
-    getAggregate(query, Options());
-}
-
-ConceptMapGroupIterable QueryManager::getGroup(const std::string& query) const {
-    getGroup(query, Options());
-}
-
-ValueGroupIterable QueryManager::getGroupAggregate(const std::string& query) const {
-    getGroupAggregate(query, Options());
-}
-
-ExplanationIterable QueryManager::explain(const Explainable& explainable) const {
-    explain(explainable, Options());
-}
-
 VoidFuture QueryManager::define(const std::string& query, const Options& options) const {
     CHECK_NATIVE(transaction);
     CHECK_QUERY(query);

--- a/cpp/lib/user/user_manager.cpp
+++ b/cpp/lib/user/user_manager.cpp
@@ -47,7 +47,7 @@ void UserManager::create(const std::string& username, const std::string& passwor
     DriverException::check_and_throw();
 }
 
-void UserManager::drop(const std::string& username) const {
+void UserManager::deleteUser(const std::string& username) const {
     CHECK_NATIVE(userManagerNative);
     _native::users_delete(userManagerNative.get(), username.c_str());
     DriverException::check_and_throw();

--- a/cpp/test/assembly/test.cpp
+++ b/cpp/test/assembly/test.cpp
@@ -28,7 +28,7 @@ int main() {
         TypeDB::Driver driver = TypeDB::Driver::coreDriver("127.0.0.1:1729");
         std::string dbName = "testAssembly";
         if (driver.databases.contains(dbName)) {
-            driver.databases.get("testAssembly").drop();
+            driver.databases.get("testAssembly").deleteDatabase();
         }
         if (driver.databases.contains(dbName)) return 1;
         driver.databases.create(dbName);

--- a/cpp/test/behaviour/steps/cloud_steps.cpp
+++ b/cpp/test/behaviour/steps/cloud_steps.cpp
@@ -34,11 +34,11 @@ const std::string DEFAULT_CLOUD_PASSWORD = "password";
 void wipeDatabases(const TypeDB::Driver& driver) {
     DatabaseIterable dbIterable = driver.databases.all();
     for (DatabaseIterator it = dbIterable.begin(); it != dbIterable.end(); ++it) {
-        (*it).drop();
+        (*it).deleteDatabase();
     }
     UserIterable userIterable = driver.users.all();
     for (UserIterator it = userIterable.begin(); it != userIterable.end(); ++it) {
-        if (it->username() != "admin") driver.users.drop(it->username());
+        if (it->username() != "admin") driver.users.deleteUser(it->username());
     }
 }
 

--- a/cpp/test/behaviour/steps/common/concept/thingapi_steps.cpp
+++ b/cpp/test/behaviour/steps/common/concept/thingapi_steps.cpp
@@ -43,7 +43,7 @@ cucumber_bdd::StepCollection<Context> thingAPISteps = {
     }),
 
     BDD_STEP("delete (attribute|entity|relation): \\$(\\S+)", {
-        context.vars[matches[2].str()]->asThing()->drop(context.transaction()).wait();
+        context.vars[matches[2].str()]->asThing()->deleteThing(context.transaction()).wait();
     }),
     BDD_STEP("(attribute|entity|relation) \\$(\\S+) is deleted: (true|false)", {
         ASSERT_EQ(parseBoolean(matches[3].str()), context.vars[matches[2].str()]->asThing()->isDeleted(context.transaction()).get());

--- a/cpp/test/behaviour/steps/common/concept/thingapi_steps.cpp
+++ b/cpp/test/behaviour/steps/common/concept/thingapi_steps.cpp
@@ -78,15 +78,14 @@ cucumber_bdd::StepCollection<Context> thingAPISteps = {
     }),
 
     BDD_STEP("(attribute|entity|relation) \\$(\\S+) get keys contain: \\$(\\S+)", {
-        std::vector<Annotation> annotations;
-        annotations.push_back(Annotation::key());
-        auto keys = collect(context.vars[matches[2].str()]->asThing()->getHas(context.transaction(), annotations));
+        auto keys = collect(context.vars[matches[2].str()]->asThing()->getHas(context.transaction(), {Annotation::key()}));
         ASSERT_TRUE(containsInstance(keys, context.vars[matches[3].str()].get()));
     }),
+
     BDD_STEP("(attribute|entity|relation) \\$(\\S+) get keys do not contain: \\$(\\S+)", {
         std::vector<Annotation> annotations;
         annotations.push_back(Annotation::key());
-        auto keys = collect(context.vars[matches[2].str()]->asThing()->getHas(context.transaction(), annotations));
+        auto keys = collect(context.vars[matches[2].str()]->asThing()->getHas(context.transaction(), annotations)); // Use the other variant just for coverage
         ASSERT_FALSE(containsInstance(keys, context.vars[matches[3].str()].get()));
     }),
 

--- a/cpp/test/behaviour/steps/common/concept/thingtype_steps.cpp
+++ b/cpp/test/behaviour/steps/common/concept/thingtype_steps.cpp
@@ -69,7 +69,7 @@ std::vector<std::string> playsLabels(Context& context, const std::string& thingC
 cucumber_bdd::StepCollection<Context> thingTypeSteps = {
     // Basic
     BDD_STEP_AND_THROWS("delete (attribute|entity|relation) type: (\\S+)", {
-        asThingType(context, matches[1].str(), matches[2].str())->drop(context.transaction()).wait();
+        asThingType(context, matches[1].str(), matches[2].str())->deleteType(context.transaction()).wait();
     }),
 
     BDD_STEP("(attribute|entity|relation)\\((\\S+)\\) set label: (\\S+)", {

--- a/cpp/test/behaviour/steps/common/database_steps.cpp
+++ b/cpp/test/behaviour/steps/common/database_steps.cpp
@@ -42,11 +42,11 @@ cucumber_bdd::StepCollection<Context> databaseSteps = {
     }),
 
     BDD_STEP("connection delete database: (\\w+)", {
-        context.driver->databases.get(matches[1]).drop();
+        context.driver->databases.get(matches[1]).deleteDatabase();
     }),
 
     BDD_STEP("connection delete database; throws exception: (\\w+)", {
-        DRIVER_THROWS(matches[1].str(), { context.driver->databases.get(matches[1]).drop(); });
+        DRIVER_THROWS(matches[1].str(), { context.driver->databases.get(matches[1]).deleteDatabase(); });
     }),
 
     // multi
@@ -66,7 +66,7 @@ cucumber_bdd::StepCollection<Context> databaseSteps = {
     }),
 
     BDD_STEP("connection delete databases:", {
-        std::function<void(pickle_table_row*)> fn = [&](pickle_table_row* row) { context.driver->databases.get(row->cells[0].value).drop(); };
+        std::function<void(pickle_table_row*)> fn = [&](pickle_table_row* row) { context.driver->databases.get(row->cells[0].value).deleteDatabase(); };
         foreach_serial(step.argument->data_table->rows, fn);
     }),
 
@@ -77,7 +77,7 @@ cucumber_bdd::StepCollection<Context> databaseSteps = {
     }),
 
     BDD_STEP("connection delete databases in parallel:", {
-        std::function<void(pickle_table_row*)> fn = [&](pickle_table_row* row) { context.driver->databases.get(row->cells[0].value).drop(); };
+        std::function<void(pickle_table_row*)> fn = [&](pickle_table_row* row) { context.driver->databases.get(row->cells[0].value).deleteDatabase(); };
         foreach_parallel(step.argument->data_table->rows, fn);
     }),
 };

--- a/cpp/test/behaviour/steps/common/user_steps.cpp
+++ b/cpp/test/behaviour/steps/common/user_steps.cpp
@@ -50,7 +50,7 @@ cucumber_bdd::StepCollection<Context> userSteps = {
         context.driver->users.passwordSet(matches[1].str(), matches[2].str());
     }),
     BDD_STEP_AND_THROWS("users delete: (\\S+)", {
-        context.driver->users.drop(matches[1].str());
+        context.driver->users.deleteUser(matches[1].str());
     }),
     BDD_STEP("\\s*get connected user\\s*", {
         auto ignored = context.driver->users.getCurrentUser();

--- a/cpp/test/behaviour/steps/core_steps.cpp
+++ b/cpp/test/behaviour/steps/core_steps.cpp
@@ -30,7 +30,7 @@ const std::string DEFAULT_CORE_ADDRESS = "127.0.0.1:1729";
 void wipeDatabases(const TypeDB::Driver& driver) {
     DatabaseIterable dbIterable = driver.databases.all();
     for (DatabaseIterator it = dbIterable.begin(); it != dbIterable.end(); ++it) {
-        (*it).drop();
+        (*it).deleteDatabase();
     }
 }
 

--- a/cpp/test/integration/test.cpp
+++ b/cpp/test/integration/test.cpp
@@ -37,7 +37,7 @@ void delete_if_exists(const TypeDB::Driver& driver, const std::string& name) {
     }
 }
 
-TEST(TestConceptAPI, TestData) {
+TEST(TestDatabaseManager, TestCreateTwice) {
     std::string dbName = "hello_from_cpp";
     TypeDB::Driver driver = TypeDB::Driver::coreDriver("127.0.0.1:1729");
     delete_if_exists(driver, dbName);

--- a/cpp/test/integration/test.cpp
+++ b/cpp/test/integration/test.cpp
@@ -33,7 +33,7 @@ using namespace TypeDB;
 
 void delete_if_exists(const TypeDB::Driver& driver, const std::string& name) {
     if (driver.databases.contains(name)) {
-        driver.databases.get(name).drop();
+        driver.databases.get(name).deleteDatabase();
     }
 }
 


### PR DESCRIPTION
## Usage and product changes
Add a few missing methods, and function variants  for UX.

## Implementation
* **Fixes** the `(DY)LD_LIBRARY_PATH` in the Mac circle assembly tests 
* Avoids using parentheses around commands in circleci config
* UX changes:
  - Renames `drop()` methods to `deleteX`
  - Default arguments for QueryManager, 
  - `initializer_list<Annotation>` variants for ConceptAPI
* iterator traits, which don't do much but encounter more specific errors on unsupported usage of the iterator.
* Hides away some static methods as regular methods in the CPP file 
* Updates `typedb_driver.i` to free the object returned by `concept_map_group_to_string` and `value_map_group_to_string`