### PR TITLE
Sync dependencies in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -712,6 +712,17 @@ jobs:
               -r ${CIRCLE_PROJECT_REPONAME} -n "TypeDB Driver $(cat VERSION)" -b "$(cat ./RELEASE_NOTES_LATEST.md)" \
               -c ${CIRCLE_SHA1} -delete $(cat VERSION) ~/dist/
 
+  sync-dependencies:
+    executor: linux-x86_64
+    steps:
+      - checkout
+      - install-bazel-linux:
+          arch: amd64
+      - run:
+          command: |
+              export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+              bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${CIRCLE_PROJECT_REPONAME}@$(cat VERSION)
+
   release-cleanup:
     executor: linux-x86_64-ubuntu-2204
     steps:
@@ -846,9 +857,15 @@ workflows:
             - deploy-release-windows-x86_64
             - deploy-release-any
 
-      - release-cleanup:
+      - sync-dependencies:
           filters:
             branches:
               only: [release]
           requires:
             - deploy-github
+      - release-cleanup:
+          filters:
+            branches:
+              only: [release]
+          requires:
+            - sync-dependencies

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1218,6 +1218,141 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
+    deploy-crate-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-rust-unit-integration
+        - test-rust-behaviour-concept
+        - test-rust-behaviour-connection
+        - test-rust-behaviour-query-read
+        - test-rust-behaviour-query-write
+      command: |
+        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
+
+    deploy-npm-snapshot:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+        - test-nodejs-integration
+        - test-nodejs-cloud-failover
+        - test-nodejs-behaviour-connection-core
+        - test-nodejs-behaviour-connection-cloud
+        - test-nodejs-behaviour-concept-core
+        - test-nodejs-behaviour-concept-cloud
+        - test-nodejs-behaviour-read-core
+        - test-nodejs-behaviour-read-cloud
+        - test-nodejs-behaviour-writable-core
+        - test-nodejs-behaviour-writable-cloud
+        - test-nodejs-behaviour-definable-core
+        - test-nodejs-behaviour-definable-cloud
+      command: |
+        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
+        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
+
+    test-deployment-npm:
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - deploy-npm-snapshot
+      command: |
+        tool/test/start-core-server.sh
+        cd nodejs/test/deployment/
+        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
+        sudo -H npm install jest --global
+        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        cd -
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+        - build-dependency
+        - build-docs
+        - test-rust-unit-integration
+        - test-rust-behaviour-concept
+        - test-rust-behaviour-connection
+        - test-rust-behaviour-driver
+        - test-rust-behaviour-query-read
+        - test-rust-behaviour-query-write
+        - test-c-integration
+        - test-java-integration
+        - test-java-behaviour-connection-core
+        - test-java-behaviour-connection-cloud
+        - test-java-behaviour-concept-core
+        - test-java-behaviour-concept-cloud
+        - test-java-behaviour-driver-core
+        - test-java-behaviour-driver-cloud
+        - test-java-behaviour-read-core
+        - test-java-behaviour-read-cloud
+        - test-java-behaviour-writable-core
+        - test-java-behaviour-writable-cloud
+        - test-java-behaviour-definable-core
+        - test-java-behaviour-definable-cloud
+        - test-python-behaviour-connection-core
+        - test-python-behaviour-connection-cloud
+        - test-python-behaviour-concept-core
+        - test-python-behaviour-concept-cloud
+        - test-python-behaviour-driver-core
+        - test-python-behaviour-driver-cloud
+        - test-python-behaviour-read-core
+        - test-python-behaviour-read-cloud
+        - test-python-behaviour-writable-core
+        - test-python-behaviour-writable-cloud
+        - test-python-behaviour-definable-core
+        - test-python-behaviour-definable-cloud
+        - test-python-integration-core
+        - test-nodejs-integration
+        - test-nodejs-cloud-failover
+        - test-nodejs-behaviour-connection-core
+        - test-nodejs-behaviour-connection-cloud
+        - test-nodejs-behaviour-concept-core
+        - test-nodejs-behaviour-concept-cloud
+        - test-nodejs-behaviour-driver-core
+        - test-nodejs-behaviour-driver-cloud
+        - test-nodejs-behaviour-read-core
+        - test-nodejs-behaviour-read-cloud
+        - test-nodejs-behaviour-writable-core
+        - test-nodejs-behaviour-writable-cloud
+        - test-nodejs-behaviour-definable-core
+        - test-nodejs-behaviour-definable-cloud
+        - test-cpp-behaviour-connection-core
+        - test-cpp-behaviour-connection-cloud
+        - test-cpp-behaviour-concept-core
+        - test-cpp-behaviour-concept-cloud
+        - test-cpp-behaviour-driver-core
+        - test-cpp-behaviour-driver-cloud
+        - test-cpp-behaviour-read-core
+        - test-cpp-behaviour-read-cloud
+        - test-cpp-behaviour-writable-core
+        - test-cpp-behaviour-writable-cloud
+        - test-cpp-behaviour-definable-core
+        - test-cpp-behaviour-definable-cloud
+        - test-cpp-integration-core
+        - deploy-crate-snapshot
+        - deploy-npm-snapshot
+        - test-deployment-npm
+    trigger-release-circleci:
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
+
 # TODO: assembly tests for all drivers to run in factory
 
 release:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1218,64 +1218,6 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-    deploy-crate-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-rust-unit-integration
-        - test-rust-behaviour-concept
-        - test-rust-behaviour-connection
-        - test-rust-behaviour-query-read
-        - test-rust-behaviour-query-write
-      command: |
-        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
-
-    deploy-npm-snapshot:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-        - test-nodejs-integration
-        - test-nodejs-cloud-failover
-        - test-nodejs-behaviour-connection-core
-        - test-nodejs-behaviour-connection-cloud
-        - test-nodejs-behaviour-concept-core
-        - test-nodejs-behaviour-concept-cloud
-        - test-nodejs-behaviour-read-core
-        - test-nodejs-behaviour-read-cloud
-        - test-nodejs-behaviour-writable-core
-        - test-nodejs-behaviour-writable-cloud
-        - test-nodejs-behaviour-definable-core
-        - test-nodejs-behaviour-definable-cloud
-      command: |
-        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
-
-    test-deployment-npm:
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - deploy-npm-snapshot
-      command: |
-        tool/test/start-core-server.sh
-        cd nodejs/test/deployment/
-        npm install https://repo.vaticle.com/repository/npm-snapshot-group/typedb-driver/-/typedb-driver-0.0.0-$FACTORY_COMMIT.tgz
-        sudo -H npm install jest --global
-        jest --detectOpenHandles application.test.js && export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        cd -
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
-
     sync-dependencies:
       image: vaticle-ubuntu-22.04
       filter:
@@ -1345,9 +1287,6 @@ build:
         - test-cpp-behaviour-definable-core
         - test-cpp-behaviour-definable-cloud
         - test-cpp-integration-core
-        - deploy-crate-snapshot
-        - deploy-npm-snapshot
-        - test-deployment-npm
     trigger-release-circleci:
       command: |
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,12 +43,11 @@ def vaticle_typeql():
     )
 
 def vaticle_typedb_protocol():
-    # needed for workspace status
-    VATICLE_TYPEDB_PROTOCOL_VERSION = "a1ebf01a761268dc28c6fd2ab8b6cd825431f3d4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "7b223fe459f9f0d1358ca3a71e531308aa328b7e"
+        # NOTE: the sync-marker is also used for workspace status by Bazel!
+        commit = "a1ebf01a761268dc28c6fd2ab8b6cd825431f3d4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/workspace-status.sh
+++ b/workspace-status.sh
@@ -27,10 +27,10 @@ else
     echo STABLE_VERSION 0.0.0-$(git rev-parse HEAD)
 fi
 
-TYPEDB_PROTOCOL_VERSION=$(grep -o 'VATICLE_TYPEDB_PROTOCOL_VERSION.*"[^"]*"' dependencies/vaticle/repositories.bzl | sed 's/.*"\(.*\)"/\1/')
+TYPEDB_PROTOCOL_VERSION=$(grep -o '"[^"]*".*sync-marker.*typedb_protocol' dependencies/vaticle/repositories.bzl | sed 's/.*"\(.*\)".*/\1/')
 if [ -z "$TYPEDB_PROTOCOL_VERSION" ]; then
   # the following line only prints when the script is run directly
-  echo "VATICLE_TYPEDB_PROTOCOL_VERSION not found in dependencies/vaticle/repositories.bzl, cannot stamp"
+  echo "@vaticle_typedb_protocol version not found in dependencies/vaticle/repositories.bzl, cannot stamp"
   exit 1
 elif [[ "$TYPEDB_PROTOCOL_VERSION" =~ ^[0-9a-f]{40}$ ]]; then # SHA
   TYPEDB_PROTOCOL_VERSION=0.0.0-$TYPEDB_PROTOCOL_VERSION


### PR DESCRIPTION
## Usage and product changes

We add a sync-dependencies job to be run in CI after successful snapshot and release deployments. The job sends a request to vaticle-bot to update all downstream dependencies.

The snapshot dependencies sync job is run in Factory CI after all behaviour and integration tests pass. The CircleCI tests only verify deployment, which is not extensive enough verification to trigger downstream propagation, and not strictly necessary for sync as that is only affected by git dependencies.

The release dependencies sync job, in contrast, runs in CircleCI and only runs after all deployments have succeeded and been verified, so that all downstream deployments can be safely updated.

Importantly, due to the way sync-dependencies is implemented, we revert `dependencies/vaticle/repositories.bzl` from having a dedicated typedb-protocol version line for the purposes of workspace-status, back to inlined version with the sync-marker. This means that the sync-marker is performing double duty as a workspace status marker.

Note: this PR does _not_ update the `dependencies` repo dependency. It will be updated automatically by the bot during its first pass.