### PR TITLE
Increase size of Windows executor in CircleCI to XL 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,6 +24,11 @@ try-import ./.bazel-remote-cache.rc
 common --enable_platform_specific_config
 
 build --incompatible_strict_action_env --java_language_version=11 --javacopt='--release 11' --enable_runfiles
+
+# Don't depend on a JAVA_HOME pointing at a system JDK
+# see https://github.com/bazelbuild/rules_jvm_external/issues/445
+build --repo_env=JAVA_HOME=../bazel_tools/jdk
+
 run --incompatible_strict_action_env --java_runtime_version=remotejdk_11
 test --incompatible_strict_action_env --test_env=PATH --cache_test_results=no --java_runtime_version=remotejdk_11
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,20 +684,10 @@ workflows:
           filters:
             branches:
               only: [master, development]
-      - deploy-snapshot-windows-x86_64:
-          filters:
-            branches:
-              only: [master, development]
+      - deploy-snapshot-windows-x86_64
 
       - deploy-maven-snapshot:
-          filters:
-            branches:
-              only: [master, development]
           requires:
-            - deploy-snapshot-linux-arm64
-            - deploy-snapshot-linux-x86_64
-            - deploy-snapshot-mac-arm64
-            - deploy-snapshot-mac-x86_64
             - deploy-snapshot-windows-x86_64
 
       - test-snapshot-linux-arm64:
@@ -729,9 +719,6 @@ workflows:
             - deploy-snapshot-mac-x86_64
             - deploy-maven-snapshot
       - test-snapshot-windows-x86_64:
-          filters:
-            branches:
-              only: [master, development]
           requires:
             - deploy-snapshot-windows-x86_64
             - deploy-maven-snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,7 +387,7 @@ jobs:
   deploy-snapshot-windows-x86_64:
     executor:
       name: win/default
-      size: large
+      size: xlarge
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:
@@ -457,7 +457,7 @@ jobs:
   test-snapshot-windows-x86_64:
     executor:
       name: win/default
-      size: large
+      size: xlarge
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:
@@ -576,7 +576,7 @@ jobs:
   deploy-release-windows-x86_64:
     executor:
       name: win/default
-      size: large
+      size: xlarge
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.0.0
+  win: circleci/windows@5.0
   macos: circleci/macos@2.4.0
 
 executors:
@@ -387,6 +387,7 @@ jobs:
   deploy-snapshot-windows-x86_64:
     executor:
       name: win/default
+      size: 2xlarge
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:
@@ -456,6 +457,7 @@ jobs:
   test-snapshot-windows-x86_64:
     executor:
       name: win/default
+      size: 2xlarge
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:
@@ -574,6 +576,7 @@ jobs:
   deploy-release-windows-x86_64:
     executor:
       name: win/default
+      size: 2xlarge
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,10 +684,20 @@ workflows:
           filters:
             branches:
               only: [master, development]
-      - deploy-snapshot-windows-x86_64
+      - deploy-snapshot-windows-x86_64:
+          filters:
+            branches:
+              only: [master, development]
 
       - deploy-maven-snapshot:
+          filters:
+            branches:
+              only: [master, development]
           requires:
+            - deploy-snapshot-linux-arm64
+            - deploy-snapshot-linux-x86_64
+            - deploy-snapshot-mac-arm64
+            - deploy-snapshot-mac-x86_64
             - deploy-snapshot-windows-x86_64
 
       - test-snapshot-linux-arm64:
@@ -719,6 +729,9 @@ workflows:
             - deploy-snapshot-mac-x86_64
             - deploy-maven-snapshot
       - test-snapshot-windows-x86_64:
+          filters:
+            branches:
+              only: [master, development]
           requires:
             - deploy-snapshot-windows-x86_64
             - deploy-maven-snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,7 +387,7 @@ jobs:
   deploy-snapshot-windows-x86_64:
     executor:
       name: win/default
-      size: 2xlarge
+      size: large
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:
@@ -457,7 +457,7 @@ jobs:
   test-snapshot-windows-x86_64:
     executor:
       name: win/default
-      size: 2xlarge
+      size: large
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:
@@ -576,7 +576,7 @@ jobs:
   deploy-release-windows-x86_64:
     executor:
       name: win/default
-      size: 2xlarge
+      size: large
       shell: cmd.exe
     working_directory: ~/typedb-driver
     steps:

--- a/.circleci/windows/dependencies.config
+++ b/.circleci/windows/dependencies.config
@@ -21,6 +21,6 @@
 
 <packages>
     <package id="bazelisk" version="1.17.0"/>
-    <package id="python" version="3.9.6"/>
+    <package id="python" version="3.11.0"/>
     <package id="openjdk11" version="11.0.9.11"/>
 </packages>

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -38,3 +38,4 @@ C:\Python311\python.exe -m pip install wheel
 REM permanently set variables for Bazel build
 SETX BAZEL_SH "C:\Program Files\Git\usr\bin\bash.exe"
 SETX BAZEL_PYTHON C:\Python311\python.exe
+SETX BAZEL_VC "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC"

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -29,7 +29,7 @@ REM install dependencies needed for build
 choco install .circleci\windows\dependencies.config  --limit-output --yes --no-progress
 
 REM create a symlink python3.exe and make it available in %PATH%
-mklink C:\Python311\python3.exe C:\Python39\python.exe
+mklink C:\Python311\python3.exe C:\Python311\python.exe
 set PATH=%PATH%;C:\Python311
 
 REM install runtime dependency for the build

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -29,12 +29,12 @@ REM install dependencies needed for build
 choco install .circleci\windows\dependencies.config  --limit-output --yes --no-progress
 
 REM create a symlink python3.exe and make it available in %PATH%
-mklink C:\Python39\python3.exe C:\Python39\python.exe
-set PATH=%PATH%;C:\Python39
+mklink C:\Python311\python3.exe C:\Python39\python.exe
+set PATH=%PATH%;C:\Python311
 
 REM install runtime dependency for the build
-C:\Python39\python.exe -m pip install wheel
+C:\Python311\python.exe -m pip install wheel
 
 REM permanently set variables for Bazel build
 SETX BAZEL_SH "C:\Program Files\Git\usr\bin\bash.exe"
-SETX BAZEL_PYTHON C:\Python39\python.exe
+SETX BAZEL_PYTHON C:\Python311\python.exe

--- a/.circleci/windows/python/deploy_snapshot.bat
+++ b/.circleci/windows/python/deploy_snapshot.bat
@@ -26,7 +26,7 @@ CALL refreshenv
 ECHO Building and deploying windows package...
 SET DEPLOY_PIP_USERNAME=%REPO_VATICLE_USERNAME%
 SET DEPLOY_PIP_PASSWORD=%REPO_VATICLE_PASSWORD%
-python.exe -m pip install twine
+python.exe -m pip install twine==3.3.0
 git rev-parse HEAD > version_temp.txt
 set /p VER=<version_temp.txt
 

--- a/.circleci/windows/python/deploy_snapshot.bat
+++ b/.circleci/windows/python/deploy_snapshot.bat
@@ -30,6 +30,9 @@ python.exe -m pip install twine==3.3.0 importlib-metadata==3.4.0
 git rev-parse HEAD > version_temp.txt
 set /p VER=<version_temp.txt
 
+bazel --output_user_root=C:/tmp run --verbose_failures --define version=%VER% //python:deploy-pip38 -- snapshot
+IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
+
 bazel --output_user_root=C:/tmp run --verbose_failures --define version=%VER% //python:deploy-pip39 -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 

--- a/.circleci/windows/python/deploy_snapshot.bat
+++ b/.circleci/windows/python/deploy_snapshot.bat
@@ -26,7 +26,7 @@ CALL refreshenv
 ECHO Building and deploying windows package...
 SET DEPLOY_PIP_USERNAME=%REPO_VATICLE_USERNAME%
 SET DEPLOY_PIP_PASSWORD=%REPO_VATICLE_PASSWORD%
-python.exe -m pip install twine==3.3.0
+python.exe -m pip install twine==3.3.0 importlib-metadata==3.4.0
 git rev-parse HEAD > version_temp.txt
 set /p VER=<version_temp.txt
 


### PR DESCRIPTION
## Usage and product changes

We increase the size of the Windows executor in CircleCI deployment job from medium to xlarge. This change necessitated upgrade from windows orb v2.0.0 to v5.0, and reduced CI time from ~40 minutes to ~20 minutes.
