### PR TITLE
Make options optional

### DIFF
--- a/cpp/include/typedb/connection/driver.hpp
+++ b/cpp/include/typedb/connection/driver.hpp
@@ -130,7 +130,7 @@ public:
      * @param type The type of session to be created (DATA or SCHEMA)
      * @param options <code>TypeDBOptions</code> for the session
      */
-    Session session(const std::string& database, SessionType sessionType, const Options& options);
+    Session session(const std::string& database, SessionType sessionType, const Options& options=Options());
 
     /**
      * Returns the logged-in user for the connection. Only for TypeDB Cloud.

--- a/cpp/include/typedb/connection/session.hpp
+++ b/cpp/include/typedb/connection/session.hpp
@@ -98,7 +98,7 @@ public:
      * @param type The type of transaction to be created (READ or WRITE)
      * @param options Options for the session
      */
-    Transaction transaction(TransactionType type, const Options& options) const;
+    Transaction transaction(TransactionType type, const Options& options=Options()) const;
 
     /**
      * Registers a callback function which will be executed when this session is closed.


### PR DESCRIPTION
## Usage and product changes

Sessions and Transactions now do not require passing an instance of options.

## Implementation

Using a new set of options by default if no options are provided when creating a session or a transaction.