### PR TITLE
Setup python3.11 CFFI in CI for sync-dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -713,15 +713,16 @@ jobs:
               -c ${CIRCLE_SHA1} -delete $(cat VERSION) ~/dist/
 
   sync-dependencies:
-    executor: linux-x86_64
+    executor: linux-x86_64-ubuntu-2204
     steps:
       - checkout
       - install-bazel-apt:
           bazel-arch: amd64
-      - run:
-          command: |
-              export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
-              bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${CIRCLE_PROJECT_REPONAME}@$(cat VERSION)
+      - run: |
+          apt update && apt install -y python3.11 python3-pip
+          python3.11 -m pip install -U cffi
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${CIRCLE_PROJECT_REPONAME}@$(cat VERSION)
 
   release-cleanup:
     executor: linux-x86_64-ubuntu-2204

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1288,6 +1288,8 @@ build:
         - test-cpp-behaviour-definable-cloud
         - test-cpp-integration-core
       command: |
+          sudo apt update && sudo apt install -y python3.11 python3-pip
+          python3.11 -m pip install -U cffi
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 


### PR DESCRIPTION
## Usage and product changes

CI executors based on Ubuntu 22.04 default to python 3.10. Due to us having to be explicit about which version of Python we are using for native addon compilation for FFI driver, we explicitly install python3.11, pip, and the cffi package before starting a sync-dependencies job. This eliminates the potential for mismatch in the future when defaults change.