### PR TITLE
Move deployment jobs from Factory CI to CIrcleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,6 +316,55 @@ commands:
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
           bazel run --jobs=8 --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release
 
+  #########################
+  # Rust deployment steps #
+  #########################
+
+  deploy-crate-snapshot-unix:
+    steps:
+      - run: |
+          export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+
+  deploy-crate-release-unix:
+    steps:
+      - run: |
+          export DEPLOY_CRATE_TOKEN=$REPO_CRATES_TOKEN
+          bazel run --jobs=8 --define version=$(cat VERSION) //rust:deploy_crate --compilation_mode=opt -- release
+
+  #########################
+  # Node deployment steps #
+  #########################
+
+  deploy-npm-snapshot-unix:
+    steps:
+      - run: |
+          export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+          export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+          bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+
+  test-npm-snapshot-unix:
+    steps:
+      - run: |
+          tool/test/start-core-server.sh
+          cd nodejs/test/deployment/
+          npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+          sudo -H npm install jest --global
+          jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+          cd -
+          tool/test/stop-core-server.sh
+          exit $TEST_SUCCESS
+
+  deploy-npm-release-unix:
+    steps:
+      - run: |
+          wget -q -O - https://cli-assets.heroku.com/apt/release.key | apt-key add -
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+          apt update -y
+          apt install -y expect npm
+          export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
+          bazel run --jobs=8 --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
+
 jobs:
 
   #################
@@ -423,13 +472,15 @@ jobs:
       - run: .circleci\windows\cpp\deploy_snapshot.bat
       - run: .circleci\windows\cpp\test_assembly.bat
 
-  deploy-maven-snapshot:
+  deploy-snapshot-any:
     executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-yum:
           bazel-arch: amd64
+      - deploy-crate-snapshot-unix
       - deploy-maven-snapshot-unix
+      - deploy-npm-snapshot-unix
 
 
   test-snapshot-linux-arm64:
@@ -484,6 +535,14 @@ jobs:
       - run: .circleci\windows\prepare.bat
       - run: .circleci\windows\python\test_deploy_snapshot.bat
       - run: .circleci\windows\java\test_deploy_snapshot.bat
+
+  test-snapshot-any:
+    executor: linux-x86_64-amazonlinux-2
+    steps:
+      - checkout
+      - install-bazel-yum:
+          bazel-arch: amd64
+      - test-npm-snapshot-unix
 
   ################
   # Release jobs #
@@ -609,52 +668,19 @@ jobs:
           root: dist
           paths: ["./*"]
 
-  deploy-maven-release:
-    executor: linux-x86_64-amazonlinux-2
-    steps:
-      - checkout
-      - install-bazel-yum:
-          bazel-arch: amd64
-      - deploy-maven-release-unix
-      - run: |
-          mkdir -p ~/dist
-          cp bazel-bin/java/libdriver-java.jar ~/dist/typedb-driver.jar
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
-
-  deploy-crate-release:
+  deploy-release-any:
     executor: linux-x86_64-ubuntu-2204
     steps:
       - checkout
       - install-bazel-apt:
           bazel-arch: amd64
+      - deploy-crate-release-unix
+      - deploy-maven-release-unix
+      - deploy-npm-release-unix
       - run: |
-          export DEPLOY_CRATE_TOKEN=$REPO_CRATES_TOKEN
-          bazel run --jobs=8 --define version=$(cat VERSION) //rust:deploy_crate --compilation_mode=opt -- release
           mkdir -p ~/dist
           cp bazel-bin/rust/assemble_crate.crate ~/dist/typedb-driver.crate
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
-
-  deploy-npm-release:
-    executor: linux-x86_64-ubuntu-2204
-    steps:
-      - checkout
-      - install-bazel-apt:
-          bazel-arch: amd64
-      - run: |
-          apt update -y
-          apt install -y expect npm
-          npm install -g n
-          n lts
-      - run: |
-          wget -q -O - https://cli-assets.heroku.com/apt/release.key | apt-key add -
-          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
-          export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
-          bazel run --jobs=8 --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
-          mkdir -p ~/dist
+          cp bazel-bin/java/libdriver-java.jar ~/dist/typedb-driver.jar
           cp bazel-bin/nodejs/assemble-npm.tar.gz ~/dist/typedb-driver-node.tar.gz
       - persist_to_workspace:
           root: ~/dist
@@ -711,7 +737,7 @@ workflows:
             branches:
               only: [master, development]
 
-      - deploy-maven-snapshot:
+      - deploy-snapshot-any:
           filters:
             branches:
               only: [master, development]
@@ -728,35 +754,42 @@ workflows:
               only: [master, development]
           requires:
             - deploy-snapshot-linux-arm64
-            - deploy-maven-snapshot
+            - deploy-snapshot-any
       - test-snapshot-linux-x86_64:
           filters:
             branches:
               only: [master, development]
           requires:
             - deploy-snapshot-linux-x86_64
-            - deploy-maven-snapshot
+            - deploy-snapshot-any
       - test-snapshot-mac-arm64:
           filters:
             branches:
               only: [master, development]
           requires:
             - deploy-snapshot-mac-arm64
-            - deploy-maven-snapshot
+            - deploy-snapshot-any
       - test-snapshot-mac-x86_64:
           filters:
             branches:
               only: [master, development]
           requires:
             - deploy-snapshot-mac-x86_64
-            - deploy-maven-snapshot
+            - deploy-snapshot-any
       - test-snapshot-windows-x86_64:
           filters:
             branches:
               only: [master, development]
           requires:
             - deploy-snapshot-windows-x86_64
-            - deploy-maven-snapshot
+            - deploy-snapshot-any
+
+      - test-snapshot-any:
+          filters:
+            branches:
+              only: [master, development]
+          requires:
+            - deploy-snapshot-any
 
   release:
     jobs:
@@ -781,7 +814,7 @@ workflows:
             branches:
               only: [release]
 
-      - deploy-maven-release:
+      - deploy-release-any:
           filters:
             branches:
               only: [release]
@@ -791,16 +824,6 @@ workflows:
             - deploy-release-mac-arm64
             - deploy-release-mac-x86_64
             - deploy-release-windows-x86_64
-
-      - deploy-crate-release:
-          filters:
-            branches:
-              only: [release]
-
-      - deploy-npm-release:
-          filters:
-            branches:
-              only: [release]
 
       - deploy-github:
           filters:
@@ -812,9 +835,7 @@ workflows:
             - deploy-release-linux-arm64
             - deploy-release-linux-x86_64
             - deploy-release-windows-x86_64
-            - deploy-maven-release
-            - deploy-crate-release
-            - deploy-npm-release
+            - deploy-release-any
 
       - release-cleanup:
           filters:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1218,65 +1218,6 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-
-    deploy-crate-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-rust-unit-integration
-        - test-rust-behaviour-concept
-        - test-rust-behaviour-connection
-        - test-rust-behaviour-query-read
-        - test-rust-behaviour-query-write
-      command: |
-        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-
-    deploy-npm-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-nodejs-integration
-        - test-nodejs-cloud-failover
-        - test-nodejs-behaviour-connection-core
-        - test-nodejs-behaviour-connection-cloud
-        - test-nodejs-behaviour-concept-core
-        - test-nodejs-behaviour-concept-cloud
-        - test-nodejs-behaviour-read-core
-        - test-nodejs-behaviour-read-cloud
-        - test-nodejs-behaviour-writable-core
-        - test-nodejs-behaviour-writable-cloud
-        - test-nodejs-behaviour-definable-core
-        - test-nodejs-behaviour-definable-cloud
-      command: |
-        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-
-    test-deployment-npm:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - deploy-npm-snapshot
-      command: |
-        tool/test/start-core-server.sh
-        cd nodejs/test/deployment/
-        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-        sudo -H npm install jest --global
-        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        cd -
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
 # TODO: assembly tests for all drivers to run in factory
 
 release:


### PR DESCRIPTION
## Usage and product changes

We move all snapshot deployment jobs from Factory CI to CIrcleCI to ensure that assembly and deployment succeed in the same environment release deployment is performed in. We also consolidate platform independent jobs into `deploy-release/snapshot-any` to further reduce the amount of CI jobs.