### PR TITLE
Only deploy releases to cloudsmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,20 +568,6 @@ jobs:
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
-      - run: |
-          mkdir -p ~/dist
-          for f in bazel-bin/python/*.whl; do
-              fname=$(basename $f)
-              base=${fname%.*}
-              pyversion=${base#typedb-driver}
-              cp $f ~/dist/typedb_driver-py${pyversion}-none-manylinux_2_17_aarch64.whl
-          done
-          cp bazel-bin/java/com.vaticle.typedb-typedb-driver-jni-linux-arm64.jar ~/dist/typedb-driver-jni-linux-arm64.jar
-          cp bazel-bin/c/typedb-driver-clib-linux-arm64.tar.gz ~/dist
-          cp bazel-bin/cpp/typedb-driver-cpp-linux-arm64.tar.gz ~/dist
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
 
   deploy-release-linux-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -593,20 +579,6 @@ jobs:
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
-      - run: |
-          mkdir -p ~/dist
-          for f in bazel-bin/python/*.whl; do
-              fname=$(basename $f)
-              base=${fname%.*}
-              pyversion=${base#typedb-driver}
-              cp $f ~/dist/typedb_driver-py${pyversion}-none-manylinux_2_17_x86_64.whl
-          done
-          cp bazel-bin/java/com.vaticle.typedb-typedb-driver-jni-linux-x86_64.jar ~/dist/typedb-driver-jni-linux-x86_64.jar
-          cp bazel-bin/c/typedb-driver-clib-linux-x86_64.tar.gz ~/dist
-          cp bazel-bin/cpp/typedb-driver-cpp-linux-x86_64.tar.gz ~/dist
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
 
   deploy-release-mac-arm64:
     executor: mac-arm64
@@ -618,20 +590,6 @@ jobs:
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
-      - run: |
-          mkdir -p ~/dist
-          for f in bazel-bin/python/*.whl; do
-              fname=$(basename $f)
-              base=${fname%.*}
-              pyversion=${base#typedb-driver}
-              cp $f ~/dist/typedb_driver-py${pyversion}-none-macosx_11_0_arm64.whl
-          done
-          cp bazel-bin/java/com.vaticle.typedb-typedb-driver-jni-macosx-arm64.jar ~/dist/typedb-driver-jni-macosx-arm64.jar
-          cp bazel-bin/c/typedb-driver-clib-mac-arm64.tar.gz ~/dist
-          cp bazel-bin/cpp/typedb-driver-cpp-mac-arm64.tar.gz ~/dist
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
 
   deploy-release-mac-x86_64:
     executor: mac-arm64
@@ -644,20 +602,6 @@ jobs:
       - deploy-maven-jni-release-unix
       - deploy-clib-release-unix
       - deploy-cpp-release-unix
-      - run: |
-          mkdir -p ~/dist
-          for f in bazel-bin/python/*.whl; do
-              fname=$(basename $f)
-              base=${fname%.*}
-              pyversion=${base#typedb-driver}
-              cp $f ~/dist/typedb_driver-py${pyversion}-none-macosx_11_0_x86_64.whl
-          done
-          cp bazel-bin/java/com.vaticle.typedb-typedb-driver-jni-macosx-x86_64.jar ~/dist/typedb-driver-jni-macosx-x86_64.jar
-          cp bazel-bin/c/typedb-driver-clib-mac-x86_64.tar.gz ~/dist
-          cp bazel-bin/cpp/typedb-driver-cpp-mac-x86_64.tar.gz ~/dist
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
 
   deploy-release-windows-x86_64:
     executor:
@@ -672,9 +616,6 @@ jobs:
       - run: .circleci\windows\java\deploy_release.bat
       - run: .circleci\windows\clib\deploy_release.bat
       - run: .circleci\windows\cpp\deploy_release.bat
-      - persist_to_workspace:
-          root: dist
-          paths: ["./*"]
 
   deploy-release-any:
     executor: linux-x86_64-ubuntu-2204
@@ -686,20 +627,10 @@ jobs:
       - deploy-maven-release-unix
       - install-npm-apt
       - deploy-npm-release-unix
-      - run: |
-          mkdir -p ~/dist
-          cp bazel-bin/rust/assemble_crate.crate ~/dist/typedb-driver.crate
-          cp bazel-bin/java/libdriver-java.jar ~/dist/typedb-driver.jar
-          cp bazel-bin/nodejs/assemble-npm.tar.gz ~/dist/typedb-driver-node.tar.gz
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
 
   deploy-github:
     executor: linux-x86_64-ubuntu-2204
     steps:
-      - attach_workspace:
-          at: ~/dist
       - checkout
       - install-bazel-apt:
           bazel-arch: amd64
@@ -710,7 +641,7 @@ jobs:
             tar -xf ghr_v0.12.1_linux_amd64.tar.gz
             ghr_v0.12.1_linux_amd64/ghr -t ${REPO_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} \
               -r ${CIRCLE_PROJECT_REPONAME} -n "TypeDB Driver $(cat VERSION)" -b "$(cat ./RELEASE_NOTES_LATEST.md)" \
-              -c ${CIRCLE_SHA1} -delete $(cat VERSION) ~/dist/
+              -c ${CIRCLE_SHA1} -delete $(cat VERSION)
 
   sync-dependencies:
     executor: linux-x86_64

--- a/.circleci/windows/clib/deploy_release.bat
+++ b/.circleci/windows/clib/deploy_release.bat
@@ -30,6 +30,3 @@ SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 SET /p VER=<VERSION
 bazel --output_user_root=C:\bazel run --verbose_failures --define version=%VER% //c:deploy-windows-x86_64-zip --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
-
-MD dist
-COPY bazel-bin\c\typedb-driver-clib-windows-x86_64.zip dist\typedb-driver-clib-windows-x86_64.zip

--- a/.circleci/windows/cpp/deploy_release.bat
+++ b/.circleci/windows/cpp/deploy_release.bat
@@ -30,6 +30,3 @@ SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 SET /p VER=<VERSION
 bazel --output_user_root=C:\bazel run --verbose_failures --define version=%VER% //cpp:deploy-windows-x86_64-zip --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
-
-MD dist
-COPY bazel-bin\cpp\typedb-driver-cpp-windows-x86_64.zip dist\typedb-driver-cpp-windows-x86_64.zip

--- a/.circleci/windows/java/deploy_release.bat
+++ b/.circleci/windows/java/deploy_release.bat
@@ -30,6 +30,3 @@ SET DEPLOY_MAVEN_PASSWORD=%REPO_TYPEDB_PASSWORD%
 SET /p VER=<VERSION
 bazel --output_user_root=C:/bazel run --verbose_failures --define version=%VER% //java:deploy-maven-jni --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
-
-MD dist
-COPY bazel-bin\java\com.vaticle.typedb-typedb-driver-jni-windows-x86_64.jar dist\typedb-driver-jni-windows-x86_64.jar

--- a/.circleci/windows/python/deploy_release.bat
+++ b/.circleci/windows/python/deploy_release.bat
@@ -40,9 +40,3 @@ IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
 bazel --output_user_root=C:/tmp run --verbose_failures --define version=%VER% //python:deploy-pip311 --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
-
-MD dist
-COPY bazel-bin\python\typedb-driver38.whl dist\typedb_driver-py38-none-win_amd64.whl
-COPY bazel-bin\python\typedb-driver39.whl dist\typedb_driver-py39-none-win_amd64.whl
-COPY bazel-bin\python\typedb-driver310.whl dist\typedb_driver-py310-none-win_amd64.whl
-COPY bazel-bin\python\typedb-driver311.whl dist\typedb_driver-py311-none-win_amd64.whl

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -1,11 +1,11 @@
-Documentation: https://typedb.com/docs/clients/overview
+Documentation: https://typedb.com/docs/drivers/overview
 
 ## Distribution
 
 #### Rust driver
 
 Available from https://crates.io/crates/typedb-driver
-Documentation: https://typedb.com/docs/clients/rust-driver
+Documentation: https://typedb.com/docs/drivers/rust/overview
 
 
 ```sh
@@ -16,7 +16,7 @@ cargo add typedb-driver@{version}
 ### Java driver
 
 Available through https://repo.typedb.com
-Documentation: https://typedb.com/docs/clients/java-driver
+Documentation: https://typedb.com/docs/drivers/java/overview
 
 ```xml
 <repositories>
@@ -37,7 +37,7 @@ Documentation: https://typedb.com/docs/clients/java-driver
 ### Python driver
 
 PyPI package: https://pypi.org/project/typedb-driver
-Documentation: https://typedb.com/docs/clients/python-driver
+Documentation: https://typedb.com/docs/drivers/python/overview
 
 Available through https://pypi.org
 
@@ -48,19 +48,19 @@ pip install typedb-driver=={version}
 ### NodeJS driver
 
 NPM package: https://www.npmjs.com/package/typedb-driver
-Documentation: https://typedb.com/docs/clients/nodejs-driver
+Documentation: https://typedb.com/docs/drivers/nodejs/overview
 
 ```
-npm install typedb-driver@
+npm install typedb-driver@{version}
 ```
 
 ### C++ driver
 
-Compiled distributions comprising headers and shared libraries available at: https://github.com/vaticle/typedb-driver/releases/tag/{version}
+Compiled distributions comprising headers and shared libraries available at: https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-driver-cpp+version%3A{version}
 
 ### C driver
 
-Compiled distributions comprising headers and shared libraries available at: https://github.com/vaticle/typedb-driver/releases/tag/{version}
-
+Compiled distributions comprising headers and shared libraries available at: https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-driver-clib+version%3A{version}
+Documentation: https://typedb.com/docs/drivers/cpp/overview
 
 { release notes }

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -56,11 +56,11 @@ npm install typedb-driver@{version}
 
 ### C++ driver
 
-Compiled distributions comprising headers and shared libraries available at: https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-driver-cpp+version%3A{version}
+Compiled distributions comprising headers and shared libraries available at: https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name:^typedb-driver-cpp+version:{version}
 
 ### C driver
 
-Compiled distributions comprising headers and shared libraries available at: https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name%3A%5Etypedb-driver-clib+version%3A{version}
+Compiled distributions comprising headers and shared libraries available at: https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name:^typedb-driver-clib+version:{version}
 Documentation: https://typedb.com/docs/drivers/cpp/overview
 
 { release notes }


### PR DESCRIPTION
## Usage and product changes

We implement the following changes to the release process:

- stop uploading build artifacts to the github releases page;
- update the release notes documentation links;
- add C and C++ artifact download link templates to the release notes template.
