### PR TITLE
Update to tonic 1.28

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "371a67999d92b4d0833cd5e016ec01c6278e72c4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "cfcf436f2fb8752cce72276e3b9b95f4bd343e24", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():


### PR DESCRIPTION
## Usage and product changes

We fix a bug in the installation of the latest typedb-driver Rust by upgrading `tonic` to version 1.28.

## Implementation

Update dependencies