### PR TITLE
Set default Python version to 3.11

### DIFF
--- a/python/BUILD
+++ b/python/BUILD
@@ -52,7 +52,7 @@ py_native_lib_rename(
 
 sphinx_docs(
     name = "docs_html",
-    target = ":assemble-pip39",
+    target = ":assemble-pip311",
     out = "driver_docs_sphinx",
     sphinx_conf = "conf.py",
     sphinx_rst = "index.rst",

--- a/python/BUILD
+++ b/python/BUILD
@@ -31,14 +31,14 @@ native_driver_versioned(python_versions = python_versions)
 
 alias(
     name = "driver_python",
-    actual = ":driver_python39",
+    actual = ":driver_python311",
     visibility = ["//visibility:public"],
 )
 
 genrule(
     name = "native-driver-wrapper-link",
     outs = ["typedb/native_driver_wrapper.py"],
-    srcs = [":native-driver-wrapper39"],
+    srcs = [":native-driver-wrapper311"],
     cmd = "cp $< $@",
     visibility = ["//visibility:public"]
 )
@@ -46,7 +46,7 @@ genrule(
 py_native_lib_rename(
     name = "native-driver-binary-link",
     out = "typedb/native_driver_python",
-    src = ":native_driver_python39",
+    src = ":native_driver_python311",
     visibility = ["//visibility:public"]
 )
 

--- a/python/docs/schema/ValueType.adoc
+++ b/python/docs/schema/ValueType.adoc
@@ -19,20 +19,3 @@ a| `STRING` a| `_ValueType(is_writable=True, is_keyable=True, 4)`
 |===
 // end::enum_constants[]
 
-// tag::methods[]
-[#_ValueType_of__]
-==== of
-
-[source,python]
-----
-static of(value_type: 0 | 1 | 2 | 3 | 4 | 5) -> ValueType
-----
-
-
-
-[caption=""]
-.Returns
-`ValueType`
-
-// end::methods[]
-

--- a/python/docs/schema/ValueType.adoc
+++ b/python/docs/schema/ValueType.adoc
@@ -25,7 +25,7 @@ a| `STRING` a| `_ValueType(is_writable=True, is_keyable=True, 4)`
 
 [source,python]
 ----
-static of(value_type: Object | Boolean | Long | Double | String | DateTime) -> ValueType
+static of(value_type: 0 | 1 | 2 | 3 | 4 | 5) -> ValueType
 ----
 
 

--- a/python/python_versions.bzl
+++ b/python/python_versions.bzl
@@ -25,11 +25,11 @@ load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 python_versions = [
     # Order matters! First python toolchain that is registered is used by Bazel's py_binary. Sphinx is incompatible with py3.8.
     {
-        "name": "python39",
-        "python_version": "3.9",
-        "python_headers": "@python39//:python_headers",
-        "libpython": "@python39//:libpython",
-        "suffix": "39",
+        "name": "python311",
+        "python_version": "3.11",
+        "python_headers": "@python311//:python_headers",
+        "libpython": "@python311//:libpython",
+        "suffix": "311",
     },
     {
         "name": "python38",
@@ -39,18 +39,18 @@ python_versions = [
         "suffix": "38",
     },
     {
+        "name": "python39",
+        "python_version": "3.9",
+        "python_headers": "@python39//:python_headers",
+        "libpython": "@python39//:libpython",
+        "suffix": "39",
+    },
+    {
         "name": "python310",
         "python_version": "3.10",
         "python_headers": "@python310//:python_headers",
         "libpython": "@python310//:libpython",
         "suffix": "310",
-    },
-    {
-        "name": "python311",
-        "python_version": "3.11",
-        "python_headers": "@python311//:python_headers",
-        "libpython": "@python311//:libpython",
-        "suffix": "311",
     },
 ]
 

--- a/python/typedb/api/concept/value/value.py
+++ b/python/typedb/api/concept/value/value.py
@@ -295,6 +295,9 @@ class ValueType(Enum):
 
     @staticmethod
     def of(value_type: Union[Object, Boolean, Long, Double, String, DateTime]) -> ValueType:
+        """
+        :meta private:
+        """
         for type_ in ValueType:
             if type_.native_object == value_type:
                 return type_


### PR DESCRIPTION
## Usage and product changes

Set default python version for python tool binaries to 3.11 as 3.9 (the previous default) was incompatible with the sync-dependencies tool.