### PR TITLE
Transition from standalone typedb-common to typeql/common

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -24,7 +24,6 @@ config:
   dependencies:
     dependencies: [build]
     typedb-behaviour: [build]
-    typedb-common: [build, release]
     typedb-protocol: [build, release]
     typeql: [build, release]
 

--- a/BUILD
+++ b/BUILD
@@ -61,7 +61,6 @@ release_validate_deps(
     name = "release-validate-deps",
     refs = "@vaticle_typedb_driver_workspace_refs//:refs.json",
     tagged_deps = [
-        "@vaticle_typedb_common",
         "@vaticle_typeql",
     ],
     tags = ["manual"],  # in order for bazel test //... to not fail

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -174,8 +174,7 @@ install_deps()
 ##############################
 
 # Load repositories
-load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common", "vaticle_typeql", "vaticle_typedb_behaviour", "vaticle_typedb_protocol")
-vaticle_typedb_common()
+load("//dependencies/vaticle:repositories.bzl", "vaticle_typeql", "vaticle_typedb_behaviour", "vaticle_typedb_protocol")
 vaticle_typeql()
 vaticle_typedb_behaviour()
 vaticle_typedb_protocol()
@@ -252,7 +251,6 @@ install_uploader_deps()
 
 # Load maven artifacts
 load("@vaticle_dependencies//tool/common:deps.bzl", vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
-load("@vaticle_typedb_common//dependencies/maven:artifacts.bzl", vaticle_typedb_common_maven_artifacts = "artifacts")
 load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_maven_artifacts = "artifacts")
 load(
     "//dependencies/maven:artifacts.bzl",
@@ -266,7 +264,6 @@ load("//dependencies/vaticle:artifacts.bzl", vaticle_typedb_driver_vaticle_maven
 
 load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
-    vaticle_typedb_common_maven_artifacts +
     vaticle_typeql_maven_artifacts +
     vaticle_dependencies_tool_maven_artifacts +
     vaticle_typedb_driver_maven_artifacts +

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,18 +28,11 @@ def vaticle_dependencies():
         commit = "3bd3fbcda4567dcea41f941eb6073b8673ba2a17", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
-def vaticle_typedb_common():
-    git_repository(
-        name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "3b704bc629b4bc994dd07f079e572af9da06202a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
-    )
-
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "e65f556a44967f283e31e428f489cd0b2bb262a5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.26.6-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():

--- a/java/BUILD
+++ b/java/BUILD
@@ -43,7 +43,7 @@ java_library(
         "//java/connection",
 
         # External dependencies from @vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
 )
 
@@ -121,7 +121,7 @@ javadoc_library(
         "//java:driver-java",
         "//java/api",
         "//java/common",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
 )
 

--- a/java/api/BUILD
+++ b/java/api/BUILD
@@ -33,7 +33,7 @@ java_library(
         "//java:typedb_driver_jni",
 
         # External dependencies from @vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/pattern",
         "@vaticle_typeql//java/query",
 

--- a/java/common/BUILD
+++ b/java/common/BUILD
@@ -36,7 +36,7 @@ java_library(
         "//java:typedb_driver_jni",
 
         # External dependencies from @vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External dependencies from Maven
         "@maven//:com_google_code_findbugs_jsr305",

--- a/java/concept/BUILD
+++ b/java/concept/BUILD
@@ -34,7 +34,7 @@ java_library(
         "//java:typedb_driver_jni",
 
         # External dependencies from @vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
 
         # External dependencies from Maven

--- a/java/test/behaviour/concept/thing/BUILD
+++ b/java/test/behaviour/concept/thing/BUILD
@@ -39,7 +39,7 @@ java_library(
         "//java/test/behaviour/connection:steps-base",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/java/test/behaviour/concept/type/attributetype/BUILD
+++ b/java/test/behaviour/concept/type/attributetype/BUILD
@@ -36,7 +36,7 @@ java_library(
         "//java/test/behaviour/connection:steps-base",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/java/test/behaviour/concept/type/thingtype/BUILD
+++ b/java/test/behaviour/concept/type/thingtype/BUILD
@@ -39,7 +39,7 @@ java_library(
         "//java/test/behaviour/connection:steps-base",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/java/test/behaviour/connection/BUILD
+++ b/java/test/behaviour/connection/BUILD
@@ -29,7 +29,7 @@ java_library(
     deps = [
         # Package dependencies
         "//java/api",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External dependencies from Maven
         "@maven//:junit_junit",

--- a/java/test/behaviour/connection/database/BUILD
+++ b/java/test/behaviour/connection/database/BUILD
@@ -36,7 +36,7 @@ java_library(
         "//java/test/behaviour/connection:steps-base",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/java/test/behaviour/connection/session/BUILD
+++ b/java/test/behaviour/connection/session/BUILD
@@ -36,7 +36,7 @@ java_library(
         "//java/test/behaviour/connection:steps-base",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/java/test/behaviour/connection/transaction/BUILD
+++ b/java/test/behaviour/connection/transaction/BUILD
@@ -37,7 +37,7 @@ java_library(
         "//java/test/behaviour/util:util",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
 
         # External Maven Dependencies

--- a/java/test/behaviour/query/BUILD
+++ b/java/test/behaviour/query/BUILD
@@ -42,7 +42,7 @@ java_library(
         "//java/test/behaviour/util",
 
         # Vaticle dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/query",

--- a/java/test/behaviour/util/BUILD
+++ b/java/test/behaviour/util/BUILD
@@ -32,7 +32,7 @@ java_library(
         "//java/api",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/java/test/integration/BUILD
+++ b/java/test/integration/BUILD
@@ -39,7 +39,7 @@ typedb_java_test(
         "//java/api",
 
         # External dependencies from @vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/query",


### PR DESCRIPTION
## Usage and product changes

We update Bazel dependencies and target paths following the merging of typedb-common into [vaticle/typeql](https://github.com/vaticle/typeql/) (see https://github.com/vaticle/typeql/pull/313).