### PR TITLE
Fix circleci assembly tests for C++ driver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ commands:
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.zip --directory test_assembly_cpp
           pushd test_assembly_cpp
-            cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
+            cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
             cmake --build . --config release
           popd
           tool/test/start-core-server.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,13 +329,15 @@ commands:
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib
           pushd test_assembly_clib
-          cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
+            cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
             cmake --build . --config release
-          ../tool/test/start-core-server.sh
-          sleep 3
-          LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          ../tool/test/stop-core-server.sh
           popd
+          tool/test/start-core-server.sh
+          sleep 3
+          pushd test_assembly_clib
+            LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          popd
+          tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
   test-clib-assembly-mac:
@@ -350,13 +352,15 @@ commands:
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.zip --directory test_assembly_clib
           pushd test_assembly_clib
-          cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY  -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
-          cmake --build . --config release
-          ../tool/test/start-core-server.sh
-          sleep 3
-          DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          ../tool/test/stop-core-server.sh
+            cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY  -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
+            cmake --build . --config release
           popd
+          tool/test/start-core-server.sh
+          sleep 3
+          pushd test_assembly_clib
+            DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          popd
+          tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
   deploy-clib-release-unix:
@@ -429,15 +433,16 @@ commands:
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.tar.gz --directory test_assembly_cpp
-
           pushd test_assembly_cpp
-            cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY && 
+            cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
             cmake --build . --config release
-          ../tool/test/start-core-server.sh
-          sleep 3
-          LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          ../tool/test/stop-core-server.sh
           popd
+          tool/test/start-core-server.sh
+          sleep 3
+          pushd test_assembly_cpp
+            LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          popd
+          tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
   test-cpp-assembly-mac:
@@ -452,12 +457,15 @@ commands:
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.zip --directory test_assembly_cpp
           pushd test_assembly_cpp
-          cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
-          cmake --build . --config release
-          ../tool/test/start-core-server.sh
+            cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
+            cmake --build . --config release
+          popd
+          tool/test/start-core-server.sh
           sleep 3
-          DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          ../tool/test/stop-core-server.sh
+          pushd test_assembly_cpp
+            DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          popd
+          tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
   
   deploy-cpp-release-unix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,13 +328,14 @@ commands:
           export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib
-          cd test_assembly_clib &&
-            cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
+          pushd test_assembly_clib
+          cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
             cmake --build . --config release
-          tool/test/start-core-server.sh
+          ../tool/test/start-core-server.sh
           sleep 3
-          cd test_assembly_clib && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          tool/test/stop-core-server.sh
+          LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          ../tool/test/stop-core-server.sh
+          popd
           exit $TEST_SUCCESS
 
   test-clib-assembly-mac:
@@ -348,13 +349,14 @@ commands:
           export ASSEMBLY=typedb-driver-clib-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.zip --directory test_assembly_clib
-          cd test_assembly_clib &&
-            cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY  -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
-            cmake --build . --config release
-          tool/test/start-core-server.sh
+          pushd test_assembly_clib
+          cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY  -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
+          cmake --build . --config release
+          ../tool/test/start-core-server.sh
           sleep 3
-          cd test_assembly_clib && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          tool/test/stop-core-server.sh
+          DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          ../tool/test/stop-core-server.sh
+          popd
           exit $TEST_SUCCESS
 
   deploy-clib-release-unix:
@@ -427,13 +429,15 @@ commands:
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.tar.gz --directory test_assembly_cpp
-          cd test_assembly_cpp &&
+
+          pushd test_assembly_cpp
             cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY && 
             cmake --build . --config release
-          tool/test/start-core-server.sh
+          ../tool/test/start-core-server.sh
           sleep 3
-          cd test_assembly_cpp && LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          tool/test/stop-core-server.sh
+          LD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          ../tool/test/stop-core-server.sh
+          popd
           exit $TEST_SUCCESS
 
   test-cpp-assembly-mac:
@@ -447,13 +451,13 @@ commands:
           export ASSEMBLY=typedb-driver-cpp-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.zip --directory test_assembly_cpp
-          cd test_assembly_cpp &&
-            cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
-            cmake --build . --config release
-          tool/test/start-core-server.sh
+          pushd test_assembly_cpp
+          cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY -DCMAKE_OSX_ARCHITECTURES=<<parameters.target-arch>> &&
+          cmake --build . --config release
+          ../tool/test/start-core-server.sh
           sleep 3
-          cd test_assembly_cpp && DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-          tool/test/stop-core-server.sh
+          DYLD_LIBRARY_PATH=$ASSEMBLY/lib ./test_assembly && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          ../tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
   
   deploy-cpp-release-unix:


### PR DESCRIPTION
## Usage and product changes
Fix assembly test paths broken in previous commit

## Implementation
* Replaces the implicit change back of directory form parentheses `(cd ...)` to use `pushd/popd`
