### PR TITLE
Release with Ubuntu 18.04 in to lower GLIBC requirement to 2.27.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,14 @@ orbs:
 
 executors:
   linux-arm64:
-    machine:
-      image: ubuntu-2004:current
-      resource_class: arm.medium
+    docker:
+      image: ubuntu:18.04
+    resource_class: arm.medium
     working_directory: ~/typedb-driver
 
   linux-x86_64:
-    machine:
-      image: ubuntu-2004:current
+    docker:
+      image: ubuntu:18.04
     working_directory: ~/typedb-driver
 
   mac-arm64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ commands:
         type: string
     steps:
       - run: |
-          bazel build --jobs=16 //c:assemble-linux-<<parameters.target-arch>>-targz
+          bazel build --jobs=8 //c:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,13 @@ orbs:
 executors:
   linux-arm64:
     docker:
-      image: ubuntu:18.04
+      - image: ubuntu:18.04
     resource_class: arm.medium
     working_directory: ~/typedb-driver
 
   linux-x86_64:
     docker:
-      image: ubuntu:18.04
+      - image: ubuntu:18.04
     working_directory: ~/typedb-driver
 
   mac-arm64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
           apt-get -y update
           apt-get -y install curl build-essential
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
-          sudo mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
+          mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
 
   install-bazel-mac:
@@ -1063,10 +1063,10 @@ jobs:
       - install-bazel-linux:
           bazel-arch: amd64
       - run: |
-          wget -q -O - https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
-          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo apt update -y
-          sudo apt install -y expect
+          wget -q -O - https://cli-assets.heroku.com/apt/release.key | apt-key add -
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+          apt update -y
+          apt install -y expect
           export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
           bazel run --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
           mkdir -p ~/dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ commands:
   deploy-pip-snapshot-unix:
     steps:
       - run: |
-          ulimit -n 100000
           export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
@@ -189,7 +188,6 @@ commands:
   deploy-maven-jni-snapshot-unix:
     steps:
       - run: |
-          ulimit -n 100000
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //java:deploy-maven-jni -- snapshot
@@ -255,7 +253,6 @@ commands:
   deploy-maven-jni-release-unix:
     steps:
       - run: |
-          ulimit -n 100000
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --define version=$(cat VERSION) //java:deploy-maven-jni --compilation_mode=opt -- release
@@ -294,7 +291,6 @@ commands:
   deploy-clib-snapshot-unix:
     steps:
       - run: |
-          ulimit -n 100000
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //c:deploy-clib-driver --compilation_mode=opt -- snapshot
@@ -325,7 +321,6 @@ commands:
         type: string
     steps:
       - run: |
-          ulimit -n 100000      
           bazel build //c:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
@@ -368,7 +363,6 @@ commands:
   deploy-clib-release-unix:
     steps:
       - run: |
-          ulimit -n 100000
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --define version=$(cat VERSION) //c:deploy-clib-driver --compilation_mode=opt -- release
@@ -399,7 +393,6 @@ commands:
   deploy-cpp-snapshot-unix:
     steps:
       - run: |
-          ulimit -n 100000
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //cpp:deploy-cpp-driver --compilation_mode=opt -- snapshot
@@ -430,7 +423,6 @@ commands:
         type: string
     steps:
       - run: |
-          ulimit -n 100000
           bazel build //cpp:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
@@ -473,7 +465,6 @@ commands:
   deploy-cpp-release-unix:
     steps:
       - run: |
-          ulimit -n 100000
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
     steps:
       - run: |
           apt-get -y update
-          apt-get -y install curl build-essential git python3 default-jre
+          apt-get -y install curl build-essential git python3 default-jre lsof
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1212,8 +1212,14 @@ workflows:
             
   typedb-driver-clib-snapshot:
     jobs:
-      - deploy-clib-snapshot-linux-arm64
-      - deploy-clib-snapshot-linux-x86_64
+      - deploy-clib-snapshot-linux-arm64:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-clib-snapshot-linux-x86_64:
+          filters:
+            branches:
+              only: [master, development]
       - deploy-clib-snapshot-mac-arm64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,9 @@ commands:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
-          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
-          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //python:deploy-pip311 -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip311 -- snapshot
 
   deploy-pip-snapshot-linux:
     parameters:
@@ -151,9 +151,9 @@ commands:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
-          bazel run --jobs=16 --define version=$(cat VERSION) //python:deploy-pip39 --compilation_mode=opt -- release
-          bazel run --jobs=16 --define version=$(cat VERSION) //python:deploy-pip310 --compilation_mode=opt -- release
-          bazel run --jobs=16 --define version=$(cat VERSION) //python:deploy-pip311 --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip39 --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip310 --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip311 --compilation_mode=opt -- release
 
   deploy-pip-release-linux:
     parameters:
@@ -190,7 +190,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //java:deploy-maven-jni -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //java:deploy-maven-jni -- snapshot
 
   deploy-maven-jni-snapshot-linux:
     parameters:
@@ -218,7 +218,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
 
   test-maven-snapshot-unix:
     steps:
@@ -255,7 +255,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(cat VERSION) //java:deploy-maven-jni --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //java:deploy-maven-jni --compilation_mode=opt -- release
 
   deploy-maven-jni-release-linux:
     parameters:
@@ -283,7 +283,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(cat VERSION) //java:deploy-maven --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //java:deploy-maven --compilation_mode=opt -- release
 
   #############################
   # C driver deployment steps #
@@ -365,7 +365,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(cat VERSION) //c:deploy-clib-driver --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //c:deploy-clib-driver --compilation_mode=opt -- release
 
   deploy-clib-release-linux:
     parameters:
@@ -395,7 +395,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //cpp:deploy-cpp-driver --compilation_mode=opt -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //cpp:deploy-cpp-driver --compilation_mode=opt -- snapshot
 
   deploy-cpp-snapshot-linux:
     parameters:
@@ -423,7 +423,7 @@ commands:
         type: string
     steps:
       - run: |
-          bazel build --jobs=16 //cpp:assemble-linux-<<parameters.target-arch>>-targz
+          bazel build --jobs=8 //cpp:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.tar.gz --directory test_assembly_cpp
@@ -467,7 +467,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release
 
   deploy-cpp-release-linux:
     parameters:
@@ -1040,7 +1040,7 @@ jobs:
           bazel-arch: amd64
       - run: |
           export DEPLOY_CRATE_TOKEN=$REPO_CRATES_TOKEN
-          bazel run --jobs=16 --define version=$(cat VERSION) //rust:deploy_crate --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //rust:deploy_crate --compilation_mode=opt -- release
           mkdir -p ~/dist
           cp bazel-bin/rust/assemble_crate.crate ~/dist/typedb-driver.crate
       - persist_to_workspace:
@@ -1059,7 +1059,7 @@ jobs:
           apt update -y
           apt install -y expect
           export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
-          bazel run --jobs=16 --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
           mkdir -p ~/dist
           cp bazel-bin/nodejs/assemble-npm.tar.gz ~/dist/typedb-driver-node.tar.gz
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
     steps:
       - run: |
           apt-get -y update
-          apt-get -y install curl build-essential
+          apt-get -y install curl build-essential git python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //c:deploy-clib-driver --compilation_mode=opt -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //c:deploy-clib-driver --compilation_mode=opt -- snapshot
 
   deploy-clib-snapshot-linux:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ commands:
         type: string
     steps:
       - run: |
+          apt-get -y update
+          apt-get -y install curl build-essential
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           sudo mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1219,14 +1219,8 @@ workflows:
             
   typedb-driver-clib-snapshot:
     jobs:
-      - deploy-clib-snapshot-linux-arm64:
-          filters:
-            branches:
-              only: [master, development]
-      - deploy-clib-snapshot-linux-x86_64:
-          filters:
-            branches:
-              only: [master, development]
+      - deploy-clib-snapshot-linux-arm64
+      - deploy-clib-snapshot-linux-x86_64
       - deploy-clib-snapshot-mac-arm64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
     steps:
       - run: |
           apt-get -y update
-          apt-get -y install curl build-essential git python3 default-jre lsof
+          apt-get -y install curl build-essential git python3 default-jre lsof cmake
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,9 @@ commands:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
-          bazel run --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
-          bazel run --define version=$(git rev-parse HEAD) //python:deploy-pip311 -- snapshot
+          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
+          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
+          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //python:deploy-pip311 -- snapshot
 
   deploy-pip-snapshot-linux:
     parameters:
@@ -151,9 +151,9 @@ commands:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
-          bazel run --define version=$(cat VERSION) //python:deploy-pip39 --compilation_mode=opt -- release
-          bazel run --define version=$(cat VERSION) //python:deploy-pip310 --compilation_mode=opt -- release
-          bazel run --define version=$(cat VERSION) //python:deploy-pip311 --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //python:deploy-pip39 --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //python:deploy-pip310 --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //python:deploy-pip311 --compilation_mode=opt -- release
 
   deploy-pip-release-linux:
     parameters:
@@ -190,7 +190,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(git rev-parse HEAD) //java:deploy-maven-jni -- snapshot
+          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //java:deploy-maven-jni -- snapshot
 
   deploy-maven-jni-snapshot-linux:
     parameters:
@@ -218,7 +218,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
+          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
 
   test-maven-snapshot-unix:
     steps:
@@ -255,7 +255,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(cat VERSION) //java:deploy-maven-jni --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //java:deploy-maven-jni --compilation_mode=opt -- release
 
   deploy-maven-jni-release-linux:
     parameters:
@@ -283,7 +283,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(cat VERSION) //java:deploy-maven --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //java:deploy-maven --compilation_mode=opt -- release
 
   #############################
   # C driver deployment steps #
@@ -293,7 +293,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(git rev-parse HEAD) //c:deploy-clib-driver --compilation_mode=opt -- snapshot
+          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //c:deploy-clib-driver --compilation_mode=opt -- snapshot
 
   deploy-clib-snapshot-linux:
     parameters:
@@ -321,7 +321,7 @@ commands:
         type: string
     steps:
       - run: |
-          bazel build //c:assemble-linux-<<parameters.target-arch>>-targz
+          bazel build --jobs=16 //c:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib
@@ -365,7 +365,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(cat VERSION) //c:deploy-clib-driver --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //c:deploy-clib-driver --compilation_mode=opt -- release
 
   deploy-clib-release-linux:
     parameters:
@@ -395,7 +395,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(git rev-parse HEAD) //cpp:deploy-cpp-driver --compilation_mode=opt -- snapshot
+          bazel run --jobs=16 --define version=$(git rev-parse HEAD) //cpp:deploy-cpp-driver --compilation_mode=opt -- snapshot
 
   deploy-cpp-snapshot-linux:
     parameters:
@@ -423,7 +423,7 @@ commands:
         type: string
     steps:
       - run: |
-          bazel build //cpp:assemble-linux-<<parameters.target-arch>>-targz
+          bazel build --jobs=16 //cpp:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.tar.gz --directory test_assembly_cpp
@@ -467,7 +467,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-          bazel run --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release
 
   deploy-cpp-release-linux:
     parameters:
@@ -1040,7 +1040,7 @@ jobs:
           bazel-arch: amd64
       - run: |
           export DEPLOY_CRATE_TOKEN=$REPO_CRATES_TOKEN
-          bazel run --define version=$(cat VERSION) //rust:deploy_crate --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //rust:deploy_crate --compilation_mode=opt -- release
           mkdir -p ~/dist
           cp bazel-bin/rust/assemble_crate.crate ~/dist/typedb-driver.crate
       - persist_to_workspace:
@@ -1059,7 +1059,7 @@ jobs:
           apt update -y
           apt install -y expect
           export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
-          bazel run --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
+          bazel run --jobs=16 --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
           mkdir -p ~/dist
           cp bazel-bin/nodejs/assemble-npm.tar.gz ~/dist/typedb-driver-node.tar.gz
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
     steps:
       - run: |
           apt-get -y update
-          apt-get -y install curl build-essential git python3
+          apt-get -y install curl build-essential git python3 default-jre
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -60,1219 +60,1219 @@ build:
         npm install
         npm run lint
 
-#    build-dependency:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        dependencies/maven/update.sh
-#        git diff --exit-code dependencies/maven/artifacts.snapshot
-#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-#
-#    build-docs:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
-#        rm -rf $DOCS_DIRS
-#        tool/docs/update.sh
-#        git add $DOCS_DIRS
-#        git diff --exit-code HEAD $DOCS_DIRS
-#
-#    test-rust-unit-integration:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
-#        tool/test/start-core-server.sh &&
-#          bazel test //rust/tests --test_output=streamed --test_arg=-- \
-#            --test_arg=integration::queries::core && 
-#          export CORE_FAILED= || export CORE_FAILED=1
-#        tool/test/stop-core-server.sh
-#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
-#
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=integration::queries::cloud \
-#            --test_arg=integration::runtimes &&
-#          export CLOUD_FAILED= || export CLOUD_FAILED=1
-#        tool/test/stop-cloud-servers.sh
-#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
-#
-#    test-rust-behaviour-concept:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::concept &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-connection:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::connection &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-driver:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::driver &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-query-read:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::query::language::match_ \
-#            --test_arg=behaviour::query::language::get \
-#            --test_arg=behaviour::query::language::fetch \
-#            --test_arg=behaviour::query::language::modifiers \
-#            --test_arg=behaviour::query::language::expression &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-query-write:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::query::language::define \
-#            --test_arg=behaviour::query::language::undefine \
-#            --test_arg=behaviour::query::language::insert \
-#            --test_arg=behaviour::query::language::delete \
-#            --test_arg=behaviour::query::language::update \
-#            --test_arg=behaviour::query::language::rule_validation &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-c-integration:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          bazel test //c/tests/integration:test-driver --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-java-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //java/test/integration/... --test_output=errors
-#
-#    test-java-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-#
-#    test-java-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-#
-#    test-java-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
-#
-#    test-java-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
-#
-#    test-java-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
-#
-#    test-java-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
-#
-#    test-java-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-#
-#    test-java-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-#
-#    test-java-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
-#
-#    test-java-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
-#
-#    test-java-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-#
-#    test-java-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-#
-#
-#    test-python-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-integration-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-core-server.sh &&
-#          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-##    test-python-integration-cloud-failover:
-##      machine: 4-core-16-gb
-##      image: vaticle-ubuntu-22.04
-##      dependencies:
-##        - build
-##      type: foreground
-##      command: |
-##        export PATH="$HOME/.local/bin:$PATH"
-##        sudo apt-get update
-##        sudo apt install python3-pip -y
-##        python3 -m pip install -U pip
-##        python3 -m pip install -r python/requirements_dev.txt
-##        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-##        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-##        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-##        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-##        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
-#
-#    test-nodejs-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel build //nodejs/...
-#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-#        cp -rL bazel-bin/nodejs/dist nodejs/.
-#        tool/test/start-core-server.sh &&
-#          node nodejs/test/integration/test-concept.js &&
-#          node nodejs/test/integration/test-connection.js &&
-#          node nodejs/test/integration/test-query.js && 
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-cloud-failover:
+    build-dependency:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        dependencies/maven/update.sh
+        git diff --exit-code dependencies/maven/artifacts.snapshot
+        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+
+    build-docs:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
+        rm -rf $DOCS_DIRS
+        tool/docs/update.sh
+        git add $DOCS_DIRS
+        git diff --exit-code HEAD $DOCS_DIRS
+
+    test-rust-unit-integration:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
+        tool/test/start-core-server.sh &&
+          bazel test //rust/tests --test_output=streamed --test_arg=-- \
+            --test_arg=integration::queries::core && 
+          export CORE_FAILED= || export CORE_FAILED=1
+        tool/test/stop-core-server.sh
+        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=integration::queries::cloud \
+            --test_arg=integration::runtimes &&
+          export CLOUD_FAILED= || export CLOUD_FAILED=1
+        tool/test/stop-cloud-servers.sh
+        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+
+    test-rust-behaviour-concept:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::concept &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-connection:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::connection &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-driver:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::driver &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-query-read:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::query::language::match_ \
+            --test_arg=behaviour::query::language::get \
+            --test_arg=behaviour::query::language::fetch \
+            --test_arg=behaviour::query::language::modifiers \
+            --test_arg=behaviour::query::language::expression &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-query-write:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::query::language::define \
+            --test_arg=behaviour::query::language::undefine \
+            --test_arg=behaviour::query::language::insert \
+            --test_arg=behaviour::query::language::delete \
+            --test_arg=behaviour::query::language::update \
+            --test_arg=behaviour::query::language::rule_validation &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-c-integration:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          bazel test //c/tests/integration:test-driver --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-java-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel test //java/test/integration/... --test_output=errors
+
+    test-java-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+
+    test-java-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+
+    test-java-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
+
+    test-java-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
+
+    test-java-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
+
+    test-java-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
+
+    test-java-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+
+    test-java-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+
+    test-java-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
+
+    test-java-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
+
+    test-java-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+
+    test-java-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+
+
+    test-python-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-integration-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-core-server.sh &&
+          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+#    test-python-integration-cloud-failover:
 #      machine: 4-core-16-gb
 #      image: vaticle-ubuntu-22.04
 #      dependencies:
 #        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel build //nodejs/...
-#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-#        cp -rL bazel-bin/nodejs/dist nodejs/.
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          node nodejs/test/integration/test-cloud-failover.js && 
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#    # TODO: Delete --jobs=1 once tests are parallelisable
-#
-#    test-nodejs-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: development
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
 #      type: foreground
 #      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
 #        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-integration-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#
-#    deploy-crate-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#        - test-rust-unit-integration
-#        - test-rust-behaviour-concept
-#        - test-rust-behaviour-connection
-#        - test-rust-behaviour-query-read
-#        - test-rust-behaviour-query-write
-#      command: |
-#        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-#
-#    deploy-npm-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#        - test-nodejs-integration
-#        - test-nodejs-cloud-failover
-#        - test-nodejs-behaviour-connection-core
-#        - test-nodejs-behaviour-connection-cloud
-#        - test-nodejs-behaviour-concept-core
-#        - test-nodejs-behaviour-concept-cloud
-#        - test-nodejs-behaviour-read-core
-#        - test-nodejs-behaviour-read-cloud
-#        - test-nodejs-behaviour-writable-core
-#        - test-nodejs-behaviour-writable-cloud
-#        - test-nodejs-behaviour-definable-core
-#        - test-nodejs-behaviour-definable-cloud
-#      command: |
-#        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-#        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-#
-#    test-deployment-npm:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - deploy-npm-snapshot
-#      command: |
-#        tool/test/start-core-server.sh
-#        cd nodejs/test/deployment/
-#        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-#        sudo -H npm install jest --global
-#        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        cd -
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
+#        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
+
+    test-nodejs-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel build //nodejs/...
+        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+        cp -rL bazel-bin/nodejs/dist nodejs/.
+        tool/test/start-core-server.sh &&
+          node nodejs/test/integration/test-concept.js &&
+          node nodejs/test/integration/test-connection.js &&
+          node nodejs/test/integration/test-query.js && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-cloud-failover:
+      machine: 4-core-16-gb
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel build //nodejs/...
+        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+        cp -rL bazel-bin/nodejs/dist nodejs/.
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          node nodejs/test/integration/test-cloud-failover.js && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+    # TODO: Delete --jobs=1 once tests are parallelisable
+
+    test-nodejs-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: development
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-integration-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+
+    deploy-crate-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-rust-unit-integration
+        - test-rust-behaviour-concept
+        - test-rust-behaviour-connection
+        - test-rust-behaviour-query-read
+        - test-rust-behaviour-query-write
+      command: |
+        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+
+    deploy-npm-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-nodejs-integration
+        - test-nodejs-cloud-failover
+        - test-nodejs-behaviour-connection-core
+        - test-nodejs-behaviour-connection-cloud
+        - test-nodejs-behaviour-concept-core
+        - test-nodejs-behaviour-concept-cloud
+        - test-nodejs-behaviour-read-core
+        - test-nodejs-behaviour-read-cloud
+        - test-nodejs-behaviour-writable-core
+        - test-nodejs-behaviour-writable-cloud
+        - test-nodejs-behaviour-definable-core
+        - test-nodejs-behaviour-definable-cloud
+      command: |
+        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+
+    test-deployment-npm:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - deploy-npm-snapshot
+      command: |
+        tool/test/start-core-server.sh
+        cd nodejs/test/deployment/
+        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+        sudo -H npm install jest --global
+        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        cd -
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
 # TODO: assembly tests for all drivers to run in factory
 

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -60,643 +60,382 @@ build:
         npm install
         npm run lint
 
-    build-dependency:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        dependencies/maven/update.sh
-        git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-
-    build-docs:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
-        rm -rf $DOCS_DIRS
-        tool/docs/update.sh
-        git add $DOCS_DIRS
-        git diff --exit-code HEAD $DOCS_DIRS
-
-    test-rust-unit-integration:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
-        tool/test/start-core-server.sh &&
-          bazel test //rust/tests --test_output=streamed --test_arg=-- \
-            --test_arg=integration::queries::core && 
-          export CORE_FAILED= || export CORE_FAILED=1
-        tool/test/stop-core-server.sh
-        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
-
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=integration::queries::cloud \
-            --test_arg=integration::runtimes &&
-          export CLOUD_FAILED= || export CLOUD_FAILED=1
-        tool/test/stop-cloud-servers.sh
-        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
-
-    test-rust-behaviour-concept:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::concept &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-connection:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::connection &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-driver:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::driver &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-query-read:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::query::language::match_ \
-            --test_arg=behaviour::query::language::get \
-            --test_arg=behaviour::query::language::fetch \
-            --test_arg=behaviour::query::language::modifiers \
-            --test_arg=behaviour::query::language::expression &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-query-write:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::query::language::define \
-            --test_arg=behaviour::query::language::undefine \
-            --test_arg=behaviour::query::language::insert \
-            --test_arg=behaviour::query::language::delete \
-            --test_arg=behaviour::query::language::update \
-            --test_arg=behaviour::query::language::rule_validation &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-c-integration:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          bazel test //c/tests/integration:test-driver --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-java-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //java/test/integration/... --test_output=errors
-
-    test-java-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-
-    test-java-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-
-    test-java-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
-
-    test-java-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
-
-    test-java-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
-
-    test-java-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
-
-    test-java-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-
-    test-java-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-
-    test-java-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
-
-    test-java-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
-
-    test-java-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-
-    test-java-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-
-
-    test-python-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-integration-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-core-server.sh &&
-          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-#    test-python-integration-cloud-failover:
-#      machine: 4-core-16-gb
+#    build-dependency:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        dependencies/maven/update.sh
+#        git diff --exit-code dependencies/maven/artifacts.snapshot
+#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+#
+#    build-docs:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs"
+#        rm -rf $DOCS_DIRS
+#        tool/docs/update.sh
+#        git add $DOCS_DIRS
+#        git diff --exit-code HEAD $DOCS_DIRS
+#
+#    test-rust-unit-integration:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
+#        tool/test/start-core-server.sh &&
+#          bazel test //rust/tests --test_output=streamed --test_arg=-- \
+#            --test_arg=integration::queries::core && 
+#          export CORE_FAILED= || export CORE_FAILED=1
+#        tool/test/stop-core-server.sh
+#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+#
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=integration::queries::cloud \
+#            --test_arg=integration::runtimes &&
+#          export CLOUD_FAILED= || export CLOUD_FAILED=1
+#        tool/test/stop-cloud-servers.sh
+#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+#
+#    test-rust-behaviour-concept:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::concept &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-connection:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::connection &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-driver:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::driver &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-query-read:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::query::language::match_ \
+#            --test_arg=behaviour::query::language::get \
+#            --test_arg=behaviour::query::language::fetch \
+#            --test_arg=behaviour::query::language::modifiers \
+#            --test_arg=behaviour::query::language::expression &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-query-write:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::query::language::define \
+#            --test_arg=behaviour::query::language::undefine \
+#            --test_arg=behaviour::query::language::insert \
+#            --test_arg=behaviour::query::language::delete \
+#            --test_arg=behaviour::query::language::update \
+#            --test_arg=behaviour::query::language::rule_validation &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-c-integration:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          bazel test //c/tests/integration:test-driver --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-java-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel test //java/test/integration/... --test_output=errors
+#
+#    test-java-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+#
+#    test-java-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+#
+#    test-java-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
+#
+#    test-java-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
+#
+#    test-java-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
+#
+#    test-java-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
+#
+#    test-java-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+#
+#    test-java-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+#
+#    test-java-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
+#
+#    test-java-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
+#
+#    test-java-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+#
+#    test-java-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+#
+#
+#    test-python-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-concept-core:
 #      image: vaticle-ubuntu-22.04
 #      dependencies:
 #        - build
@@ -711,568 +450,829 @@ build:
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
-
-    test-nodejs-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel build //nodejs/...
-        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-        cp -rL bazel-bin/nodejs/dist nodejs/.
-        tool/test/start-core-server.sh &&
-          node nodejs/test/integration/test-concept.js &&
-          node nodejs/test/integration/test-connection.js &&
-          node nodejs/test/integration/test-query.js && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-cloud-failover:
-      machine: 4-core-16-gb
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel build //nodejs/...
-        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-        cp -rL bazel-bin/nodejs/dist nodejs/.
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          node nodejs/test/integration/test-cloud-failover.js && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-    # TODO: Delete --jobs=1 once tests are parallelisable
-
-    test-nodejs-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: development
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-integration-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-
-    deploy-crate-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-rust-unit-integration
-        - test-rust-behaviour-concept
-        - test-rust-behaviour-connection
-        - test-rust-behaviour-query-read
-        - test-rust-behaviour-query-write
-      command: |
-        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-
-    deploy-npm-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-nodejs-integration
-        - test-nodejs-cloud-failover
-        - test-nodejs-behaviour-connection-core
-        - test-nodejs-behaviour-connection-cloud
-        - test-nodejs-behaviour-concept-core
-        - test-nodejs-behaviour-concept-cloud
-        - test-nodejs-behaviour-read-core
-        - test-nodejs-behaviour-read-cloud
-        - test-nodejs-behaviour-writable-core
-        - test-nodejs-behaviour-writable-cloud
-        - test-nodejs-behaviour-definable-core
-        - test-nodejs-behaviour-definable-cloud
-      command: |
-        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-
-    test-deployment-npm:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - deploy-npm-snapshot
-      command: |
-        tool/test/start-core-server.sh
-        cd nodejs/test/deployment/
-        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-        sudo -H npm install jest --global
-        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        cd -
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-integration-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        tool/test/start-core-server.sh &&
+#          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+##    test-python-integration-cloud-failover:
+##      machine: 4-core-16-gb
+##      image: vaticle-ubuntu-22.04
+##      dependencies:
+##        - build
+##      type: foreground
+##      command: |
+##        export PATH="$HOME/.local/bin:$PATH"
+##        sudo apt-get update
+##        sudo apt install python3-pip -y
+##        python3 -m pip install -U pip
+##        python3 -m pip install -r python/requirements_dev.txt
+##        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+##        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+##        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+##        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+##        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
+#
+#    test-nodejs-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel build //nodejs/...
+#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+#        cp -rL bazel-bin/nodejs/dist nodejs/.
+#        tool/test/start-core-server.sh &&
+#          node nodejs/test/integration/test-concept.js &&
+#          node nodejs/test/integration/test-connection.js &&
+#          node nodejs/test/integration/test-query.js && 
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-cloud-failover:
+#      machine: 4-core-16-gb
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel build //nodejs/...
+#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+#        cp -rL bazel-bin/nodejs/dist nodejs/.
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          node nodejs/test/integration/test-cloud-failover.js && 
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#    # TODO: Delete --jobs=1 once tests are parallelisable
+#
+#    test-nodejs-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: development
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-integration-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#
+#    deploy-crate-snapshot:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#        - test-rust-unit-integration
+#        - test-rust-behaviour-concept
+#        - test-rust-behaviour-connection
+#        - test-rust-behaviour-query-read
+#        - test-rust-behaviour-query-write
+#      command: |
+#        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+#
+#    deploy-npm-snapshot:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#        - test-nodejs-integration
+#        - test-nodejs-cloud-failover
+#        - test-nodejs-behaviour-connection-core
+#        - test-nodejs-behaviour-connection-cloud
+#        - test-nodejs-behaviour-concept-core
+#        - test-nodejs-behaviour-concept-cloud
+#        - test-nodejs-behaviour-read-core
+#        - test-nodejs-behaviour-read-cloud
+#        - test-nodejs-behaviour-writable-core
+#        - test-nodejs-behaviour-writable-cloud
+#        - test-nodejs-behaviour-definable-core
+#        - test-nodejs-behaviour-definable-cloud
+#      command: |
+#        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+#        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+#
+#    test-deployment-npm:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - deploy-npm-snapshot
+#      command: |
+#        tool/test/start-core-server.sh
+#        cd nodejs/test/deployment/
+#        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+#        sudo -H npm install jest --global
+#        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        cd -
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
 
 # TODO: assembly tests for all drivers to run in factory
 

--- a/c/tests/assembly/CMakeLists.txt
+++ b/c/tests/assembly/CMakeLists.txt
@@ -18,7 +18,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 if(NOT DEFINED TYPEDB_ASSEMBLY)
     message(FATAL_ERROR "TYPEDB_ASSEMBLY is not set")
 ENDIF()

--- a/cpp/test/assembly/CMakeLists.txt
+++ b/cpp/test/assembly/CMakeLists.txt
@@ -18,7 +18,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 if(NOT DEFINED TYPEDB_ASSEMBLY)
     message(FATAL_ERROR "TYPEDB_ASSEMBLY is not set")
 ENDIF()

--- a/python/python_versions.bzl
+++ b/python/python_versions.bzl
@@ -48,4 +48,4 @@ python_versions = [
 
 def register_all_toolchains():
     for version in python_versions:
-        python_register_toolchains(name=version["name"], python_version=version["python_version"])
+        python_register_toolchains(name=version["name"], python_version=version["python_version"], ignore_root_user_error = True)


### PR DESCRIPTION
## Usage and product changes

We downgrade from Ubuntu 20.04 to 18.04 in CircleCI assembly and deployment jobs, using a Docker image. This lowers the minimum supported glibc version from 2.31 to 2.27.
