### PR TITLE
Release from Amazon Linux to supports GLIBC 2.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,13 +195,14 @@ commands:
         type: string
     steps:
       - run: |
-          bazel build --jobs=8 //c:assemble-linux-<<parameters.target-arch>>-targz
-          export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
+          yum install -y cmake3 make
+          bazel build --jobs=8 //c:assemble-linux-x86_64-targz
+          export ASSEMBLY=typedb-driver-clib-linux-x86_64
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib
           pushd test_assembly_clib
-            cmake ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
-            cmake --build . --config release
+            cmake3 ../c/tests/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
+            cmake3 --build . --config release
           popd
           tool/test/start-core-server.sh
           sleep 3
@@ -258,13 +259,14 @@ commands:
         type: string
     steps:
       - run: |
+          yum install -y cmake3 make
           bazel build --jobs=8 //cpp:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
           tar -xf bazel-bin/cpp/$ASSEMBLY.tar.gz --directory test_assembly_cpp
           pushd test_assembly_cpp
-            cmake ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
-            cmake --build . --config release
+            cmake3 ../cpp/test/assembly -DTYPEDB_ASSEMBLY=$(pwd)/$ASSEMBLY &&
+            cmake3 --build . --config release
           popd
           tool/test/start-core-server.sh
           sleep 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,15 @@ orbs:
   macos: circleci/macos@2.4.0
 
 executors:
-  linux-arm64-ubuntu-1804:
+  linux-arm64-amazonlinux-2:
     docker:
-      - image: ubuntu:18.04
+      - image: amazonlinux:2
     resource_class: arm.large
     working_directory: ~/typedb-driver
 
-  linux-x86_64-ubuntu-1804:
+  linux-x86_64-amazonlinux-2:
     docker:
-      - image: ubuntu:18.04
+      - image: amazonlinux:2
     resource_class: large
     working_directory: ~/typedb-driver
 
@@ -57,10 +57,9 @@ commands:
         type: string
     steps:
       - run: |
-          apt-get -y update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
-          apt-get -y install curl build-essential git python3 python3-pip python3.8 default-jre lsof cmake file wget
-          python3.8 -m pip install pip==21.3.1
+          amazon-linux-extras install python3.8 -y
+          yum install -y git tar java-1.8.0-openjdk gcc gcc-c++ file lsof which procps
+          ln -s /usr/bin/python3.8 /usr/bin/python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -79,15 +78,15 @@ commands:
   ###########################
   # Python deployment steps #
   ###########################
-
-  install-pip-requirements-linux-py37:
-    steps:
-      - run: |
-          apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y python3.7
-          update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
-          update-alternatives --install /usr/bin/python3 python /usr/bin/python3.7 2
-          python3 -m pip install pip==21.3.1
-          python3 -m pip install -r python/requirements_dev.txt
+#
+#  install-pip-requirements-linux-py37:
+#    steps:
+#      - run: |
+#          apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y python3.7
+#          update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
+#          update-alternatives --install /usr/bin/python3 python /usr/bin/python3.7 2
+#          python3 -m pip install pip==21.3.1
+#          python3 -m pip install -r python/requirements_dev.txt
 
   install-pip-requirements:
     steps:
@@ -97,6 +96,7 @@ commands:
 
   deploy-pip-snapshot-unix:
     steps:
+      - install-pip-requirements
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -104,16 +104,6 @@ commands:
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip311 -- snapshot
-
-  deploy-pip-snapshot-linux:
-    steps:
-      - install-pip-requirements-linux-py37
-      - deploy-pip-snapshot-unix
-
-  deploy-pip-snapshot-mac:
-    steps:
-      - install-pip-requirements
-      - deploy-pip-snapshot-unix
 
   test-pip-snapshot-unix:
     steps:
@@ -129,6 +119,7 @@ commands:
 
   deploy-pip-release-unix:
     steps:
+      - install-pip-requirements
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
@@ -137,15 +128,6 @@ commands:
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip310 --compilation_mode=opt -- release
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip311 --compilation_mode=opt -- release
 
-  deploy-pip-release-linux:
-    steps:
-      - install-pip-requirements-linux-py37
-      - deploy-pip-release-unix
-
-  deploy-pip-release-mac:
-    steps:
-      - install-pip-requirements
-      - deploy-pip-release-unix
 
   #########################
   # Java deployment steps #
@@ -329,13 +311,13 @@ jobs:
   #################
 
   deploy-snapshot-linux-arm64:
-    executor: linux-arm64-ubuntu-1804
+    executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
           bazel-arch: arm64
 
-      - deploy-pip-snapshot-linux
+      - deploy-pip-snapshot-unix
 
       - deploy-maven-jni-snapshot-unix
 
@@ -348,13 +330,13 @@ jobs:
           target-arch: arm64
 
   deploy-snapshot-linux-x86_64:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
           bazel-arch: amd64
 
-      - deploy-pip-snapshot-linux
+      - deploy-pip-snapshot-unix
 
       - deploy-maven-jni-snapshot-unix
 
@@ -373,7 +355,7 @@ jobs:
       - install-bazel-mac:
           bazel-arch: arm64
 
-      - deploy-pip-snapshot-mac
+      - deploy-pip-snapshot-unix
 
       - deploy-maven-jni-snapshot-unix
 
@@ -395,7 +377,7 @@ jobs:
       - install-bazel-mac:
           bazel-arch: amd64
 
-      - deploy-pip-snapshot-mac
+      - deploy-pip-snapshot-unix
 
       - deploy-maven-jni-snapshot-unix
 
@@ -429,7 +411,7 @@ jobs:
       - run: .circleci\windows\cpp\test_assembly.bat
 
   deploy-maven-snapshot:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -438,7 +420,7 @@ jobs:
 
 
   test-snapshot-linux-arm64:
-    executor: linux-arm64-ubuntu-1804
+    executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -448,7 +430,7 @@ jobs:
       - test-maven-snapshot-unix
 
   test-snapshot-linux-x86_64:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -494,12 +476,12 @@ jobs:
   ################
 
   deploy-release-linux-arm64:
-    executor: linux-arm64-ubuntu-1804
+    executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
           bazel-arch: arm64
-      - deploy-pip-release-linux
+      - deploy-pip-release-unix
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
@@ -519,12 +501,12 @@ jobs:
           paths: ["./*"]
 
   deploy-release-linux-x86_64:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
           bazel-arch: amd64
-      - deploy-pip-release-linux
+      - deploy-pip-release-unix
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
@@ -550,7 +532,7 @@ jobs:
       - checkout
       - install-bazel-mac:
           bazel-arch: arm64
-      - deploy-pip-release-mac
+      - deploy-pip-release-unix
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
@@ -577,7 +559,7 @@ jobs:
       - macos/install-rosetta
       - install-bazel-mac:
           bazel-arch: amd64
-      - deploy-pip-release-mac
+      - deploy-pip-release-unix
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
@@ -613,7 +595,7 @@ jobs:
           paths: ["./*"]
 
   deploy-maven-release:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -627,7 +609,7 @@ jobs:
           paths: ["./*"]
 
   deploy-crate-release:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -642,7 +624,7 @@ jobs:
           paths: ["./*"]
 
   deploy-npm-release:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -661,7 +643,7 @@ jobs:
           paths: ["./*"]
 
   deploy-github:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - attach_workspace:
           at: ~/dist
@@ -678,7 +660,7 @@ jobs:
               -c ${CIRCLE_SHA1} -delete $(cat VERSION) ~/dist/
 
   release-cleanup:
-    executor: linux-x86_64-ubuntu-1804
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - run: |
@@ -693,28 +675,28 @@ workflows:
       - deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
       - deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
       - deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
       - deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
 
       - deploy-maven-snapshot:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64
@@ -725,35 +707,35 @@ workflows:
       - test-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-maven-snapshot
       - test-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
           requires:
             - deploy-snapshot-linux-x86_64
             - deploy-maven-snapshot
       - test-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
           requires:
             - deploy-snapshot-mac-arm64
             - deploy-maven-snapshot
       - test-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
           requires:
             - deploy-snapshot-mac-x86_64
             - deploy-maven-snapshot
       - test-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, circleci-build-amazonlinux-2]
           requires:
             - deploy-snapshot-windows-x86_64
             - deploy-maven-snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,15 +78,6 @@ commands:
   ###########################
   # Python deployment steps #
   ###########################
-#
-#  install-pip-requirements-linux-py37:
-#    steps:
-#      - run: |
-#          apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y python3.7
-#          update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
-#          update-alternatives --install /usr/bin/python3 python /usr/bin/python3.7 2
-#          python3 -m pip install pip==21.3.1
-#          python3 -m pip install -r python/requirements_dev.txt
 
   install-pip-requirements:
     steps:
@@ -196,8 +187,8 @@ commands:
     steps:
       - run: |
           yum install -y cmake3 make
-          bazel build --jobs=8 //c:assemble-linux-x86_64-targz
-          export ASSEMBLY=typedb-driver-clib-linux-x86_64
+          bazel build --jobs=8 //c:assemble-linux-<<parameters.target-arch>>-targz
+          export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
           tar -xf bazel-bin/c/$ASSEMBLY.tar.gz --directory test_assembly_clib
           pushd test_assembly_clib
@@ -677,28 +668,28 @@ workflows:
       - deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
       - deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
       - deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
       - deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
 
       - deploy-maven-snapshot:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64
@@ -709,35 +700,35 @@ workflows:
       - test-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-maven-snapshot
       - test-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
           requires:
             - deploy-snapshot-linux-x86_64
             - deploy-maven-snapshot
       - test-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
           requires:
             - deploy-snapshot-mac-arm64
             - deploy-maven-snapshot
       - test-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
           requires:
             - deploy-snapshot-mac-x86_64
             - deploy-maven-snapshot
       - test-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, development, circleci-build-amazonlinux-2]
+              only: [master, development]
           requires:
             - deploy-snapshot-windows-x86_64
             - deploy-maven-snapshot

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -59,1222 +59,1222 @@ build:
         cd nodejs
         npm install
         npm run lint
-#
-#    build-dependency:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        dependencies/maven/update.sh
-#        git diff --exit-code dependencies/maven/artifacts.snapshot
-#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-#
-#    build-docs:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar xzO doxygen-1.10.0/bin/doxygen > /var/tmp/doxygen &&
-#          sudo mv /var/tmp/doxygen /usr/local/bin/ && sudo chmod +x /usr/local/bin/doxygen
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs cpp/docs"
-#        rm -rf $DOCS_DIRS
-#        tool/docs/update.sh
-#        git add $DOCS_DIRS
-#        git diff --exit-code HEAD $DOCS_DIRS
-#
-#    test-rust-unit-integration:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
-#        tool/test/start-core-server.sh &&
-#          bazel test //rust/tests --test_output=streamed --test_arg=-- \
-#            --test_arg=integration::queries::core &&
-#          export CORE_FAILED= || export CORE_FAILED=1
-#        tool/test/stop-core-server.sh
-#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
-#
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=integration::queries::cloud \
-#            --test_arg=integration::runtimes &&
-#          export CLOUD_FAILED= || export CLOUD_FAILED=1
-#        tool/test/stop-cloud-servers.sh
-#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
-#
-#    test-rust-behaviour-concept:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::concept &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-connection:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::connection &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-driver:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::driver &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-query-read:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::query::language::match_ \
-#            --test_arg=behaviour::query::language::get \
-#            --test_arg=behaviour::query::language::fetch \
-#            --test_arg=behaviour::query::language::modifiers \
-#            --test_arg=behaviour::query::language::expression &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-rust-behaviour-query-write:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-#            --test_arg=behaviour::query::language::define \
-#            --test_arg=behaviour::query::language::undefine \
-#            --test_arg=behaviour::query::language::insert \
-#            --test_arg=behaviour::query::language::delete \
-#            --test_arg=behaviour::query::language::update \
-#            --test_arg=behaviour::query::language::rule_validation &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-c-integration:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          bazel test //c/tests/integration:test-driver --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-java-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //java/test/integration/... --test_output=errors
-#
-#    test-java-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-#
-#    test-java-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-#
-#    test-java-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
-#
-#    test-java-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
-#
-#    test-java-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
-#
-#    test-java-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
-#
-#    test-java-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-#
-#    test-java-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-#
-#    test-java-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
-#
-#    test-java-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
-#
-#    test-java-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
-#        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-#
-#    test-java-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
-#        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-#
-#
-#    test-python-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
-#          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        sudo apt-get update
-#        sudo apt install python3-pip -y
-#        python3 -m pip install -U pip
-#        python3 -m pip install -r python/requirements_dev.txt
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-python-integration-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-core-server.sh &&
-#          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-##    test-python-integration-cloud-failover:
-##      machine: 4-core-16-gb
-##      image: vaticle-ubuntu-22.04
-##      dependencies:
-##        - build
-##      type: foreground
-##      command: |
-##        export PATH="$HOME/.local/bin:$PATH"
-##        sudo apt-get update
-##        sudo apt install python3-pip -y
-##        python3 -m pip install -U pip
-##        python3 -m pip install -r python/requirements_dev.txt
-##        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-##        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-##        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-##        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-##        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
-#
-#    test-nodejs-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel build //nodejs/...
-#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-#        cp -rL bazel-bin/nodejs/dist nodejs/.
-#        tool/test/start-core-server.sh &&
-#          node nodejs/test/integration/test-concept.js &&
-#          node nodejs/test/integration/test-connection.js &&
-#          node nodejs/test/integration/test-query.js &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-cloud-failover:
+
+    build-dependency:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        dependencies/maven/update.sh
+        git diff --exit-code dependencies/maven/artifacts.snapshot
+        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+
+    build-docs:
+      image: vaticle-ubuntu-22.04
+      command: |
+        curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar xzO doxygen-1.10.0/bin/doxygen > /var/tmp/doxygen &&
+          sudo mv /var/tmp/doxygen /usr/local/bin/ && sudo chmod +x /usr/local/bin/doxygen
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs cpp/docs"
+        rm -rf $DOCS_DIRS
+        tool/docs/update.sh
+        git add $DOCS_DIRS
+        git diff --exit-code HEAD $DOCS_DIRS
+
+    test-rust-unit-integration:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
+        tool/test/start-core-server.sh &&
+          bazel test //rust/tests --test_output=streamed --test_arg=-- \
+            --test_arg=integration::queries::core && 
+          export CORE_FAILED= || export CORE_FAILED=1
+        tool/test/stop-core-server.sh
+        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=integration::queries::cloud \
+            --test_arg=integration::runtimes &&
+          export CLOUD_FAILED= || export CLOUD_FAILED=1
+        tool/test/stop-cloud-servers.sh
+        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+
+    test-rust-behaviour-concept:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::concept &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-connection:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::connection &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-driver:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::driver &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-query-read:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::query::language::match_ \
+            --test_arg=behaviour::query::language::get \
+            --test_arg=behaviour::query::language::fetch \
+            --test_arg=behaviour::query::language::modifiers \
+            --test_arg=behaviour::query::language::expression &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-rust-behaviour-query-write:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+            --test_arg=behaviour::query::language::define \
+            --test_arg=behaviour::query::language::undefine \
+            --test_arg=behaviour::query::language::insert \
+            --test_arg=behaviour::query::language::delete \
+            --test_arg=behaviour::query::language::update \
+            --test_arg=behaviour::query::language::rule_validation &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-c-integration:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          bazel test //c/tests/integration:test-driver --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-java-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel test //java/test/integration/... --test_output=errors
+
+    test-java-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+
+    test-java-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+
+    test-java-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
+
+    test-java-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
+
+    test-java-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
+
+    test-java-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
+
+    test-java-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+
+    test-java-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+
+    test-java-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
+
+    test-java-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
+
+    test-java-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
+        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+
+    test-java-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
+        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+
+
+    test-python-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
+          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-python-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-python-integration-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-core-server.sh &&
+          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+#    test-python-integration-cloud-failover:
 #      machine: 4-core-16-gb
 #      image: vaticle-ubuntu-22.04
 #      dependencies:
 #        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel build //nodejs/...
-#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-#        cp -rL bazel-bin/nodejs/dist nodejs/.
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          node nodejs/test/integration/test-cloud-failover.js &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#    # TODO: Delete --jobs=1 once tests are parallelisable
-#
-#    test-nodejs-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: development
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
-#          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-nodejs-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-connection-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
 #      type: foreground
 #      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
 #        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
 #        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-#          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-connection-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-concept-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-concept-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-driver-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-driver-cloud:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-read-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-read-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-writable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-writable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-definable-core:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
-#          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-behaviour-definable-cloud:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        source tool/test/start-cloud-servers.sh &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
-#    test-cpp-integration-core:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        sudo apt-get update
-#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
-#
-#
-#    deploy-crate-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#        - test-rust-unit-integration
-#        - test-rust-behaviour-concept
-#        - test-rust-behaviour-connection
-#        - test-rust-behaviour-query-read
-#        - test-rust-behaviour-query-write
-#      command: |
-#        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-#
-#    deploy-npm-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#        - test-nodejs-integration
-#        - test-nodejs-cloud-failover
-#        - test-nodejs-behaviour-connection-core
-#        - test-nodejs-behaviour-connection-cloud
-#        - test-nodejs-behaviour-concept-core
-#        - test-nodejs-behaviour-concept-cloud
-#        - test-nodejs-behaviour-read-core
-#        - test-nodejs-behaviour-read-cloud
-#        - test-nodejs-behaviour-writable-core
-#        - test-nodejs-behaviour-writable-cloud
-#        - test-nodejs-behaviour-definable-core
-#        - test-nodejs-behaviour-definable-cloud
-#      command: |
-#        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-#        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-#
-#    test-deployment-npm:
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - deploy-npm-snapshot
-#      command: |
-#        tool/test/start-core-server.sh
-#        cd nodejs/test/deployment/
-#        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-#        sudo -H npm install jest --global
-#        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        cd -
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
+#        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
+
+    test-nodejs-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel build //nodejs/...
+        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+        cp -rL bazel-bin/nodejs/dist nodejs/.
+        tool/test/start-core-server.sh &&
+          node nodejs/test/integration/test-concept.js &&
+          node nodejs/test/integration/test-connection.js &&
+          node nodejs/test/integration/test-query.js && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-cloud-failover:
+      machine: 4-core-16-gb
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        bazel build //nodejs/...
+        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+        cp -rL bazel-bin/nodejs/dist nodejs/.
+        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+          node nodejs/test/integration/test-cloud-failover.js && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+    # TODO: Delete --jobs=1 once tests are parallelisable
+
+    test-nodejs-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: development
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
+          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-nodejs-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-connection-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-connection-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-concept-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-concept-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-driver-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-driver-cloud:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-read-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-read-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-writable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-writable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-definable-core:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
+          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-behaviour-definable-cloud:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        source tool/test/start-cloud-servers.sh &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-cloud-servers.sh
+        exit $TEST_SUCCESS
+
+    test-cpp-integration-core:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        sudo apt-get update
+        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+
+    deploy-crate-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-rust-unit-integration
+        - test-rust-behaviour-concept
+        - test-rust-behaviour-connection
+        - test-rust-behaviour-query-read
+        - test-rust-behaviour-query-write
+      command: |
+        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+
+    deploy-npm-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-nodejs-integration
+        - test-nodejs-cloud-failover
+        - test-nodejs-behaviour-connection-core
+        - test-nodejs-behaviour-connection-cloud
+        - test-nodejs-behaviour-concept-core
+        - test-nodejs-behaviour-concept-cloud
+        - test-nodejs-behaviour-read-core
+        - test-nodejs-behaviour-read-cloud
+        - test-nodejs-behaviour-writable-core
+        - test-nodejs-behaviour-writable-cloud
+        - test-nodejs-behaviour-definable-core
+        - test-nodejs-behaviour-definable-cloud
+      command: |
+        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+
+    test-deployment-npm:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - deploy-npm-snapshot
+      command: |
+        tool/test/start-core-server.sh
+        cd nodejs/test/deployment/
+        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+        sudo -H npm install jest --global
+        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        cd -
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
 # TODO: assembly tests for all drivers to run in factory
 

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -59,646 +59,385 @@ build:
         cd nodejs
         npm install
         npm run lint
-
-    build-dependency:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        dependencies/maven/update.sh
-        git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-
-    build-docs:
-      image: vaticle-ubuntu-22.04
-      command: |
-        curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar xzO doxygen-1.10.0/bin/doxygen > /var/tmp/doxygen &&
-          sudo mv /var/tmp/doxygen /usr/local/bin/ && sudo chmod +x /usr/local/bin/doxygen
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs cpp/docs"
-        rm -rf $DOCS_DIRS
-        tool/docs/update.sh
-        git add $DOCS_DIRS
-        git diff --exit-code HEAD $DOCS_DIRS
-
-    test-rust-unit-integration:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
-        tool/test/start-core-server.sh &&
-          bazel test //rust/tests --test_output=streamed --test_arg=-- \
-            --test_arg=integration::queries::core && 
-          export CORE_FAILED= || export CORE_FAILED=1
-        tool/test/stop-core-server.sh
-        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
-
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=integration::queries::cloud \
-            --test_arg=integration::runtimes &&
-          export CLOUD_FAILED= || export CLOUD_FAILED=1
-        tool/test/stop-cloud-servers.sh
-        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
-
-    test-rust-behaviour-concept:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::concept &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-connection:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::connection &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-driver:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::driver &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-query-read:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::query::language::match_ \
-            --test_arg=behaviour::query::language::get \
-            --test_arg=behaviour::query::language::fetch \
-            --test_arg=behaviour::query::language::modifiers \
-            --test_arg=behaviour::query::language::expression &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-rust-behaviour-query-write:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
-            --test_arg=behaviour::query::language::define \
-            --test_arg=behaviour::query::language::undefine \
-            --test_arg=behaviour::query::language::insert \
-            --test_arg=behaviour::query::language::delete \
-            --test_arg=behaviour::query::language::update \
-            --test_arg=behaviour::query::language::rule_validation &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-c-integration:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          bazel test //c/tests/integration:test-driver --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-java-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel test //java/test/integration/... --test_output=errors
-
-    test-java-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-
-    test-java-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
-    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
-
-    test-java-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
-
-    test-java-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
-
-    test-java-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
-
-    test-java-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
-
-    test-java-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-
-    test-java-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
-
-    test-java-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
-
-    test-java-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
-
-    test-java-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
-        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-
-    test-java-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
-        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
-
-
-    test-python-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
-          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-python-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-python-integration-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-core-server.sh &&
-          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-#    test-python-integration-cloud-failover:
-#      machine: 4-core-16-gb
+#
+#    build-dependency:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        dependencies/maven/update.sh
+#        git diff --exit-code dependencies/maven/artifacts.snapshot
+#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+#
+#    build-docs:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz | tar xzO doxygen-1.10.0/bin/doxygen > /var/tmp/doxygen &&
+#          sudo mv /var/tmp/doxygen /usr/local/bin/ && sudo chmod +x /usr/local/bin/doxygen
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        DOCS_DIRS="java/docs nodejs/docs python/docs rust/docs cpp/docs"
+#        rm -rf $DOCS_DIRS
+#        tool/docs/update.sh
+#        git add $DOCS_DIRS
+#        git diff --exit-code HEAD $DOCS_DIRS
+#
+#    test-rust-unit-integration:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel test //rust:typedb_driver_unit_tests --test_output=streamed || exit 1
+#        tool/test/start-core-server.sh &&
+#          bazel test //rust/tests --test_output=streamed --test_arg=-- \
+#            --test_arg=integration::queries::core &&
+#          export CORE_FAILED= || export CORE_FAILED=1
+#        tool/test/stop-core-server.sh
+#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+#
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=integration::queries::cloud \
+#            --test_arg=integration::runtimes &&
+#          export CLOUD_FAILED= || export CLOUD_FAILED=1
+#        tool/test/stop-cloud-servers.sh
+#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+#
+#    test-rust-behaviour-concept:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::concept &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-connection:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::connection &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-driver:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::driver &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-query-read:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::query::language::match_ \
+#            --test_arg=behaviour::query::language::get \
+#            --test_arg=behaviour::query::language::fetch \
+#            --test_arg=behaviour::query::language::modifiers \
+#            --test_arg=behaviour::query::language::expression &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-rust-behaviour-query-write:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          bazel test //rust/tests --test_output=streamed --test_env=ROOT_CA=$ROOT_CA --test_arg=-- \
+#            --test_arg=behaviour::query::language::define \
+#            --test_arg=behaviour::query::language::undefine \
+#            --test_arg=behaviour::query::language::insert \
+#            --test_arg=behaviour::query::language::delete \
+#            --test_arg=behaviour::query::language::update \
+#            --test_arg=behaviour::query::language::rule_validation &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-c-integration:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          bazel test //c/tests/integration:test-driver --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-java-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel test //java/test/integration/... --test_output=errors
+#
+#    test-java-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        .factory/test-core.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+#
+#    test-java-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/connection/... --test_output=errors --jobs=1
+#    # TODO: delete --jobs=1 if we fix the issue with excess memory usage
+#
+#    test-java-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/concept/... --test_output=errors
+#
+#    test-java-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/concept/... --test_output=errors
+#
+#    test-java-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/driver/query/... --test_output=errors
+#
+#    test-java-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
+#
+#    test-java-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/match/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/get/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+#
+#    test-java-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/match/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/get/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/fetch/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/modifiers/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/expression/... --test_output=errors
+#
+#    test-java-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/update/... --test_output=errors
+#
+#    test-java-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/insert/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/delete/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/update/... --test_output=errors
+#
+#    test-java-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-core.sh //java/test/behaviour/query/language/define/... --test_output=errors
+#        .factory/test-core.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+#
+#    test-java-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/define/... --test_output=errors
+#        .factory/test-cloud.sh //java/test/behaviour/query/language/undefine/... --test_output=errors
+#
+#
+#    test-python-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //python/tests/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //python/tests/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-concept-core:
 #      image: vaticle-ubuntu-22.04
 #      dependencies:
 #        - build
@@ -713,568 +452,829 @@ build:
 #        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
-
-    test-nodejs-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel build //nodejs/...
-        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-        cp -rL bazel-bin/nodejs/dist nodejs/.
-        tool/test/start-core-server.sh &&
-          node nodejs/test/integration/test-concept.js &&
-          node nodejs/test/integration/test-connection.js &&
-          node nodejs/test/integration/test-query.js && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-cloud-failover:
-      machine: 4-core-16-gb
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        bazel build //nodejs/...
-        cp -rL bazel-bin/nodejs/node_modules nodejs/.
-        cp -rL bazel-bin/nodejs/dist nodejs/.
-        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          node nodejs/test/integration/test-cloud-failover.js && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-    # TODO: Delete --jobs=1 once tests are parallelisable
-
-    test-nodejs-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: development
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
-          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-nodejs-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh && # use source to receive export vars
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-connection-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
-          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-connection-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-concept-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 && 
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-concept-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-driver-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-driver-cloud:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-read-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-read-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-writable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-writable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-definable-core:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
-          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-behaviour-definable-cloud:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        source tool/test/start-cloud-servers.sh &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-cloud-servers.sh
-        exit $TEST_SUCCESS
-
-    test-cpp-integration-core:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        sudo apt-get update
-        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
-
-    deploy-crate-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-rust-unit-integration
-        - test-rust-behaviour-concept
-        - test-rust-behaviour-connection
-        - test-rust-behaviour-query-read
-        - test-rust-behaviour-query-write
-      command: |
-        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-
-    deploy-npm-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-nodejs-integration
-        - test-nodejs-cloud-failover
-        - test-nodejs-behaviour-connection-core
-        - test-nodejs-behaviour-connection-cloud
-        - test-nodejs-behaviour-concept-core
-        - test-nodejs-behaviour-concept-cloud
-        - test-nodejs-behaviour-read-core
-        - test-nodejs-behaviour-read-cloud
-        - test-nodejs-behaviour-writable-core
-        - test-nodejs-behaviour-writable-cloud
-        - test-nodejs-behaviour-definable-core
-        - test-nodejs-behaviour-definable-cloud
-      command: |
-        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-
-    test-deployment-npm:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - deploy-npm-snapshot
-      command: |
-        tool/test/start-core-server.sh
-        cd nodejs/test/deployment/
-        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-        sudo -H npm install jest --global
-        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        cd -
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/concept/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/driver/query/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/match/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/get/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/fetch/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/modifiers/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/expression/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/insert/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/delete/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/update/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/define/... --test_output=errors &&
+#          .factory/test-core.sh //python/tests/behaviour/query/language/undefine/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        sudo apt-get update
+#        sudo apt install python3-pip -y
+#        python3 -m pip install -U pip
+#        python3 -m pip install -r python/requirements_dev.txt
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //python/tests/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-python-integration-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        tool/test/start-core-server.sh &&
+#          bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+##    test-python-integration-cloud-failover:
+##      machine: 4-core-16-gb
+##      image: vaticle-ubuntu-22.04
+##      dependencies:
+##        - build
+##      type: foreground
+##      command: |
+##        export PATH="$HOME/.local/bin:$PATH"
+##        sudo apt-get update
+##        sudo apt install python3-pip -y
+##        python3 -m pip install -U pip
+##        python3 -m pip install -r python/requirements_dev.txt
+##        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+##        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+##        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+##        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+##        bazel test //python/tests/integration:test_cloud_failover --test_output=errors
+#
+#    test-nodejs-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel build //nodejs/...
+#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+#        cp -rL bazel-bin/nodejs/dist nodejs/.
+#        tool/test/start-core-server.sh &&
+#          node nodejs/test/integration/test-concept.js &&
+#          node nodejs/test/integration/test-connection.js &&
+#          node nodejs/test/integration/test-query.js &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-cloud-failover:
+#      machine: 4-core-16-gb
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        bazel build //nodejs/...
+#        cp -rL bazel-bin/nodejs/node_modules nodejs/.
+#        cp -rL bazel-bin/nodejs/dist nodejs/.
+#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
+#          node nodejs/test/integration/test-cloud-failover.js &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/database/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/session/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/connection/transaction/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#    # TODO: Delete --jobs=1 once tests are parallelisable
+#
+#    test-nodejs-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/driver/query/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/match/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/get/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/expression/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/fetch/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/modifiers/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/insert/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/delete/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/update/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: development
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/define/... --test_output=errors --jobs=1 &&
+#          .factory/test-core.sh //nodejs/test/behaviour/query/language/undefine/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-nodejs-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh && # use source to receive export vars
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          .factory/test-cloud.sh //nodejs/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-connection-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/database/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/session/... --test_output=streamed --jobs=1 &&
+#          .factory/test-core.sh //cpp/test/behaviour/connection/transaction/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-connection-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/database/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/session/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/transaction/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/connection/user/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-concept-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/concept/... --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-concept-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //cpp/test/behaviour/concept/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-driver-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/driver/query/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-driver-cloud:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/driver/query/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-read-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/match/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/get/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/fetch/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/modifiers/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/expression/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-read-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&  # use source to receive export vars
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/match/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/get/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/fetch/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/modifiers/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/expression/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-writable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/insert/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/delete/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/update/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-writable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/insert/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/delete/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/update/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-definable-core:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/define/... --test_output=errors &&
+#          .factory/test-core.sh //cpp/test/behaviour/query/language/undefine/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-behaviour-definable-cloud:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        source tool/test/start-cloud-servers.sh &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/define/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          .factory/test-cloud.sh //cpp/test/behaviour/query/language/undefine/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-cloud-servers.sh
+#        exit $TEST_SUCCESS
+#
+#    test-cpp-integration-core:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        sudo apt-get update
+#        sudo apt install clang-format-15 -y && sudo ln -s $(which clang-format-15) /usr/bin/clang-format
+#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          bazel test //cpp/test/integration/... --test_output=streamed --jobs=1 &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
+#
+#
+#    deploy-crate-snapshot:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#        - test-rust-unit-integration
+#        - test-rust-behaviour-concept
+#        - test-rust-behaviour-connection
+#        - test-rust-behaviour-query-read
+#        - test-rust-behaviour-query-write
+#      command: |
+#        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+#
+#    deploy-npm-snapshot:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#        - test-nodejs-integration
+#        - test-nodejs-cloud-failover
+#        - test-nodejs-behaviour-connection-core
+#        - test-nodejs-behaviour-connection-cloud
+#        - test-nodejs-behaviour-concept-core
+#        - test-nodejs-behaviour-concept-cloud
+#        - test-nodejs-behaviour-read-core
+#        - test-nodejs-behaviour-read-cloud
+#        - test-nodejs-behaviour-writable-core
+#        - test-nodejs-behaviour-writable-cloud
+#        - test-nodejs-behaviour-definable-core
+#        - test-nodejs-behaviour-definable-cloud
+#      command: |
+#        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+#        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+#        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+#
+#    test-deployment-npm:
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - deploy-npm-snapshot
+#      command: |
+#        tool/test/start-core-server.sh
+#        cd nodejs/test/deployment/
+#        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+#        sudo -H npm install jest --global
+#        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        cd -
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
 
 # TODO: assembly tests for all drivers to run in factory
 


### PR DESCRIPTION
## Usage and product changes

We migrate release jobs in CircleCI from Ubuntu-18.04 to Amazon Linux 2 docker image (RedHat-based), in order to downgrade the GLIBC dependency from 2.27 to 2.26. This approach will enable many users who use Amazon Linux 2 to be sure that they can use TypeDB drivers to connect to TypeDB.


## Implementation

- CircleCI release jobs run using the `amazonlinux:2` docker image instead of the `ubuntu:18.04` docker image
- Migrate jobs to use 'yum/rpm' infrastructure instead of apt/deb infrastructure