### PR TITLE
Update to allow Unicode TypeQL variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ This repository stores all TypeDB Drivers built by Vaticle.
 
 See the table below for links to README files, documentation, and source code.
 
-| Driver  | Readme | Documentation                                                                 | Driver location                                                               |
-|---------|--------|-------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| Rust | [README](https://github.com/vaticle/typedb-driver/tree/development/rust/README.md) | [Documentation](https://typedb.com/docs/clients/rust-driver)       | [`rust/`](https://github.com/vaticle/typedb-driver/tree/development/rust)     |
-| Python | [README](https://github.com/vaticle/typedb-driver/tree/development/python/README.md) | [Documentation](https://typedb.com/docs/clients/python-driver)   | [`python/`](https://github.com/vaticle/typedb-driver/tree/development/python) |
-| Node.js | [README](https://github.com/vaticle/typedb-driver/tree/development/nodejs/README.md) | [Documentation](https://typedb.com/docs/clients/nodejs-driver) | [`nodejs/`](https://github.com/vaticle/typedb-driver/tree/development/nodejs) |
-| Java | [README](https://github.com/vaticle/typedb-driver/tree/development/java/README.md) | [Documentation](https://typedb.com/docs/clients/java-driver)       | [`java/`](https://github.com/vaticle/typedb-driver/tree/development/java)     |
-| C | Coming soon | Coming soon | [`c/`](https://github.com/vaticle/typedb-driver/tree/development/c)   |
-| C++ | [README](https://github.com/vaticle/typedb-driver/tree/development/cpp/README.md) | Coming soon | [`cpp/`](https://github.com/vaticle/typedb-driver/tree/development/cpp)   |
+| Driver  | Readme                                                                               | Documentation                                                    | Driver location                                                               |
+|---------|--------------------------------------------------------------------------------------|------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| Rust    | [README](https://github.com/vaticle/typedb-driver/tree/development/rust/README.md)   | [Documentation](https://typedb.com/docs/drivers/rust/overview)   | [`rust/`](https://github.com/vaticle/typedb-driver/tree/development/rust)     |
+| Python  | [README](https://github.com/vaticle/typedb-driver/tree/development/python/README.md) | [Documentation](https://typedb.com/docs/drivers/python/overview) | [`python/`](https://github.com/vaticle/typedb-driver/tree/development/python) |
+| Node.js | [README](https://github.com/vaticle/typedb-driver/tree/development/nodejs/README.md) | [Documentation](https://typedb.com/docs/drivers/nodejs/overview) | [`nodejs/`](https://github.com/vaticle/typedb-driver/tree/development/nodejs) |
+| Java    | [README](https://github.com/vaticle/typedb-driver/tree/development/java/README.md)   | [Documentation](https://typedb.com/docs/drivers/java/overview)   | [`java/`](https://github.com/vaticle/typedb-driver/tree/development/java)     |
+| C       | [README](https://github.com/vaticle/typedb-driver/tree/development/c/README.md)      | -                                                                | [`c/`](https://github.com/vaticle/typedb-driver/tree/development/c)           |
+| C++     | [README](https://github.com/vaticle/typedb-driver/tree/development/cpp/README.md)    | [Documentation](https://typedb.com/docs/drivers/cpp/overview)    | [`cpp/`](https://github.com/vaticle/typedb-driver/tree/development/cpp)       |
 
 ### Package hosting
+
 Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
 Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
 enables your organization to create, store and share packages in any format, to any place, with total

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -15,8 +15,8 @@
 @maven//:com_google_http_client_google_http_client_1_34_2
 @maven//:com_google_j2objc_j2objc_annotations_1_3
 @maven//:com_google_protobuf_protobuf_java_3_21_1
-@maven//:com_vaticle_typedb_typedb_cloud_runner_f78fdb0d3ac4c533c0eb9a2e02d986702435efe4
-@maven//:com_vaticle_typedb_typedb_runner_525f9e989ac9fb2d06a05e0ad61c711610803526
+@maven//:com_vaticle_typedb_typedb_cloud_runner_54c3f23385f356d830e1ab1bb66345acfce103e7
+@maven//:com_vaticle_typedb_typedb_runner_240c3c108f8cbf6e620e52c4df8730431ec13e3f
 @maven//:commons_codec_commons_codec_1_11
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging_1_2

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "525f9e989ac9fb2d06a05e0ad61c711610803526",
+        commit = "240c3c108f8cbf6e620e52c4df8730431ec13e3f",
     )
 
 def vaticle_typedb_cloud_artifact():
@@ -39,10 +39,10 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        commit = "f78fdb0d3ac4c533c0eb9a2e02d986702435efe4",
+        commit = "54c3f23385f356d830e1ab1bb66345acfce103e7",
     )
 
 maven_artifacts = {
-    'com.vaticle.typedb:typedb-runner': '525f9e989ac9fb2d06a05e0ad61c711610803526',
-    'com.vaticle.typedb:typedb-cloud-runner': 'f78fdb0d3ac4c533c0eb9a2e02d986702435efe4',
+    'com.vaticle.typedb:typedb-runner': '240c3c108f8cbf6e620e52c4df8730431ec13e3f',
+    'com.vaticle.typedb:typedb-cloud-runner': '54c3f23385f356d830e1ab1bb66345acfce103e7',
 }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,7 +39,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "3a523f4d7d40b0c5d3b9af68f31a3859215fa671",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "025798c62d768404fb5453ef6e48bf4d8cb17b87",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
@@ -55,5 +55,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "46a16939c1dd94aac6aebc3dd7e50e8280d3dfe5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "64430c4fb512a70d2f5cc02087e0b8561bff7417",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/rust/tests/behaviour/query/language/steps.rs
+++ b/rust/tests/behaviour/query/language/steps.rs
@@ -90,6 +90,11 @@ generic_step_impl! {
         assert_err!(typeql_delete(context, step).await);
     }
 
+    #[step(expr = "typeql delete; throws exception containing {string}")]
+    async fn typeql_delete_throws_containing(context: &mut Context, step: &Step, exception: String) {
+        assert!(typeql_delete(context, step).await.unwrap_err().to_string().contains(&exception));
+    }
+
     #[step(expr = "typeql update")]
     async fn typeql_update(context: &mut Context, step: &Step) -> TypeDBResult {
         let parsed = parse_query(step.docstring().unwrap())?;


### PR DESCRIPTION
## Usage and product changes

We update TypeQL and tests to ensure that support for Unicode TypeQL variable names (https://github.com/vaticle/typeql/pull/310) is included.

## Implementation
- Update TypeDB artifacts, and TypeQL and Behaviour dependencies
- Add missing steps to test a new case: `delete` queries that throw an exception with a specialised exception
- Update README links
