### PR TITLE
Missing trailing comma in BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -77,7 +77,7 @@ filegroup(
         "@vaticle_dependencies//tool/ide:rust_sync",
         "@vaticle_dependencies//tool/sonarcloud:code-analysis",
         "@vaticle_dependencies//tool/unuseddeps:unused-deps",
-        "@rust_analyzer_toolchain_tools//lib/rustlib/src:rustc_srcs"
+        "@rust_analyzer_toolchain_tools//lib/rustlib/src:rustc_srcs",
         "@vaticle_dependencies//tool/sync:dependencies",
     ],
 )


### PR DESCRIPTION
## Usage and product changes

Fix typo in the CI tools build verification job. 
