### PR TITLE
Migrate artifact hosting to cloudsmith 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ commands:
     steps:
       - install-pip-requirements
       - run: |
-          export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_PIP_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_PIP_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip38 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
@@ -121,9 +121,11 @@ commands:
       - run: |
           tool/test/start-core-server.sh
           python3.8 -m pip install wheel 
-          python3.8 -m pip install --extra-index-url https://repo.vaticle.com/repository/pypi-snapshot/simple typedb-driver==0.0.0+$(git rev-parse HEAD)
+          python3.8 -m pip install --extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple typedb-driver==0.0.0+$(git rev-parse HEAD)
           sleep 3
-          (cd python/tests/deployment/ && python3.8 -m unittest test && export TEST_SUCCESS=0 || export TEST_SUCCESS=1)
+          pushd python/tests/deployment/
+            python3.8 -m unittest test && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          popd
           tool/test/stop-core-server.sh
           exit $TEST_SUCCESS
 
@@ -154,15 +156,15 @@ commands:
   deploy-maven-jni-snapshot-unix:
     steps:
       - run: |
-          export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //java:deploy-maven-jni -- snapshot
 
   deploy-maven-snapshot-unix:
     steps:
       - run: |
-          export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
 
   test-maven-snapshot-unix:
@@ -177,15 +179,15 @@ commands:
   deploy-maven-jni-release-unix:
     steps:
       - run: |
-          export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(cat VERSION) //java:deploy-maven-jni --compilation_mode=opt -- release
 
   deploy-maven-release-unix:
     steps:
       - run: |
-          export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(cat VERSION) //java:deploy-maven --compilation_mode=opt -- release
 
   ######################
@@ -195,8 +197,8 @@ commands:
   deploy-clib-snapshot-unix:
     steps:
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //c:deploy-clib-driver --compilation_mode=opt -- snapshot
 
   test-clib-assembly-linux:
@@ -248,8 +250,8 @@ commands:
   deploy-clib-release-unix:
     steps:
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(cat VERSION) //c:deploy-clib-driver --compilation_mode=opt -- release
 
   ########################
@@ -259,8 +261,8 @@ commands:
   deploy-cpp-snapshot-unix:
     steps:
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //cpp:deploy-cpp-driver --compilation_mode=opt -- snapshot
 
   test-cpp-assembly-linux:
@@ -312,8 +314,8 @@ commands:
   deploy-cpp-release-unix:
     steps:
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --jobs=8 --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release
 
   #########################
@@ -323,7 +325,7 @@ commands:
   deploy-crate-snapshot-unix:
     steps:
       - run: |
-          export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+          export DEPLOY_CRATE_TOKEN=$REPO_TYPEDB_CRATES_TOKEN
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
 
   deploy-crate-release-unix:
@@ -339,8 +341,8 @@ commands:
   deploy-npm-snapshot-unix:
     steps:
       - run: |
-          export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_NPM_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_NPM_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
 
   test-npm-snapshot-unix:
@@ -348,7 +350,7 @@ commands:
       - run: |
           tool/test/start-core-server.sh
           cd nodejs/test/deployment/
-          npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+          npm install --registry https://npm.cloudsmith.io/typedb/public-snapshot/ "typedb-driver@0.0.0-$FACTORY_COMMIT"
           sudo -H npm install jest --global
           jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
           cd -

--- a/.circleci/windows/clib/deploy_release.bat
+++ b/.circleci/windows/clib/deploy_release.bat
@@ -24,8 +24,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_ARTIFACT_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_ARTIFACT_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 SET /p VER=<VERSION
 bazel --output_user_root=C:\bazel run --verbose_failures --define version=%VER% //c:deploy-windows-x86_64-zip --compilation_mode=opt -- release

--- a/.circleci/windows/clib/deploy_snapshot.bat
+++ b/.circleci/windows/clib/deploy_snapshot.bat
@@ -24,8 +24,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_ARTIFACT_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_ARTIFACT_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt

--- a/.circleci/windows/cpp/deploy_release.bat
+++ b/.circleci/windows/cpp/deploy_release.bat
@@ -24,8 +24,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_ARTIFACT_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_ARTIFACT_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 SET /p VER=<VERSION
 bazel --output_user_root=C:\bazel run --verbose_failures --define version=%VER% //cpp:deploy-windows-x86_64-zip --compilation_mode=opt -- release

--- a/.circleci/windows/cpp/deploy_snapshot.bat
+++ b/.circleci/windows/cpp/deploy_snapshot.bat
@@ -24,8 +24,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_ARTIFACT_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_ARTIFACT_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt

--- a/.circleci/windows/java/deploy_release.bat
+++ b/.circleci/windows/java/deploy_release.bat
@@ -24,8 +24,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_MAVEN_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_MAVEN_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_MAVEN_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_MAVEN_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 SET /p VER=<VERSION
 bazel --output_user_root=C:/bazel run --verbose_failures --define version=%VER% //java:deploy-maven-jni --compilation_mode=opt -- release

--- a/.circleci/windows/java/deploy_snapshot.bat
+++ b/.circleci/windows/java/deploy_snapshot.bat
@@ -24,8 +24,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_MAVEN_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_MAVEN_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_MAVEN_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_MAVEN_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt

--- a/.circleci/windows/python/deploy_snapshot.bat
+++ b/.circleci/windows/python/deploy_snapshot.bat
@@ -24,8 +24,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_PIP_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_PIP_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_PIP_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_PIP_PASSWORD=%REPO_TYPEDB_PASSWORD%
 python.exe -m pip install twine==3.3.0 importlib-metadata==3.4.0
 git rev-parse HEAD > version_temp.txt
 set /p VER=<version_temp.txt

--- a/.circleci/windows/python/test_deploy_snapshot.bat
+++ b/.circleci/windows/python/test_deploy_snapshot.bat
@@ -32,7 +32,7 @@ RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
 START /B "" typedb-server-windows\typedb server
 
-python3 -m pip install --extra-index-url https://repo.vaticle.com/repository/pypi-snapshot/simple typedb-driver==0.0.0+%VER%
+python3 -m pip install --extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple typedb-driver==0.0.0+%VER%
 cd python/tests/deployment
 python3 -m unittest test
 SET IS_ERROR=%ERRORLEVEL%

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -48,8 +48,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //...
@@ -85,8 +85,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
@@ -110,8 +110,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
@@ -126,8 +126,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
@@ -143,8 +143,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
@@ -163,8 +163,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
@@ -187,8 +187,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
@@ -208,8 +208,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -223,8 +223,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel test //java/test/integration/... --test_output=errors
@@ -234,8 +234,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
@@ -246,8 +246,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
@@ -258,8 +258,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
@@ -269,8 +269,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
@@ -280,8 +280,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
@@ -291,8 +291,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
@@ -305,8 +305,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
@@ -323,8 +323,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
@@ -341,8 +341,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
@@ -357,8 +357,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
@@ -373,8 +373,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
@@ -388,8 +388,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
@@ -403,8 +403,8 @@ build:
       type: foreground
       command: |
         export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 
@@ -423,8 +423,8 @@ build:
       type: foreground
       command: |
         export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 
@@ -448,8 +448,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -469,8 +469,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
@@ -490,8 +490,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -511,8 +511,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
@@ -535,8 +535,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -563,8 +563,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
@@ -591,8 +591,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -617,8 +617,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
@@ -643,8 +643,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -668,8 +668,8 @@ build:
         sudo apt install python3-pip -y
         python3 -m pip install -U pip
         python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
@@ -686,8 +686,8 @@ build:
       type: foreground
       command: |
         export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 
@@ -710,8 +710,8 @@ build:
 #        sudo apt install python3-pip -y
 #        python3 -m pip install -U pip
 #        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
 #        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
@@ -721,8 +721,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //nodejs/...
         cp -rL bazel-bin/nodejs/node_modules nodejs/.
@@ -741,8 +741,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //nodejs/...
         cp -rL bazel-bin/nodejs/node_modules nodejs/.
@@ -758,8 +758,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
           .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
@@ -774,8 +774,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
           .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
@@ -791,8 +791,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
           .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
@@ -805,8 +805,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
           .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
@@ -820,8 +820,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
           .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
@@ -834,8 +834,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
           .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
@@ -851,8 +851,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
@@ -872,8 +872,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
           .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
@@ -893,8 +893,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
@@ -912,8 +912,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
           .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
@@ -931,8 +931,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
           .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
@@ -949,8 +949,8 @@ build:
       dependencies:
         - build
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh && # use source to receive export vars
           .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
@@ -967,8 +967,8 @@ build:
       command: |
         sudo apt-get update
         sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -985,8 +985,8 @@ build:
         - build
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&
@@ -1006,8 +1006,8 @@ build:
       command: |
         sudo apt-get update
         sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -1022,8 +1022,8 @@ build:
         - build
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
@@ -1040,8 +1040,8 @@ build:
       command: |
         sudo apt-get update
         sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -1056,8 +1056,8 @@ build:
         - build
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&
@@ -1077,8 +1077,8 @@ build:
       command: |
         sudo apt-get update
         sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -1100,8 +1100,8 @@ build:
         - build
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
@@ -1125,8 +1125,8 @@ build:
       command: |
         sudo apt-get update
         sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -1146,8 +1146,8 @@ build:
         - build
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&
@@ -1169,8 +1169,8 @@ build:
       command: |
         sudo apt-get update
         sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&
@@ -1189,8 +1189,8 @@ build:
         - build
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         source tool/test/start-cloud-servers.sh &&
@@ -1208,8 +1208,8 @@ build:
       command: |
         sudo apt-get update
         sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         tool/test/start-core-server.sh &&

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Discussion Forum](https://img.shields.io/discourse/https/forum.typedb.com/topics.svg)](https://forum.typedb.com)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typedb-796de3.svg)](https://stackoverflow.com/questions/tagged/typedb)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat)](https://cloudsmith.com)
 
 This repository stores all TypeDB Drivers built by Vaticle.
 
@@ -18,3 +19,9 @@ See the table below for links to README files, documentation, and source code.
 | Java | [README](https://github.com/vaticle/typedb-driver/tree/development/java/README.md) | [Documentation](https://typedb.com/docs/clients/java-driver)       | [`java/`](https://github.com/vaticle/typedb-driver/tree/development/java)     |
 | C | Coming soon | Coming soon | [`c/`](https://github.com/vaticle/typedb-driver/tree/development/c)   |
 | C++ | [README](https://github.com/vaticle/typedb-driver/tree/development/cpp/README.md) | Coming soon | [`cpp/`](https://github.com/vaticle/typedb-driver/tree/development/cpp)   |
+
+### Package hosting
+Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.

--- a/RELEASE_NOTES_LATEST.md
+++ b/RELEASE_NOTES_LATEST.md
@@ -22,7 +22,7 @@ Documentation: https://typedb.com/docs/clients/java-driver
 <repositories>
     <repository>
         <id>repo.typedb.com</id>
-        <url>https://repo.typedb.com/public/public/maven/</url>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 <dependencies>

--- a/RELEASE_NOTES_LATEST.md
+++ b/RELEASE_NOTES_LATEST.md
@@ -15,14 +15,14 @@ cargo add typedb-driver@2.26.5
 
 ### Java driver
 
-Available through https://repo.vaticle.com
+Available through https://repo.typedb.com
 Documentation: https://typedb.com/docs/clients/java-driver
 
 ```xml
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public/maven/</url>
     </repository>
 </repositories>
 <dependencies>

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -15,14 +15,14 @@ cargo add typedb-driver@{version}
 
 ### Java driver
 
-Available through https://repo.vaticle.com
+Available through https://repo.typedb.com
 Documentation: https://typedb.com/docs/clients/java-driver
 
 ```xml
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public/maven/</url>
     </repository>
 </repositories>
 <dependencies>

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -22,7 +22,7 @@ Documentation: https://typedb.com/docs/clients/java-driver
 <repositories>
     <repository>
         <id>repo.typedb.com</id>
-        <url>https://repo.typedb.com/public/public/maven/</url>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 <dependencies>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -240,6 +240,12 @@ rules_ts_dependencies(
 load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains")
 register_jq_toolchains()
 
+# Load @vaticle_bazel_distribution_cloudsmith
+load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
+cloudsmith_deps()
+load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
+install_cloudsmith_deps()
+
 ###############
 # Load @maven #
 ###############

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -240,11 +240,11 @@ rules_ts_dependencies(
 load("@aspect_bazel_lib//lib:repositories.bzl", "register_jq_toolchains")
 register_jq_toolchains()
 
-# Load @vaticle_bazel_distribution_cloudsmith
-load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
-cloudsmith_deps()
-load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
-install_cloudsmith_deps()
+# Load @vaticle_bazel_distribution_uploader
+load("@vaticle_bazel_distribution//common/uploader:deps.bzl", uploader_deps = "deps")
+uploader_deps()
+load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
+install_uploader_deps()
 
 ###############
 # Load @maven #

--- a/c/BUILD
+++ b/c/BUILD
@@ -149,50 +149,50 @@ assemble_zip(
     target_compatible_with = constraint_win_x86_64,
 )
 
-# Deployment to repo.vaticle.com
+# Deployment to repo.typedb.com
 deploy_artifact(
     name = "deploy-linux-arm64-targz",
     target = ":assemble-linux-arm64-targz",
-    artifact_group = "vaticle_typedb_driver_clib",
+    artifact_group = "typedb-driver-clib-linux-arm64",
     artifact_name = "typedb-driver-clib-linux-arm64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-linux-x86_64-targz",
     target = ":assemble-linux-x86_64-targz",
-    artifact_group = "vaticle_typedb_driver_clib",
+    artifact_group = "typedb-driver-clib-linux-x86_64",
     artifact_name = "typedb-driver-clib-linux-x86_64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-arm64-zip",
     target = ":assemble-mac-arm64-zip",
-    artifact_group = "vaticle_typedb_driver_clib",
+    artifact_group = "typedb-driver-clib-mac-arm64",
     artifact_name = "typedb-driver-clib-mac-arm64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-x86_64-zip",
     target = ":assemble-mac-x86_64-zip",
-    artifact_group = "vaticle_typedb_driver_clib",
+    artifact_group = "typedb-driver-clib-mac-x86_64",
     artifact_name = "typedb-driver-clib-mac-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-windows-x86_64-zip",
     target = ":assemble-windows-x86_64-zip",
-    artifact_group = "vaticle_typedb_driver_clib",
+    artifact_group = "typedb-driver-clib-windows-x86_64",
     artifact_name = "typedb-driver-clib-windows-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 alias(

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -134,50 +134,50 @@ assemble_zip(
     target_compatible_with = constraint_win_x86_64,
 )
 
-# Deployment to repo.vaticle.com
+# Deployment to repo.typedb.com
 deploy_artifact(
     name = "deploy-linux-arm64-targz",
     target = ":assemble-linux-arm64-targz",
-    artifact_group = "vaticle_typedb_driver_cpp",
+    artifact_group = "typedb-driver-cpp-linux-arm64",
     artifact_name = "typedb-driver-cpp-linux-arm64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-linux-x86_64-targz",
     target = ":assemble-linux-x86_64-targz",
-    artifact_group = "vaticle_typedb_driver_cpp",
+    artifact_group = "typedb-driver-cpp-linux-x86_64",
     artifact_name = "typedb-driver-cpp-linux-x86_64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-arm64-zip",
     target = ":assemble-mac-arm64-zip",
-    artifact_group = "vaticle_typedb_driver_cpp",
+    artifact_group = "typedb-driver-cpp-mac-arm64",
     artifact_name = "typedb-driver-cpp-mac-arm64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-x86_64-zip",
     target = ":assemble-mac-x86_64-zip",
-    artifact_group = "vaticle_typedb_driver_cpp",
+    artifact_group = "typedb-driver-cpp-mac-x86_64",
     artifact_name = "typedb-driver-cpp-mac-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-windows-x86_64-zip",
     target = ":assemble-windows-x86_64-zip",
-    artifact_group = "vaticle_typedb_driver_cpp",
+    artifact_group = "typedb-driver-cpp-windows-x86_64",
     artifact_name = "typedb-driver-cpp-windows-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 alias(

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -15,8 +15,8 @@
 @maven//:com_google_http_client_google_http_client_1_34_2
 @maven//:com_google_j2objc_j2objc_annotations_1_3
 @maven//:com_google_protobuf_protobuf_java_3_21_1
-@maven//:com_vaticle_typedb_typedb_cloud_runner_1e0400ba243914013225a3820e37e19bb85d5798
-@maven//:com_vaticle_typedb_typedb_runner_95a72636d35355c564fe03c41f0341e9a03e1a17
+@maven//:com_vaticle_typedb_typedb_cloud_runner_f78fdb0d3ac4c533c0eb9a2e02d986702435efe4
+@maven//:com_vaticle_typedb_typedb_runner_525f9e989ac9fb2d06a05e0ad61c711610803526
 @maven//:commons_codec_commons_codec_1_11
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging_1_2

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,21 +25,21 @@ load("@vaticle_dependencies//distribution:deployment.bzl", "deployment", "deploy
 def vaticle_typedb_artifact():
     native_artifact_files(
         name = "vaticle_typedb_artifact",
-        group_name = "vaticle_typedb",
+        group_name = "typedb-server-{platform}",
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
-        tag_source = deployment["artifact.release"],
-        commit_source = deployment["artifact.snapshot"],
-        commit = "e0941f2f70988fa0a7fe9510b175e91d55126db4",
+        tag_source = deployment["artifact"]["release"]["download"],
+        commit_source = deployment["artifact"]["snapshot"]["download"],
+        commit = "ec2389722fdca18ba91b3ce868426253fc460e33",
     )
 
 def vaticle_typedb_cloud_artifact():
     native_artifact_files(
         name = "vaticle_typedb_cloud_artifact",
-        group_name = "vaticle_typedb_cloud",
-        artifact_name = "typedb-cloud-all-{platform}-{version}.{ext}",
-        tag_source = deployment_private["artifact.release"],
-        commit_source = deployment_private["artifact.snapshot"],
-        commit = "332275dfce4d02c8293216251a35a23c2e991f33",
+        group_name = "typedb-cloud-server-{platform}",
+        artifact_name = "typedb-cloud-server-{platform}-{version}.{ext}",
+        tag_source = deployment_private["artifact"]["release"]["download"],
+        commit_source = deployment_private["artifact"]["snapshot"]["download"],
+        commit = "edde901db7683f9309fdbb300f1d5bb67d420372",
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "ec2389722fdca18ba91b3ce868426253fc460e33",
+        commit = "525f9e989ac9fb2d06a05e0ad61c711610803526",
     )
 
 def vaticle_typedb_cloud_artifact():
@@ -39,10 +39,10 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        commit = "edde901db7683f9309fdbb300f1d5bb67d420372",
+        commit = "f78fdb0d3ac4c533c0eb9a2e02d986702435efe4",
     )
 
 maven_artifacts = {
-    'com.vaticle.typedb:typedb-runner': '95a72636d35355c564fe03c41f0341e9a03e1a17',
-    'com.vaticle.typedb:typedb-cloud-runner': '1e0400ba243914013225a3820e37e19bb85d5798',
+    'com.vaticle.typedb:typedb-runner': '525f9e989ac9fb2d06a05e0ad61c711610803526',
+    'com.vaticle.typedb:typedb-cloud-runner': 'f78fdb0d3ac4c533c0eb9a2e02d986702435efe4',
 }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -47,7 +47,7 @@ def vaticle_typedb_protocol():
     VATICLE_TYPEDB_PROTOCOL_VERSION = "a1ebf01a761268dc28c6fd2ab8b6cd825431f3d4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/krishnangovindraj/typedb-protocol",
+        remote = "https://github.com/vaticle/typedb-protocol",
         commit = "7b223fe459f9f0d1358ca3a71e531308aa328b7e"
     )
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,7 +32,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "731c7d149c40e9ae1430a29cea4c3819a68d3b2d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "fb539f760b16412118d68c782c9cdf7d93e6f395",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,31 +24,31 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "1d4919aa905a180dbe97b145d6861881893724e9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/krishnangovindraj/dependencies",
+        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "1f0f1ec07c9869423b5698271fcca76fde4b4f9e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/krishnangovindraj/typedb-common",
+        commit = "731c7d149c40e9ae1430a29cea4c3819a68d3b2d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        tag = "2.25.8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/krishnangovindraj/typeql",
+        commit = "2212a98f5eb7ec3f9e5389831cf2ceebd63d5044",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
     # needed for workspace status
-    VATICLE_TYPEDB_PROTOCOL_VERSION = "9575d084bf4a8618175b70c316b476a8d3984cab" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+    VATICLE_TYPEDB_PROTOCOL_VERSION = "2.25.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        commit = VATICLE_TYPEDB_PROTOCOL_VERSION
+        remote = "https://github.com/krishnangovindraj/typedb-protocol",
+        commit = "7b223fe459f9f0d1358ca3a71e531308aa328b7e"
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,27 +24,27 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "a4a3bac9515fd51365e02f6aad762f67357e49a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "fb539f760b16412118d68c782c9cdf7d93e6f395",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "dbc333528ecdafa5b571344237e831619c3fa5f0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/krishnangovindraj/typeql",
-        commit = "2212a98f5eb7ec3f9e5389831cf2ceebd63d5044",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/vaticle/typeql",
+        commit = "3a523f4d7d40b0c5d3b9af68f31a3859215fa671",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
     # needed for workspace status
-    VATICLE_TYPEDB_PROTOCOL_VERSION = "2.25.2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+    VATICLE_TYPEDB_PROTOCOL_VERSION = "a1ebf01a761268dc28c6fd2ab8b6cd825431f3d4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/krishnangovindraj/typedb-protocol",

--- a/java/BUILD
+++ b/java/BUILD
@@ -69,8 +69,8 @@ assemble_maven(
 
 deploy_maven(
     name = "deploy-maven",
-    release = deployment["maven.release"],
-    snapshot = deployment["maven.snapshot"],
+    release = deployment['maven']['release']['upload'],
+    snapshot = deployment['maven']['snapshot']['upload'],
     target = ":assemble-maven",
 )
 
@@ -104,8 +104,8 @@ assemble_maven(
 
 deploy_maven(
     name = "deploy-maven-jni",
-    release = deployment["maven.release"],
-    snapshot = deployment["maven.snapshot"],
+    release = deployment['maven']['release']['upload'],
+    snapshot = deployment['maven']['snapshot']['upload'],
     target = ":assemble-maven-jni",
 )
 

--- a/java/README.md
+++ b/java/README.md
@@ -11,8 +11,8 @@ To learn about the methods available for executing queries and retrieving their 
 ```xml
 <repositories>
     <repository>
-        <id>repo.vaticle.com</id>
-        <url>https://repo.vaticle.com/repository/maven/</url>
+        <id>repo.typedb.com</id>
+        <url>https://repo.typedb.com/public/public/maven/</url>
     </repository>
 </repositories>
 

--- a/java/README.md
+++ b/java/README.md
@@ -12,7 +12,7 @@ To learn about the methods available for executing queries and retrieving their 
 <repositories>
     <repository>
         <id>repo.typedb.com</id>
-        <url>https://repo.typedb.com/public/public/maven/</url>
+        <url>https://repo.typedb.com/public/public-release/maven/</url>
     </repository>
 </repositories>
 

--- a/java/test/behaviour/BehaviourTest.java
+++ b/java/test/behaviour/BehaviourTest.java
@@ -21,7 +21,7 @@
 
 package com.vaticle.typedb.driver.test.behaviour;
 
-import com.vaticle.typedb.core.test.runner.TypeDBSingleton;
+import com.vaticle.typedb.common.test.TypeDBSingleton;
 import org.junit.AfterClass;
 
 public abstract class BehaviourTest {

--- a/java/test/behaviour/BehaviourTest.java
+++ b/java/test/behaviour/BehaviourTest.java
@@ -21,7 +21,7 @@
 
 package com.vaticle.typedb.driver.test.behaviour;
 
-import com.vaticle.typedb.common.test.TypeDBSingleton;
+import com.vaticle.typedb.core.tool.runner.TypeDBSingleton;
 import org.junit.AfterClass;
 
 public abstract class BehaviourTest {

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -21,7 +21,7 @@
 
 package com.vaticle.typedb.driver.test.behaviour.connection;
 
-import com.vaticle.typedb.common.test.TypeDBSingleton;
+import com.vaticle.typedb.core.tool.runner.TypeDBSingleton;
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBOptions;
 import com.vaticle.typedb.driver.api.TypeDBSession;

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -21,7 +21,7 @@
 
 package com.vaticle.typedb.driver.test.behaviour.connection;
 
-import com.vaticle.typedb.core.test.runner.TypeDBSingleton;
+import com.vaticle.typedb.common.test.TypeDBSingleton;
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBOptions;
 import com.vaticle.typedb.driver.api.TypeDBSession;

--- a/java/test/behaviour/connection/ConnectionStepsCloud.java
+++ b/java/test/behaviour/connection/ConnectionStepsCloud.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.driver.test.behaviour.connection;
 
-import com.vaticle.typedb.common.test.TypeDBRunner;
-import com.vaticle.typedb.common.test.TypeDBSingleton;
-import com.vaticle.typedb.common.test.cloud.TypeDBCloudRunner;
+import com.vaticle.typedb.core.tool.runner.TypeDBRunner;
+import com.vaticle.typedb.core.tool.runner.TypeDBSingleton;
+import com.vaticle.typedb.cloud.tool.runner.TypeDBCloudRunner;
 import com.vaticle.typedb.driver.TypeDB;
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBCredential;

--- a/java/test/behaviour/connection/ConnectionStepsCloud.java
+++ b/java/test/behaviour/connection/ConnectionStepsCloud.java
@@ -21,13 +21,13 @@
 
 package com.vaticle.typedb.driver.test.behaviour.connection;
 
+import com.vaticle.typedb.common.test.TypeDBRunner;
+import com.vaticle.typedb.common.test.TypeDBSingleton;
+import com.vaticle.typedb.common.test.cloud.TypeDBCloudRunner;
 import com.vaticle.typedb.driver.TypeDB;
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBCredential;
 import com.vaticle.typedb.driver.api.TypeDBOptions;
-import com.vaticle.typedb.core.test.runner.TypeDBRunner;
-import com.vaticle.typedb.core.test.runner.TypeDBSingleton;
-import com.vaticle.typedb.cloud.test.runner.TypeDBCloudRunner;
 import com.vaticle.typedb.driver.api.database.Database;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;

--- a/java/test/behaviour/connection/ConnectionStepsCore.java
+++ b/java/test/behaviour/connection/ConnectionStepsCore.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.driver.test.behaviour.connection;
 
-import com.vaticle.typedb.core.test.runner.TypeDBCoreRunner;
-import com.vaticle.typedb.core.test.runner.TypeDBRunner;
-import com.vaticle.typedb.core.test.runner.TypeDBSingleton;
+import com.vaticle.typedb.common.test.TypeDBRunner;
+import com.vaticle.typedb.common.test.TypeDBSingleton;
+import com.vaticle.typedb.common.test.core.TypeDBCoreRunner;
 import com.vaticle.typedb.driver.TypeDB;
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBOptions;

--- a/java/test/behaviour/connection/ConnectionStepsCore.java
+++ b/java/test/behaviour/connection/ConnectionStepsCore.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.driver.test.behaviour.connection;
 
-import com.vaticle.typedb.common.test.TypeDBRunner;
-import com.vaticle.typedb.common.test.TypeDBSingleton;
-import com.vaticle.typedb.common.test.core.TypeDBCoreRunner;
+import com.vaticle.typedb.core.tool.runner.TypeDBRunner;
+import com.vaticle.typedb.core.tool.runner.TypeDBSingleton;
+import com.vaticle.typedb.core.tool.runner.TypeDBCoreRunner;
 import com.vaticle.typedb.driver.TypeDB;
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBOptions;

--- a/java/test/deployment/pom.xml
+++ b/java/test/deployment/pom.xml
@@ -30,14 +30,14 @@ under the License.
     <url>https://maven.apache.org</url>
     <repositories>
         <repository>
-            <id>repo.vaticle.com.release</id>
-            <name>repo.vaticle.com</name>
-            <url>https://repo.vaticle.com/repository/maven/</url>
+            <id>repo.typedb.com.release</id>
+            <name>repo.typedb.com</name>
+            <url>https://repo.typedb.com/public/public/maven/</url>
         </repository>
         <repository>
-            <id>repo.vaticle.com.snapshot</id>
-            <name>repo.vaticle.com</name>
-            <url>https://repo.vaticle.com/repository/maven-snapshot/</url>
+            <id>repo.typedb.com.snapshot</id>
+            <name>repo.typedb.com</name>
+            <url>https://repo.typedb.com/public/public-snapshot/maven/</url>
         </repository>
     </repositories>
     <build>

--- a/java/test/deployment/pom.xml
+++ b/java/test/deployment/pom.xml
@@ -32,7 +32,7 @@ under the License.
         <repository>
             <id>repo.typedb.com.release</id>
             <name>repo.typedb.com</name>
-            <url>https://repo.typedb.com/public/public/maven/</url>
+            <url>https://repo.typedb.com/public/public-release/maven/</url>
         </repository>
         <repository>
             <id>repo.typedb.com.snapshot</id>

--- a/java/test/integration/DriverQueryTest.java
+++ b/java/test/integration/DriverQueryTest.java
@@ -21,7 +21,7 @@
 
 package com.vaticle.typedb.driver.test.integration;
 
-import com.vaticle.typedb.core.test.runner.TypeDBCoreRunner;
+import com.vaticle.typedb.core.tool.runner.TypeDBCoreRunner;
 import com.vaticle.typedb.driver.TypeDB;
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBOptions;

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -120,8 +120,8 @@ assemble_npm(
 deploy_npm(
     name = "deploy-npm",
     target = ":assemble-npm",
-    snapshot = deployment["npm.snapshot"],
-    release = deployment["npm.release"],
+    snapshot = deployment['npm']['snapshot'],
+    release = deployment['npm']['release'],
 )
 
 # This rule should be in tool/typedoc, but there is a problem with the path configurations

--- a/python/rules.bzl
+++ b/python/rules.bzl
@@ -92,8 +92,8 @@ def native_driver_versioned(python_versions):
         deploy_pip(
             name = "deploy-pip" + version["suffix"],
             target = ":assemble-pip" + version["suffix"],
-            snapshot = deployment["pypi.snapshot"],
-            release = deployment["pypi.release"],
+            snapshot = deployment['pypi']['snapshot'],
+            release = deployment['pypi']['release'],
             suffix = version["suffix"],
             distribution_tag = select({
                 "@vaticle_bazel_distribution//platform:is_mac_arm64": "py" + version["suffix"] + "-none-macosx_11_0_arm64",

--- a/python/tests/deployment/requirements.txt
+++ b/python/tests/deployment/requirements.txt
@@ -19,6 +19,6 @@
 # under the License.
 #
 
---extra-index-url https://repo.vaticle.com/repository/pypi-snapshot/simple
+--extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple
 
 typedb-driver==DRIVER_PYTHON_VERSION_MARKER

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -92,8 +92,8 @@ assemble_crate(
 
 deploy_crate(
     name = "deploy_crate",
-    release = deployment["crate.release"],
-    snapshot = deployment["crate.snapshot"],
+    release = deployment['crate']['release'],
+    snapshot = deployment['crate']['snapshot'],
     target = ":assemble_crate",
 )
 


### PR DESCRIPTION
## Usage and product changes

Updates artifact deployment & consumption rules to use cloudsmith (repo.typedb.com) instead of the self-hosted sonatype repository (repo.vaticle.com).

## Implementation
* Updates deployment & artifact consumption rules to point to Cloudsmith and update deployment rules and repositories
* Updates `artifact_group`s to reflect the revised repository layout
* Update package import paths for TypeDBRunner