### PR TITLE
Revert to python3.9 in Bazel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,7 @@ commands:
         type: string
     steps:
       - run: |
-          brew install python@3.8 python@3.11
-          python3.11 -m pip install -U chardet
+          brew install python@3.8
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.bazel-arch>>"
           sudo mv "bazelisk-darwin-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,8 +651,9 @@ jobs:
       - install-bazel-apt:
           bazel-arch: amd64
       - run: |
-          apt update && apt install -y python3.11 python3-pip
-          python3.11 -m pip install -U cffi
+          add-apt-repository ppa:deadsnakes/ppa
+          apt update && apt install -y python3.9 python3.9-distutils python3-pip
+          python3.9 -m pip install -U cffi
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${CIRCLE_PROJECT_REPONAME}@$(cat VERSION)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,10 @@ workflows:
           filters:
             branches:
               only: [master, development]
-      - deploy-snapshot-mac-x86_64
+      - deploy-snapshot-mac-x86_64:
+          filters:
+            branches:
+              only: [master, development]
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,8 @@ commands:
         type: string
     steps:
       - run: |
-          brew install python@3.8
+          brew install python@3.8 python@3.11
+          python3.11 -m pip install -U chardet
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.bazel-arch>>"
           sudo mv "bazelisk-darwin-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,10 +681,7 @@ workflows:
           filters:
             branches:
               only: [master, development]
-      - deploy-snapshot-mac-x86_64:
-          filters:
-            branches:
-              only: [master, development]
+      - deploy-snapshot-mac-x86_64
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1288,8 +1288,9 @@ build:
         - test-cpp-behaviour-definable-cloud
         - test-cpp-integration-core
       command: |
-          sudo apt update && sudo apt install -y python3.11 python3-pip
-          python3.11 -m pip install -U cffi
+          sudo add-apt-repository ppa:deadsnakes/ppa
+          sudo apt update && sudo apt install -y python3.9 python3.9-distutils python3-pip
+          python3.9 -m pip install -U cffi
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 

--- a/python/BUILD
+++ b/python/BUILD
@@ -31,14 +31,14 @@ native_driver_versioned(python_versions = python_versions)
 
 alias(
     name = "driver_python",
-    actual = ":driver_python311",
+    actual = ":driver_python39",
     visibility = ["//visibility:public"],
 )
 
 genrule(
     name = "native-driver-wrapper-link",
     outs = ["typedb/native_driver_wrapper.py"],
-    srcs = [":native-driver-wrapper311"],
+    srcs = [":native-driver-wrapper39"],
     cmd = "cp $< $@",
     visibility = ["//visibility:public"]
 )
@@ -46,13 +46,13 @@ genrule(
 py_native_lib_rename(
     name = "native-driver-binary-link",
     out = "typedb/native_driver_python",
-    src = ":native_driver_python311",
+    src = ":native_driver_python39",
     visibility = ["//visibility:public"]
 )
 
 sphinx_docs(
     name = "docs_html",
-    target = ":assemble-pip311",
+    target = ":assemble-pip39",
     out = "driver_docs_sphinx",
     sphinx_conf = "conf.py",
     sphinx_rst = "index.rst",

--- a/python/python_versions.bzl
+++ b/python/python_versions.bzl
@@ -25,11 +25,11 @@ load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 python_versions = [
     # Order matters! First python toolchain that is registered is used by Bazel's py_binary. Sphinx is incompatible with py3.8.
     {
-        "name": "python311",
-        "python_version": "3.11",
-        "python_headers": "@python311//:python_headers",
-        "libpython": "@python311//:libpython",
-        "suffix": "311",
+        "name": "python39",
+        "python_version": "3.9",
+        "python_headers": "@python39//:python_headers",
+        "libpython": "@python39//:libpython",
+        "suffix": "39",
     },
     {
         "name": "python38",
@@ -39,18 +39,18 @@ python_versions = [
         "suffix": "38",
     },
     {
-        "name": "python39",
-        "python_version": "3.9",
-        "python_headers": "@python39//:python_headers",
-        "libpython": "@python39//:libpython",
-        "suffix": "39",
-    },
-    {
         "name": "python310",
         "python_version": "3.10",
         "python_headers": "@python310//:python_headers",
         "libpython": "@python310//:libpython",
         "suffix": "310",
+    },
+    {
+        "name": "python311",
+        "python_version": "3.11",
+        "python_headers": "@python311//:python_headers",
+        "libpython": "@python311//:libpython",
+        "suffix": "311",
     },
 ]
 


### PR DESCRIPTION
## Usage and product changes

Revert to python3.9 (using deadsnakes on Ubuntu 22.04) for compatibility with both sync-depdendencies and deployment infrastructure.