### PR TITLE
Fix CircleCI sync dependencies configuration mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -716,8 +716,8 @@ jobs:
     executor: linux-x86_64
     steps:
       - checkout
-      - install-bazel-linux:
-          arch: amd64
+      - install-bazel-apt:
+          bazel-arch: amd64
       - run:
           command: |
               export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN

--- a/BUILD
+++ b/BUILD
@@ -78,5 +78,6 @@ filegroup(
         "@vaticle_dependencies//tool/sonarcloud:code-analysis",
         "@vaticle_dependencies//tool/unuseddeps:unused-deps",
         "@rust_analyzer_toolchain_tools//lib/rustlib/src:rustc_srcs"
+        "@vaticle_dependencies//tool/sync:dependencies",
     ],
 )


### PR DESCRIPTION
## Usage and product changes

The sync-dependencies step in CircleCI used an obsolete setup step which no longer exists. This PR fixes that issue.
