### PR TITLE
Add setSupertype docs to nodejs thing types

### DIFF
--- a/nodejs/api/concept/type/AttributeType.ts
+++ b/nodejs/api/concept/type/AttributeType.ts
@@ -96,6 +96,19 @@ export interface AttributeType extends ThingType {
 
     /** @inheritdoc */
     getSupertype(transaction: TypeDBTransaction): Promise<AttributeType>;
+
+    /**
+     * Sets the supplied <code>AttributeType</code> as the supertype of the current <code>AttributeType</code>.
+     *
+     * ### Examples
+     *
+     * ```ts
+     * attributeType.setSupertype(transaction, superAttributeType).resolve();
+     * ```
+     *
+     * @param transaction The current transaction
+     * @param superAttributeType The <code>AttributeType</code> to set as the supertype of this <code>AttributeType</code>
+     */
     setSupertype(transaction: TypeDBTransaction, type: AttributeType): Promise<void>;
 
     /** @inheritdoc */

--- a/nodejs/api/concept/type/EntityType.ts
+++ b/nodejs/api/concept/type/EntityType.ts
@@ -33,6 +33,19 @@ export interface EntityType extends ThingType {
 
     /** @inheritDoc */
     getSupertype(transaction: TypeDBTransaction): Promise<EntityType>;
+
+    /**
+     * Sets the supplied <code>EntityType</code> as the supertype of the current <code>EntityType</code>.
+     *
+     * ### Examples
+     *
+     * ```ts
+     * entityType.setSupertype(transaction, superEntityType).resolve();
+     * ```
+     *
+     * @param transaction The current transaction
+     * @param superEntityType The <code>EntityType</code> to set as the supertype of this <code>EntityType</code>
+     */
     setSupertype(transaction: TypeDBTransaction, superEntityType: EntityType): Promise<void>;
 
     /** @inheritDoc */

--- a/nodejs/api/concept/type/RelationType.ts
+++ b/nodejs/api/concept/type/RelationType.ts
@@ -44,7 +44,19 @@ export interface RelationType extends ThingType {
 
     /** @inheritDoc */
     getSupertype(transaction: TypeDBTransaction): Promise<RelationType | null>;
-    /** @inheritDoc */
+
+    /**
+     * Sets the supplied <code>RelationType</code> as the supertype of the current <code>RelationType</code>.
+     *
+     * ### Examples
+     *
+     * ```ts
+     * relationType.setSupertype(transaction, superRelationType).resolve();
+     * ```
+     *
+     * @param transaction The current transaction
+     * @param superRelationType The <code>RelationType</code> to set as the supertype of this <code>RelationType</code>
+     */
     setSupertype(transaction: TypeDBTransaction, type: RelationType): Promise<void>;
 
     /** @inheritDoc */

--- a/nodejs/docs/schema/AttributeType.adoc
+++ b/nodejs/docs/schema/AttributeType.adoc
@@ -1989,7 +1989,7 @@ attributeType.setRegex(transaction, regex)
 setSupertype(transaction, type): Promise<void>
 ----
 
-
+Sets the supplied ``AttributeType`` as the supertype of the current ``AttributeType``.
 
 [caption=""]
 .Input parameters
@@ -1997,13 +1997,20 @@ setSupertype(transaction, type): Promise<void>
 [options="header"]
 |===
 |Name |Description |Type
-a| `transaction` a|  a| `TypeDBTransaction`
+a| `transaction` a| The current transaction a| `TypeDBTransaction`
 a| `type` a|  a| `AttributeType`
 |===
 
 [caption=""]
 .Returns
 `Promise<void>`
+
+[caption=""]
+.Code examples
+[source,nodejs]
+----
+attributeType.setSupertype(transaction, superAttributeType).resolve();
+----
 
 [#_AttributeType_unsetAbstract__transaction_TypeDBTransaction]
 ==== unsetAbstract

--- a/nodejs/docs/schema/EntityType.adoc
+++ b/nodejs/docs/schema/EntityType.adoc
@@ -1425,7 +1425,7 @@ thingType.setPlays(transaction, role) thingType.setPlays(transaction, role, over
 setSupertype(transaction, superEntityType): Promise<void>
 ----
 
-
+Sets the supplied ``EntityType`` as the supertype of the current ``EntityType``.
 
 [caption=""]
 .Input parameters
@@ -1433,13 +1433,20 @@ setSupertype(transaction, superEntityType): Promise<void>
 [options="header"]
 |===
 |Name |Description |Type
-a| `transaction` a|  a| `TypeDBTransaction`
-a| `superEntityType` a|  a| `EntityType`
+a| `transaction` a| The current transaction a| `TypeDBTransaction`
+a| `superEntityType` a| The ``EntityType`` to set as the supertype of this ``EntityType`` a| `EntityType`
 |===
 
 [caption=""]
 .Returns
 `Promise<void>`
+
+[caption=""]
+.Code examples
+[source,nodejs]
+----
+entityType.setSupertype(transaction, superEntityType).resolve();
+----
 
 [#_EntityType_unsetAbstract__transaction_TypeDBTransaction]
 ==== unsetAbstract

--- a/nodejs/docs/schema/RelationType.adoc
+++ b/nodejs/docs/schema/RelationType.adoc
@@ -1573,7 +1573,7 @@ relationType.setRelates(transaction, roleLabel) relationType.setRelates(transact
 setSupertype(transaction, type): Promise<void>
 ----
 
-
+Sets the supplied ``RelationType`` as the supertype of the current ``RelationType``.
 
 [caption=""]
 .Input parameters
@@ -1581,13 +1581,20 @@ setSupertype(transaction, type): Promise<void>
 [options="header"]
 |===
 |Name |Description |Type
-a| `transaction` a|  a| `TypeDBTransaction`
+a| `transaction` a| The current transaction a| `TypeDBTransaction`
 a| `type` a|  a| `RelationType`
 |===
 
 [caption=""]
 .Returns
 `Promise<void>`
+
+[caption=""]
+.Code examples
+[source,nodejs]
+----
+relationType.setSupertype(transaction, superRelationType).resolve();
+----
 
 [#_RelationType_unsetAbstract__transaction_TypeDBTransaction]
 ==== unsetAbstract


### PR DESCRIPTION
## Usage and product changes

We add missing documentation for the `setSupertype` concept API in the NodeJS Driver.