### PR TITLE
Fix fetch sub-query aggregation null pointer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ executors:
     resource_class: arm.large
     working_directory: ~/typedb-driver
 
-  linux-arm64-ubuntu-2004:
+  linux-arm64-ubuntu-2204:
     docker:
-      - image: ubuntu:20.04
+      - image: ubuntu:22.04
     resource_class: arm.large
     working_directory: ~/typedb-driver
 
@@ -44,9 +44,9 @@ executors:
     resource_class: large
     working_directory: ~/typedb-driver
 
-  linux-x86_64-ubuntu-2004:
+  linux-x86_64-ubuntu-2204:
     docker:
-      - image: ubuntu:20.04
+      - image: ubuntu:22.04
     resource_class: large
     working_directory: ~/typedb-driver
 
@@ -559,13 +559,13 @@ jobs:
       - run: .circleci\windows\python\deploy_snapshot.bat
 
   test-pip-snapshot-linux-arm64:
-    executor: linux-arm64-ubuntu-2004
+    executor: linux-arm64-ubuntu-2204
     steps:
       - test-pip-snapshot-linux:
           bazel-arch: arm64
 
   test-pip-snapshot-linux-x86_64:
-    executor: linux-x86_64-ubuntu-2004
+    executor: linux-x86_64-ubuntu-2204
     steps:
       - test-pip-snapshot-linux:
           bazel-arch: amd64

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -59,105 +59,105 @@ build:
         cd nodejs
         npm install
         npm run lint
-
-    build-dependency:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        dependencies/maven/update.sh
-        git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-
-    build-docs:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
-        rm -rf $DOCS_DIRS
-        tool/docs/update.sh
-        git add $DOCS_DIRS
-        git diff --exit-code HEAD $DOCS_DIRS
-
-    test-rust-unit-integration:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
-        tool/test/start-core-server.sh &&
-          bazel test //rust/tests --test_output=streamed --test_arg=-- \
-            --test_arg=integration::queries::core && 
-          export CORE_FAILED= || export CORE_FAILED=1
-        tool/test/stop-core-server.sh
-        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
-
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=integration::queries::cloud \
-            --test_arg=integration::runtimes &&
-          export CLOUD_FAILED= || export CLOUD_FAILED=1
-        tool/test/stop-cloud-servers.sh
-        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
-
-    test-rust-behaviour-concept:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::concept &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-connection:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::connection &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-driver:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::driver &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
+#
+#    build-dependency:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        dependencies/maven/update.sh
+#        git diff --exit-code dependencies/maven/artifacts.snapshot
+#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+#
+#    build-docs:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
+#        rm -rf $DOCS_DIRS
+#        tool/docs/update.sh
+#        git add $DOCS_DIRS
+#        git diff --exit-code HEAD $DOCS_DIRS
+#
+#    test-rust-unit-integration:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
+#        tool/test/start-core-server.sh &&
+#          bazel test //rust/tests --test_output=streamed --test_arg=-- \
+#            --test_arg=integration::queries::core &&
+#          export CORE_FAILED= || export CORE_FAILED=1
+#        tool/test/stop-core-server.sh
+#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+#
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=integration::queries::cloud \
+#            --test_arg=integration::runtimes &&
+#          export CLOUD_FAILED= || export CLOUD_FAILED=1
+#        tool/test/stop-cloud-servers.sh
+#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+#
+#    test-rust-behaviour-concept:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::concept &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-connection:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::connection &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-driver:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::driver &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
 
     test-rust-behaviour-query-read:
       machine: 8-core-32-gb
       image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -175,131 +175,131 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-
-    test-rust-behaviour-query-write:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::query::language::define \
-            --test_arg=behaviour::query::language::undefine \
-            --test_arg=behaviour::query::language::insert \
-            --test_arg=behaviour::query::language::delete \
-            --test_arg=behaviour::query::language::update \
-            --test_arg=behaviour::query::language::rule_validation &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-c-integration:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          bazel test //c/tests/integration:test-driver --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-java-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //java/test/integration/... --test_output=errors
-
-    test-java-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-
-    test-java-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-
-    test-java-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
-
-    test-java-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
-
-    test-java-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
-
-    test-java-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
+#
+#    test-rust-behaviour-query-write:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::query::language::define \
+#            --test_arg=behaviour::query::language::undefine \
+#            --test_arg=behaviour::query::language::insert \
+#            --test_arg=behaviour::query::language::delete \
+#            --test_arg=behaviour::query::language::update \
+#            --test_arg=behaviour::query::language::rule_validation &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-c-integration:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          bazel test //c/tests/integration:test-driver --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-java-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel test //java/test/integration/... --test_output=errors
+#
+#    test-java-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+#
+#    test-java-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+#
+#    test-java-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
+#
+#    test-java-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
+#
+#    test-java-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
+#
+#    test-java-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
 
     test-java-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -315,9 +315,9 @@ build:
 
     test-java-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -330,200 +330,200 @@ build:
         .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
         .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
         .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-
-    test-java-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
-
-    test-java-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
-
-    test-java-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-
-    test-java-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-
-
-    test-python-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
+#
+#    test-java-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
+#
+#    test-java-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
+#
+#    test-java-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+#
+#    test-java-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+#
+#
+#    test-python-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
 
     test-python-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -549,9 +549,9 @@ build:
 
     test-python-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -574,126 +574,126 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-
-    test-python-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-integration-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-core-server.sh &&
-          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-integration-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        tool/test/start-core-server.sh &&
+#          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
 
 #    test-python-integration-cloud-failover:
 #      machine: 4-core-16-gb
@@ -712,139 +712,139 @@ build:
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 #        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
-
-    test-nodejs-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel build //nodejs/...
-        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-        cp -rL bazel-bin/nodejs/dist nodejs/.
-        tool/test/start-core-server.sh &&
-          node nodejs/test/integration/test-concept.js &&
-          node nodejs/test/integration/test-connection.js &&
-          node nodejs/test/integration/test-query.js && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-cloud-failover:
-      machine: 4-core-16-gb
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel build //nodejs/...
-        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-        cp -rL bazel-bin/nodejs/dist nodejs/.
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          node nodejs/test/integration/test-cloud-failover.js && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-    # TODO: Delete --jobs=1 once tests are parallelisable
-
-    test-nodejs-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
+#
+#    test-nodejs-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel build //nodejs/...
+#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+#        cp -rL bazel-bin/nodejs/dist nodejs/.
+#        tool/test/start-core-server.sh &&
+#          node nodejs/test/integration/test-concept.js &&
+#          node nodejs/test/integration/test-connection.js &&
+#          node nodejs/test/integration/test-query.js &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-cloud-failover:
+#      machine: 4-core-16-gb
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel build //nodejs/...
+#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+#        cp -rL bazel-bin/nodejs/dist nodejs/.
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          node nodejs/test/integration/test-cloud-failover.js &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#    # TODO: Delete --jobs=1 once tests are parallelisable
+#
+#    test-nodejs-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
 
     test-nodejs-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -863,9 +863,9 @@ build:
 
     test-nodejs-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -881,193 +881,193 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: development
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: development
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
 
     test-cpp-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -1090,9 +1090,9 @@ build:
 
     test-cpp-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -1110,169 +1110,169 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-
-    test-cpp-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-integration-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-
-    deploy-crate-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-rust-unit-integration
-        - test-rust-behaviour-concept
-        - test-rust-behaviour-connection
-        - test-rust-behaviour-query-read
-        - test-rust-behaviour-query-write
-      command: |
-        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-
-    deploy-npm-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-nodejs-integration
-        - test-nodejs-cloud-failover
-        - test-nodejs-behaviour-connection-core
-        - test-nodejs-behaviour-connection-cloud
-        - test-nodejs-behaviour-concept-core
-        - test-nodejs-behaviour-concept-cloud
-        - test-nodejs-behaviour-read-core
-        - test-nodejs-behaviour-read-cloud
-        - test-nodejs-behaviour-writable-core
-        - test-nodejs-behaviour-writable-cloud
-        - test-nodejs-behaviour-definable-core
-        - test-nodejs-behaviour-definable-cloud
-      command: |
-        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-
-    test-deployment-npm:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - deploy-npm-snapshot
-      command: |
-        tool/test/start-core-server.sh
-        cd nodejs/test/deployment/
-        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-        sudo -H npm install jest --global
-        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        cd -
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-integration-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#
+#    deploy-crate-snapshot:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#        - test-rust-unit-integration
+#        - test-rust-behaviour-concept
+#        - test-rust-behaviour-connection
+#        - test-rust-behaviour-query-read
+#        - test-rust-behaviour-query-write
+#      command: |
+#        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+#
+#    deploy-npm-snapshot:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#        - test-nodejs-integration
+#        - test-nodejs-cloud-failover
+#        - test-nodejs-behaviour-connection-core
+#        - test-nodejs-behaviour-connection-cloud
+#        - test-nodejs-behaviour-concept-core
+#        - test-nodejs-behaviour-concept-cloud
+#        - test-nodejs-behaviour-read-core
+#        - test-nodejs-behaviour-read-cloud
+#        - test-nodejs-behaviour-writable-core
+#        - test-nodejs-behaviour-writable-cloud
+#        - test-nodejs-behaviour-definable-core
+#        - test-nodejs-behaviour-definable-cloud
+#      command: |
+#        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+#        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+#
+#    test-deployment-npm:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - deploy-npm-snapshot
+#      command: |
+#        tool/test/start-core-server.sh
+#        cd nodejs/test/deployment/
+#        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+#        sudo -H npm install jest --global
+#        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        cd -
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
 
 # TODO: assembly tests for all drivers to run in factory
 

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -59,105 +59,105 @@ build:
         cd nodejs
         npm install
         npm run lint
-#
-#    build-dependency:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        dependencies/maven/update.sh
-#        git diff --exit-code dependencies/maven/artifacts.snapshot
-#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-#
-#    build-docs:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
-#        rm -rf $DOCS_DIRS
-#        tool/docs/update.sh
-#        git add $DOCS_DIRS
-#        git diff --exit-code HEAD $DOCS_DIRS
-#
-#    test-rust-unit-integration:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
-#        tool/test/start-core-server.sh &&
-#          bazel test //rust/tests --test_output=streamed --test_arg=-- \
-#            --test_arg=integration::queries::core &&
-#          export CORE_FAILED= || export CORE_FAILED=1
-#        tool/test/stop-core-server.sh
-#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
-#
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=integration::queries::cloud \
-#            --test_arg=integration::runtimes &&
-#          export CLOUD_FAILED= || export CLOUD_FAILED=1
-#        tool/test/stop-cloud-servers.sh
-#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
-#
-#    test-rust-behaviour-concept:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::concept &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-connection:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::connection &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-driver:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::driver &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
+
+    build-dependency:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        dependencies/maven/update.sh
+        git diff --exit-code dependencies/maven/artifacts.snapshot
+        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+
+    build-docs:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
+        rm -rf $DOCS_DIRS
+        tool/docs/update.sh
+        git add $DOCS_DIRS
+        git diff --exit-code HEAD $DOCS_DIRS
+
+    test-rust-unit-integration:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
+        tool/test/start-core-server.sh &&
+          bazel test //rust/tests --test_output=streamed --test_arg=-- \
+            --test_arg=integration::queries::core && 
+          export CORE_FAILED= || export CORE_FAILED=1
+        tool/test/stop-core-server.sh
+        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=integration::queries::cloud \
+            --test_arg=integration::runtimes &&
+          export CLOUD_FAILED= || export CLOUD_FAILED=1
+        tool/test/stop-cloud-servers.sh
+        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+
+    test-rust-behaviour-concept:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::concept &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-connection:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::connection &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-driver:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::driver &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
 
     test-rust-behaviour-query-read:
       machine: 8-core-32-gb
       image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -175,131 +175,131 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-query-write:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::query::language::define \
-#            --test_arg=behaviour::query::language::undefine \
-#            --test_arg=behaviour::query::language::insert \
-#            --test_arg=behaviour::query::language::delete \
-#            --test_arg=behaviour::query::language::update \
-#            --test_arg=behaviour::query::language::rule_validation &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-c-integration:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          bazel test //c/tests/integration:test-driver --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-java-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //java/test/integration/... --test_output=errors
-#
-#    test-java-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-#
-#    test-java-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-#
-#    test-java-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
-#
-#    test-java-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
-#
-#    test-java-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
-#
-#    test-java-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
+
+    test-rust-behaviour-query-write:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::query::language::define \
+            --test_arg=behaviour::query::language::undefine \
+            --test_arg=behaviour::query::language::insert \
+            --test_arg=behaviour::query::language::delete \
+            --test_arg=behaviour::query::language::update \
+            --test_arg=behaviour::query::language::rule_validation &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-c-integration:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          bazel test //c/tests/integration:test-driver --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-java-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel test //java/test/integration/... --test_output=errors
+
+    test-java-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+
+    test-java-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+
+    test-java-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
+
+    test-java-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
+
+    test-java-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
+
+    test-java-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
 
     test-java-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -315,9 +315,9 @@ build:
 
     test-java-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -330,200 +330,200 @@ build:
         .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
         .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
         .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-#
-#    test-java-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
-#
-#    test-java-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
-#
-#    test-java-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-#
-#    test-java-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-#
-#
-#    test-python-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
+
+    test-java-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
+
+    test-java-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
+
+    test-java-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+
+    test-java-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+
+
+    test-python-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
 
     test-python-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -549,9 +549,9 @@ build:
 
     test-python-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -574,126 +574,126 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-#
-#    test-python-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-integration-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-core-server.sh &&
-#          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
+
+    test-python-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-integration-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-core-server.sh &&
+          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
 #    test-python-integration-cloud-failover:
 #      machine: 4-core-16-gb
@@ -712,139 +712,139 @@ build:
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 #        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
-#
-#    test-nodejs-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel build //nodejs/...
-#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-#        cp -rL bazel-bin/nodejs/dist nodejs/.
-#        tool/test/start-core-server.sh &&
-#          node nodejs/test/integration/test-concept.js &&
-#          node nodejs/test/integration/test-connection.js &&
-#          node nodejs/test/integration/test-query.js &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-cloud-failover:
-#      machine: 4-core-16-gb
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel build //nodejs/...
-#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-#        cp -rL bazel-bin/nodejs/dist nodejs/.
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          node nodejs/test/integration/test-cloud-failover.js &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#    # TODO: Delete --jobs=1 once tests are parallelisable
-#
-#    test-nodejs-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
+
+    test-nodejs-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel build //nodejs/...
+        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+        cp -rL bazel-bin/nodejs/dist nodejs/.
+        tool/test/start-core-server.sh &&
+          node nodejs/test/integration/test-concept.js &&
+          node nodejs/test/integration/test-connection.js &&
+          node nodejs/test/integration/test-query.js && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-cloud-failover:
+      machine: 4-core-16-gb
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel build //nodejs/...
+        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+        cp -rL bazel-bin/nodejs/dist nodejs/.
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          node nodejs/test/integration/test-cloud-failover.js && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+    # TODO: Delete --jobs=1 once tests are parallelisable
+
+    test-nodejs-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
 
     test-nodejs-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -863,9 +863,9 @@ build:
 
     test-nodejs-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       command: |
@@ -881,193 +881,193 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: development
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: development
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
 
     test-cpp-behaviour-read-core:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -1090,9 +1090,9 @@ build:
 
     test-cpp-behaviour-read-cloud:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies:
         - build
       type: foreground
@@ -1110,169 +1110,169 @@ build:
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-cloud-servers.sh
         exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-integration-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#
-#    deploy-crate-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#        - test-rust-unit-integration
-#        - test-rust-behaviour-concept
-#        - test-rust-behaviour-connection
-#        - test-rust-behaviour-query-read
-#        - test-rust-behaviour-query-write
-#      command: |
-#        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-#
-#    deploy-npm-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#        - test-nodejs-integration
-#        - test-nodejs-cloud-failover
-#        - test-nodejs-behaviour-connection-core
-#        - test-nodejs-behaviour-connection-cloud
-#        - test-nodejs-behaviour-concept-core
-#        - test-nodejs-behaviour-concept-cloud
-#        - test-nodejs-behaviour-read-core
-#        - test-nodejs-behaviour-read-cloud
-#        - test-nodejs-behaviour-writable-core
-#        - test-nodejs-behaviour-writable-cloud
-#        - test-nodejs-behaviour-definable-core
-#        - test-nodejs-behaviour-definable-cloud
-#      command: |
-#        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-#        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-#
-#    test-deployment-npm:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - deploy-npm-snapshot
-#      command: |
-#        tool/test/start-core-server.sh
-#        cd nodejs/test/deployment/
-#        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-#        sudo -H npm install jest --global
-#        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        cd -
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-integration-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+
+    deploy-crate-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-rust-unit-integration
+        - test-rust-behaviour-concept
+        - test-rust-behaviour-connection
+        - test-rust-behaviour-query-read
+        - test-rust-behaviour-query-write
+      command: |
+        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+
+    deploy-npm-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-nodejs-integration
+        - test-nodejs-cloud-failover
+        - test-nodejs-behaviour-connection-core
+        - test-nodejs-behaviour-connection-cloud
+        - test-nodejs-behaviour-concept-core
+        - test-nodejs-behaviour-concept-cloud
+        - test-nodejs-behaviour-read-core
+        - test-nodejs-behaviour-read-cloud
+        - test-nodejs-behaviour-writable-core
+        - test-nodejs-behaviour-writable-cloud
+        - test-nodejs-behaviour-definable-core
+        - test-nodejs-behaviour-definable-cloud
+      command: |
+        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+
+    test-deployment-npm:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - deploy-npm-snapshot
+      command: |
+        tool/test/start-core-server.sh
+        cd nodejs/test/deployment/
+        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+        sudo -H npm install jest --global
+        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        cd -
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
 # TODO: assembly tests for all drivers to run in factory
 

--- a/cpp/include/typedb/answer/json.hpp
+++ b/cpp/include/typedb/answer/json.hpp
@@ -59,7 +59,7 @@ const std::string ATTRIBUTE = "attribute";
 }  // namespace JSONConstant
 
 enum class JSONType {
-    NONE,
+    INVALID,
 
     MAP,
     ARRAY,
@@ -67,10 +67,13 @@ enum class JSONType {
     BOOLEAN,
     LONG,
     DOUBLE,
-    STRING
+    STRING,
+
+    NULL_VALUE
 };
 
 class JSON;
+class JSONNull{};
 
 using JSONMap = std::map<std::string, JSON>;
 using JSONArray = std::vector<JSON>;
@@ -99,6 +102,7 @@ public:
     bool isLong() const;
     bool isDouble() const;
     bool isString() const;
+    bool isNull() const;
 
     const JSONMap& asMap() const;
     const JSONArray& asArray() const;
@@ -106,6 +110,7 @@ public:
     const JSONLong& asLong() const;
     const JSONDouble& asDouble() const;
     const JSONString& asString() const;
+    const JSONNull& asNull() const;
 
 private:
     JSONType _type;
@@ -116,11 +121,13 @@ private:
         JSONBoolean boolValue;
         JSONLong longValue;
         JSONDouble doubleValue;
+        JSONNull nullValue;
     };
 
     JSON(JSONBoolean);
     JSON(JSONLong);
     JSON(JSONDouble);
+    JSON(JSONNull);
 
     JSON(const JSONString&);
     JSON(const JSONMap&);

--- a/cpp/test/behaviour/steps/common/concept_tables.cpp
+++ b/cpp/test/behaviour/steps/common/concept_tables.cpp
@@ -316,6 +316,8 @@ bool compareJSON(const TypeDB::JSON& first, const TypeDB::JSON& second) {
             return compareJSONArrayUnordered(first.asArray(), second.asArray());
         case TypeDB::JSONType::MAP:
             return compareJSONMap(first.asMap(), second.asMap());
+        case TypeDB::JSONType::NULL_VALUE:
+            return second.isNull();
         default:
             throw std::runtime_error("UNIMPLEMENTED");
     }

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.25.7",
+        commit = "30ed5438810bd82b6f2aa8a46599822926ed2e1b",
     )
 
 def vaticle_typedb_cloud_artifact():

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "30ed5438810bd82b6f2aa8a46599822926ed2e1b",
+        commit = "e0941f2f70988fa0a7fe9510b175e91d55126db4",
     )
 
 def vaticle_typedb_cloud_artifact():
@@ -39,5 +39,5 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "a4a57f31124aafaf338af11b00414c0dbdd52c15",
+        commit = "332275dfce4d02c8293216251a35a23c2e991f33",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "454cd894396ee22f440b01ebbee4cc53e50f97ea",
+        commit = "a4a57f31124aafaf338af11b00414c0dbdd52c15",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -54,6 +54,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "348425193aac94e691fa0328e69f291e2b4fa4d1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "46a16939c1dd94aac6aebc3dd7e50e8280d3dfe5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -54,6 +54,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "1bf6d5dd0f5f95a1617fbecb3d076d3d9bc159d4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "348425193aac94e691fa0328e69f291e2b4fa4d1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/java/api/answer/JSON.java
+++ b/java/api/answer/JSON.java
@@ -26,6 +26,7 @@ import com.eclipsesource.json.JsonValue;
 import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.driver.common.exception.TypeDBDriverException;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,8 @@ public abstract class JSON {
             return new JSON.Number(value.asFloat());
         } else if (value.isBoolean()) {
             return new JSON.Boolean(value.asBoolean());
+        } else if (value.isNull()) {
+            return new JSON.Null();
         } else {
             throw new TypeDBDriverException(ILLEGAL_STATE);
         }
@@ -123,7 +126,7 @@ public abstract class JSON {
         public boolean equals(java.lang.Object obj) {
             if (obj == this) return true;
             if (obj == null || getClass() != obj.getClass()) return false;
-            JSON.Object that = (JSON.Object)obj;
+            JSON.Object that = (JSON.Object) obj;
             return this.object.equals(that.object);
         }
 
@@ -179,7 +182,7 @@ public abstract class JSON {
         public boolean equals(java.lang.Object obj) {
             if (obj == this) return true;
             if (obj == null || getClass() != obj.getClass()) return false;
-            JSON.Array that = (JSON.Array)obj;
+            JSON.Array that = (JSON.Array) obj;
             return this.array.equals(that.array);
         }
 
@@ -220,7 +223,7 @@ public abstract class JSON {
         public boolean equals(java.lang.Object obj) {
             if (obj == this) return true;
             if (obj == null || getClass() != obj.getClass()) return false;
-            JSON.Number that = (JSON.Number)obj;
+            JSON.Number that = (JSON.Number) obj;
             return this.number == that.number;
         }
 
@@ -231,8 +234,8 @@ public abstract class JSON {
 
         @Override
         public java.lang.String toString() {
-            long integerPart = (long)number;
-            if ((double)integerPart == number) {
+            long integerPart = (long) number;
+            if ((double) integerPart == number) {
                 return Long.toString(integerPart);
             } else {
                 return Double.toString(number);
@@ -259,7 +262,7 @@ public abstract class JSON {
         public boolean equals(java.lang.Object obj) {
             if (obj == this) return true;
             if (obj == null || getClass() != obj.getClass()) return false;
-            JSON.String that = (JSON.String)obj;
+            JSON.String that = (JSON.String) obj;
             return this.string.equals(that.string);
         }
 
@@ -293,7 +296,7 @@ public abstract class JSON {
         public boolean equals(java.lang.Object obj) {
             if (obj == this) return true;
             if (obj == null || getClass() != obj.getClass()) return false;
-            JSON.Boolean that = (JSON.Boolean)obj;
+            JSON.Boolean that = (JSON.Boolean) obj;
             return this.aBoolean == that.aBoolean;
         }
 
@@ -305,6 +308,25 @@ public abstract class JSON {
         @Override
         public java.lang.String toString() {
             return java.lang.Boolean.toString(aBoolean);
+        }
+    }
+
+    private static class Null extends JSON {
+
+        @Override
+        public boolean equals(java.lang.Object obj) {
+            if (obj == this) return true;
+            return obj != null && getClass() == obj.getClass();
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public java.lang.String toString() {
+            return "null";
         }
     }
 }

--- a/java/api/answer/JSON.java
+++ b/java/api/answer/JSON.java
@@ -26,7 +26,6 @@ import com.eclipsesource.json.JsonValue;
 import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.driver.common.exception.TypeDBDriverException;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;

--- a/nodejs/api/answer/JSON.ts
+++ b/nodejs/api/answer/JSON.ts
@@ -20,6 +20,7 @@
  */
 
 export type JSON =
+    | null
     | string
     | number
     | boolean

--- a/nodejs/test/behaviour/util/Util.ts
+++ b/nodejs/test/behaviour/util/Util.ts
@@ -62,10 +62,6 @@ export function JSONEqualsUnordered(first: JSON, second: JSON): boolean {
 }
 
 export function JSONArrayEquals(first: JSONArray, second: JSONArray): boolean {
-    console.log("Checking equality?")
-    console.log(first);
-    console.log(second);
-    console.log("\n");
     if (first.length != second.length) return false;
     const secondCopy = [...second];
     for (const f of first) {

--- a/nodejs/test/behaviour/util/Util.ts
+++ b/nodejs/test/behaviour/util/Util.ts
@@ -50,7 +50,9 @@ export function splitString(value: string, separator: string, limit: number): st
 
 
 export function JSONEqualsUnordered(first: JSON, second: JSON): boolean {
-    if (Array.isArray(first) && Array.isArray(second)) {
+    if (first == null && second == null) {
+        return true;
+    } else if (Array.isArray(first) && Array.isArray(second)) {
         return JSONArrayEquals(first, second);
     } else if (first instanceof Object && second instanceof Object) {
         return JSONObjectEquals(first as JSONObject, second as JSONObject);
@@ -60,6 +62,10 @@ export function JSONEqualsUnordered(first: JSON, second: JSON): boolean {
 }
 
 export function JSONArrayEquals(first: JSONArray, second: JSONArray): boolean {
+    console.log("Checking equality?")
+    console.log(first);
+    console.log(second);
+    console.log("\n");
     if (first.length != second.length) return false;
     const secondCopy = [...second];
     for (const f of first) {
@@ -82,7 +88,7 @@ export function JSONObjectEquals(first: JSONObject, second: JSONObject): boolean
     for (const key in first) {
         const firstValue = first[key];
         const secondValue = second[key];
-        if (secondValue == null || !JSONEqualsUnordered(firstValue, secondValue)) {
+        if (!JSONEqualsUnordered(firstValue, secondValue)) {
             return false;
         }
     }

--- a/rust/docs/answer/JSON.adoc
+++ b/rust/docs/answer/JSON.adoc
@@ -10,6 +10,7 @@
 |Variant
 a| `Array(Vec<JSON>)`
 a| `Boolean(bool)`
+a| `Null`
 a| `Number(f64)`
 a| `Object(HashMap<Cow<'static, str>, JSON>)`
 a| `String(Cow<'static, str>)`

--- a/rust/src/answer/json.rs
+++ b/rust/src/answer/json.rs
@@ -32,6 +32,7 @@ pub enum JSON {
     String(Cow<'static, str>),
     Number(f64),
     Boolean(bool),
+    Null,
 }
 
 impl fmt::Display for JSON {
@@ -60,6 +61,7 @@ impl fmt::Display for JSON {
             JSON::String(string) => write_escaped_string(string, f)?,
             JSON::Number(number) => write!(f, "{number}")?,
             JSON::Boolean(boolean) => write!(f, "{boolean}")?,
+            JSON::Null => write!(f, "null")?,
         }
         Ok(())
     }

--- a/rust/src/answer/readable_concept.rs
+++ b/rust/src/answer/readable_concept.rs
@@ -60,7 +60,7 @@ impl Node {
             Node::Leaf(Some(Concept::RelationType(RelationType { label, .. }))) => {
                 json_type(RelationType::ROOT_LABEL, Cow::Owned(label))
             },
-            Node::Leaf(Some(Concept::AttributeType(AttributeType { label, value_type, .. }))) => {Some(
+            Node::Leaf(Some(Concept::AttributeType(AttributeType { label, value_type, .. }))) => {
                 json_attribute_type(Cow::Owned(label), value_type)
             },
             Node::Leaf(Some(Concept::RoleType(RoleType { label, .. }))) => {
@@ -77,6 +77,7 @@ impl Node {
             Node::Leaf(None) => JSON::Null,
             Node::Leaf(Some(concept @ (Concept::Entity(_) | Concept::Relation(_)))) => {
                 unreachable!("Unexpected concept encountered in fetch response: {concept:?}")
+            }
         }
     }
 }

--- a/rust/src/answer/readable_concept.rs
+++ b/rust/src/answer/readable_concept.rs
@@ -41,7 +41,7 @@ impl Tree {
 pub(crate) enum Node {
     Map(HashMap<String, Node>),
     List(Vec<Node>),
-    Leaf(Concept),
+    Leaf(Option<Concept>),
 }
 
 impl Node {
@@ -49,38 +49,34 @@ impl Node {
         match self {
             Node::Map(map) => {
                 JSON::Object(map.into_iter().map(|(var, node)| (Cow::Owned(var), node.into_json())).collect())
-            }
+            },
             Node::List(list) => JSON::Array(list.into_iter().map(Node::into_json).collect()),
-            Node::Leaf(Concept::RootThingType(_)) => {
+            Node::Leaf(Some(Concept::RootThingType(_))) => {
                 json_type(RootThingType::LABEL, Cow::Borrowed(RootThingType::LABEL))
-            }
-            Node::Leaf(Concept::EntityType(EntityType { label, .. })) => {
+            },
+            Node::Leaf(Some(Concept::EntityType(EntityType { label, .. }))) => {
                 json_type(EntityType::ROOT_LABEL, Cow::Owned(label))
-            }
-            Node::Leaf(Concept::RelationType(RelationType { label, .. })) => {
+            },
+            Node::Leaf(Some(Concept::RelationType(RelationType { label, .. }))) => {
                 json_type(RelationType::ROOT_LABEL, Cow::Owned(label))
-            }
-            Node::Leaf(Concept::AttributeType(AttributeType { label, value_type, .. })) => {
+            },
+            Node::Leaf(Some(Concept::AttributeType(AttributeType { label, value_type, .. }))) => {Some(
                 json_attribute_type(Cow::Owned(label), value_type)
-            }
-
-            Node::Leaf(Concept::RoleType(RoleType { label, .. })) => {
+            },
+            Node::Leaf(Some(Concept::RoleType(RoleType { label, .. }))) => {
                 json_type("relation:role", Cow::Owned(label.to_string()))
-            }
-
-            Node::Leaf(Concept::Attribute(Attribute {
+            },
+            Node::Leaf(Some(Concept::Attribute(Attribute {
                 type_: AttributeType { label, value_type, .. }, value, ..
-            })) => JSON::Object(
+            }))) => JSON::Object(
                 [(TYPE, json_attribute_type(Cow::Owned(label), value_type)), (VALUE, json_value(value))].into(),
             ),
-
-            Node::Leaf(Concept::Value(value)) => {
+            Node::Leaf(Some(Concept::Value(value))) => {
                 JSON::Object([(VALUE_TYPE, json_value_type(value.get_type())), (VALUE, json_value(value))].into())
-            }
-
-            Node::Leaf(concept @ (Concept::Entity(_) | Concept::Relation(_))) => {
+            },
+            Node::Leaf(None) => JSON::Null,
+            Node::Leaf(Some(concept @ (Concept::Entity(_) | Concept::Relation(_)))) => {
                 unreachable!("Unexpected concept encountered in fetch response: {concept:?}")
-            }
         }
     }
 }

--- a/rust/src/answer/readable_concept.rs
+++ b/rust/src/answer/readable_concept.rs
@@ -49,31 +49,33 @@ impl Node {
         match self {
             Node::Map(map) => {
                 JSON::Object(map.into_iter().map(|(var, node)| (Cow::Owned(var), node.into_json())).collect())
-            },
+            }
             Node::List(list) => JSON::Array(list.into_iter().map(Node::into_json).collect()),
             Node::Leaf(Some(Concept::RootThingType(_))) => {
                 json_type(RootThingType::LABEL, Cow::Borrowed(RootThingType::LABEL))
-            },
+            }
             Node::Leaf(Some(Concept::EntityType(EntityType { label, .. }))) => {
                 json_type(EntityType::ROOT_LABEL, Cow::Owned(label))
-            },
+            }
             Node::Leaf(Some(Concept::RelationType(RelationType { label, .. }))) => {
                 json_type(RelationType::ROOT_LABEL, Cow::Owned(label))
-            },
+            }
             Node::Leaf(Some(Concept::AttributeType(AttributeType { label, value_type, .. }))) => {
                 json_attribute_type(Cow::Owned(label), value_type)
-            },
+            }
             Node::Leaf(Some(Concept::RoleType(RoleType { label, .. }))) => {
                 json_type("relation:role", Cow::Owned(label.to_string()))
-            },
+            }
             Node::Leaf(Some(Concept::Attribute(Attribute {
-                type_: AttributeType { label, value_type, .. }, value, ..
+                type_: AttributeType { label, value_type, .. },
+                value,
+                ..
             }))) => JSON::Object(
                 [(TYPE, json_attribute_type(Cow::Owned(label), value_type)), (VALUE, json_value(value))].into(),
             ),
             Node::Leaf(Some(Concept::Value(value))) => {
                 JSON::Object([(VALUE_TYPE, json_value_type(value.get_type())), (VALUE, json_value(value))].into())
-            },
+            }
             Node::Leaf(None) => JSON::Null,
             Node::Leaf(Some(concept @ (Concept::Entity(_) | Concept::Relation(_)))) => {
                 unreachable!("Unexpected concept encountered in fetch response: {concept:?}")

--- a/rust/src/connection/network/proto/concept.rs
+++ b/rust/src/connection/network/proto/concept.rs
@@ -26,7 +26,10 @@ use itertools::Itertools;
 use typedb_protocol::{
     concept,
     r#type::{annotation, Annotation as AnnotationProto, Transitivity as TransitivityProto},
-    readable_concept_tree::{self, node::readable_concept::ReadableConcept as ReadableConceptProto},
+    readable_concept_tree::{
+        self,
+        node::readable_concept::{ReadableConcept as ReadableConceptProto, ReadableConcept},
+    },
     thing, thing_type,
     value::Value as ValueProtoInner,
     Attribute as AttributeProto, AttributeType as AttributeTypeProto, Concept as ConceptProto,
@@ -36,7 +39,6 @@ use typedb_protocol::{
     RelationType as RelationTypeProto, RoleType as RoleTypeProto, Thing as ThingProto, ThingType as ThingTypeProto,
     Value as ValueProto, ValueGroup as ValueGroupProto, ValueType as ValueTypeProto,
 };
-use typedb_protocol::readable_concept_tree::node::readable_concept::ReadableConcept;
 
 use super::{FromProto, IntoProto, TryFromProto};
 use crate::{
@@ -176,27 +178,24 @@ impl TryFromProto<readable_concept_tree::node::ReadableConcept> for Option<Conce
         match proto.readable_concept {
             Some(ReadableConceptProto::EntityType(entity_type_proto)) => {
                 Ok(Some(Concept::EntityType(EntityType::from_proto(entity_type_proto))))
-            },
+            }
             Some(ReadableConceptProto::RelationType(relation_type_proto)) => {
                 Ok(Some(Concept::RelationType(RelationType::from_proto(relation_type_proto))))
-            },
+            }
             Some(ReadableConceptProto::AttributeType(attribute_type_proto)) => {
                 AttributeType::try_from_proto(attribute_type_proto)
                     .map(|attr_type| Some(Concept::AttributeType(attr_type)))
-            },
+            }
             Some(ReadableConceptProto::RoleType(role_type_proto)) => {
                 Ok(Some(Concept::RoleType(RoleType::from_proto(role_type_proto))))
-            },
+            }
             Some(ReadableConceptProto::Attribute(attribute_proto)) => {
-                Attribute::try_from_proto(attribute_proto)
-                    .map(|attr| Some(Concept::Attribute(attr)))
-            },
+                Attribute::try_from_proto(attribute_proto).map(|attr| Some(Concept::Attribute(attr)))
+            }
             Some(ReadableConceptProto::Value(value_proto)) => {
                 Value::try_from_proto(value_proto).map(|value| Some(Concept::Value(value)))
-            },
-            Some(ReadableConceptProto::ThingTypeRoot(_)) => {
-                Ok(Some(Concept::RootThingType(RootThingType)))
-            },
+            }
+            Some(ReadableConceptProto::ThingTypeRoot(_)) => Ok(Some(Concept::RootThingType(RootThingType))),
             None => Ok(None),
         }
     }

--- a/rust/src/connection/network/proto/concept.rs
+++ b/rust/src/connection/network/proto/concept.rs
@@ -175,26 +175,28 @@ impl TryFromProto<readable_concept_tree::node::ReadableConcept> for Option<Conce
     fn try_from_proto(proto: readable_concept_tree::node::ReadableConcept) -> Result<Self> {
         match proto.readable_concept {
             Some(ReadableConceptProto::EntityType(entity_type_proto)) => {
-                Ok(Self::EntityType(EntityType::from_proto(entity_type_proto)))
-            }
+                Ok(Some(Concept::EntityType(EntityType::from_proto(entity_type_proto))))
+            },
             Some(ReadableConceptProto::RelationType(relation_type_proto)) => {
-                Ok(Self::RelationType(RelationType::from_proto(relation_type_proto)))
-            }
+                Ok(Some(Concept::RelationType(RelationType::from_proto(relation_type_proto))))
+            },
             Some(ReadableConceptProto::AttributeType(attribute_type_proto)) => {
-                AttributeType::try_from_proto(attribute_type_proto).map(Self::AttributeType)
-            }
-
+                AttributeType::try_from_proto(attribute_type_proto)
+                    .map(|attr_type| Some(Concept::AttributeType(attr_type)))
+            },
             Some(ReadableConceptProto::RoleType(role_type_proto)) => {
-                Ok(Self::RoleType(RoleType::from_proto(role_type_proto)))
-            }
-
+                Ok(Some(Concept::RoleType(RoleType::from_proto(role_type_proto))))
+            },
             Some(ReadableConceptProto::Attribute(attribute_proto)) => {
-                Attribute::try_from_proto(attribute_proto).map(Self::Attribute)
-            }
-
-            Some(ReadableConceptProto::Value(value_proto)) => Value::try_from_proto(value_proto).map(Self::Value),
-
-            Some(ReadableConceptProto::ThingTypeRoot(_)) => Ok(Self::RootThingType(RootThingType)),
+                Attribute::try_from_proto(attribute_proto)
+                    .map(|attr| Some(Concept::Attribute(attr)))
+            },
+            Some(ReadableConceptProto::Value(value_proto)) => {
+                Value::try_from_proto(value_proto).map(|value| Some(Concept::Value(value)))
+            },
+            Some(ReadableConceptProto::ThingTypeRoot(_)) => {
+                Ok(Some(Concept::RootThingType(RootThingType)))
+            },
             None => Ok(None),
         }
     }

--- a/rust/tests/behaviour/util/mod.rs
+++ b/rust/tests/behaviour/util/mod.rs
@@ -164,7 +164,7 @@ pub fn json_matches_str(string: &str, json: &JSON) -> TypeDBResult<bool> {
 fn parse_json(json: &str) -> TypeDBResult<JSON> {
     fn serde_json_into_fetch_answer(json: serde_json::Value) -> JSON {
         match json {
-            serde_json::Value::Null => unreachable!("nulls are not allowed in fetch results"),
+            serde_json::Value::Null => JSON::Null,
             serde_json::Value::Bool(bool) => JSON::Boolean(bool),
             serde_json::Value::Number(number) => JSON::Number(number.as_f64().unwrap()),
             serde_json::Value::String(string) => JSON::String(Cow::Owned(string)),
@@ -216,6 +216,7 @@ fn jsons_equal_up_to_reorder(lhs: &JSON, rhs: &JSON) -> bool {
         (JSON::String(lhs), JSON::String(rhs)) => lhs == rhs,
         (&JSON::Number(lhs), &JSON::Number(rhs)) => equals_approximate(lhs, rhs),
         (JSON::Boolean(lhs), JSON::Boolean(rhs)) => lhs == rhs,
+        (JSON::Null, JSON::Null) => true,
         _ => false,
     }
 }


### PR DESCRIPTION
## Usage and product changes

We fix a bug where a Fetch query with a Get-Aggregate subquery that returned an empty (ie. undefined) answer throw a null pointer exception.

For example this used to incorrectly throw an exception if 'Alice' doesn't have any salaries in the database, since a 'sum' is undefined for 0 entries.
```
match
$x isa person, has name $n; $n == "Alice";
fetch
$n as "name";
total-salary: {
  match $x has salary $s;
  get $s; 
  sum $s;
};
```

We now correctly return the following JSON structure
```
[
  {
    "name": {"value": "Alice",  "type":  {"label": "name", "root": "attribute", "value_type": "string"}},
    "total-salary": null
  }
]
```

## Implementation

* We introduce a 'null' variant internally in each language's JSON representation.
* We update behaviour test runners and evaluators to handle nulls in the JSON answers to be checked against.