### PR TITLE
Implement new steps for getting answers from templated get

### DIFF
--- a/cpp/test/behaviour/steps/common/query_steps.cpp
+++ b/cpp/test/behaviour/steps/common/query_steps.cpp
@@ -175,6 +175,16 @@ cucumber_bdd::StepCollection<Context> querySteps = {
         assert(context.lastValueGroupResult.size() == 1);  // STEP REQUIRES ONE VALUE
         ASSERT_FALSE(context.lastValueGroupResult[0].value().has_value());
     }),
+    BDD_STEP("get answers of templated typeql get", {
+        std::string queryTemplate = step.argument->doc_string->content;
+        std::vector<std::string> varNames = extractVarsFromQueryTemplate(queryTemplate);
+        if (context.lastConceptMapResult.size() != 1) {
+            throw std::runtime_error("Can only retrieve answers of templated typeql get given 1 previous answer");
+        }
+        ConceptMap& cm = context.lastConceptMapResult[0];
+        std::string substitutedQuery = applyTemplate(queryTemplate, varNames, cm);
+        context.setResult(context.transaction().query.get(substitutedQuery, TypeDB::Options()));
+    }),
     BDD_STEP("templated typeql get; throws exception", {
         std::string queryTemplate = step.argument->doc_string->content;
         std::vector<std::string> varNames = extractVarsFromQueryTemplate(queryTemplate);

--- a/csharp/Test/Behaviour/Query/QuerySteps.cs
+++ b/csharp/Test/Behaviour/Query/QuerySteps.cs
@@ -532,6 +532,21 @@ namespace TypeDB.Driver.Test.Behaviour
             }
         }
 
+        [Then(@"get answers of templated typeql get")]
+        public void GetAnswersOfTemplatedTypeqlGet(DocString templatedQuery)
+        {
+            if (_answers!.Count != 1)
+            {
+                throw new BehaviourTestException("Can only retrieve answers of templated typeql get given 1 previous answer");
+            }
+
+            IConceptMap answer = _answers![0];
+
+            string query = ApplyQueryTemplate(templatedQuery.Content, answer);
+            ClearAnswers();
+            _answers = Tx.Query.Get(query).ToList();
+        }
+
         [Then(@"templated typeql get; throws exception")]
         public void TemplatedTypeqlGetThrowsException(DocString templatedQuery)
         {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -35,10 +35,10 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        tag = "2.27.0-rc0",
+        commit = "81def47a63eacbd51934e63ba842b06116643c15",
     )
 
 maven_artifacts = {
     'com.vaticle.typedb:typedb-runner': '0.0.0-fee8e9c5a8c17a58b4639b91e23458e715e0d3a3',
-    'com.vaticle.typedb:typedb-cloud-runner': '0.0.0-2c96925694c196be3c898aa3ffc0f56ccc84f400',
+    'com.vaticle.typedb:typedb-cloud-runner': '0.0.0-81def47a63eacbd51934e63ba842b06116643c15',
 }

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,7 +25,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.27.0-rc0",
+        commit = "67e67c1fce09860598a49383d938de0a14742707"
     )
 
 def vaticle_typedb_cloud_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "4871520d7f68ff40cd88562d4932d085284ad6fb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "f7ca0ef86896eedf6240e4b72f9217a3e4d7497e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
@@ -43,5 +43,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "6bd4b47bdb6c4464bdab0d5a547f10f3c2a46f2c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "e8fa4c974c78a2b1b722dd80bd5aa4bc1e32c39f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/java/test/behaviour/query/QuerySteps.java
+++ b/java/test/behaviour/query/QuerySteps.java
@@ -515,6 +515,19 @@ public class QuerySteps {
         }
     }
 
+    @Then("get answers of templated typeql get")
+    public void get_answers_of_templated_typeql_get(String templatedTypeQLQuery) {
+        if (answers.size() != 1) {
+            throw new ScenarioDefinitionException("Can only retrieve answers of templated typeql get given 1 previous answer");
+        }
+        String templatedQuery = String.join("\n", templatedTypeQLQuery);
+
+        ConceptMap answer = answers.get(0);
+        String queryString = applyQueryTemplate(templatedQuery, answer);
+        clearAnswers();
+        answers = tx().query().get(String.join("\n", queryString)).collect(Collectors.toList());
+    }
+
     @Then("templated typeql get; throws exception")
     public void templated_typeql_get_throws_exception(String templatedTypeQLQuery) {
         String templatedQuery = String.join("\n", templatedTypeQLQuery);

--- a/nodejs/test/behaviour/query/QuerySteps.ts
+++ b/nodejs/test/behaviour/query/QuerySteps.ts
@@ -476,7 +476,6 @@ Then("group aggregate answer value is empty", async () => {
     assert(!valueAnswerGroups[0].value);
 });
 
-
 function variableFromTemplatePlaceholder(placeholder: string): string {
     if (placeholder.endsWith(".iid")) return placeholder.replace(".iid", "").replace("answer.", "");
     else throw new Error("Cannot replace template not based on IID.");
@@ -508,6 +507,17 @@ Then("each answer satisfies", async (template: string) => {
         const query = applyQueryTemplate(template, answer);
         assert.strictEqual((await tx().query.get(query).collect()).length, 1);
     }
+});
+
+Then("get answers of templated typeql get", async (template: string) => {
+    if (answers.length != 1) {
+        throw new Error("Can only retrieve answers of templated typeql get given 1 previous answer");
+    }
+    const answer = answers[0];
+    const query = applyQueryTemplate(template, answer);
+
+    clearAnswers();
+    answers = await tx().query.get(query).collect();
 });
 
 Then("templated typeql get; throws exception", async (template: string) => {

--- a/python/tests/behaviour/query/query_steps.py
+++ b/python/tests/behaviour/query/query_steps.py
@@ -564,6 +564,16 @@ def step_impl(context: Context):
         assert_that(list(context.tx().query.get(query)), has_length(1))
 
 
+@step("get answers of templated typeql get")
+def step_impl(context: Context):
+    if len(context.answers) > 1:
+        raise ValueError("Can only retrieve answers of templated typeql get given 1 previous answer")
+    answer = context.answers[0]
+    query = apply_query_template(template=context.text, answer=answer)
+    context.clear_answers()
+    context.answers = [answer for answer in context.tx().query.get(query=query)]
+
+
 @step("templated typeql get; throws exception")
 def step_impl(context: Context):
     for answer in context.answers:

--- a/rust/tests/behaviour/query/language/steps.rs
+++ b/rust/tests/behaviour/query/language/steps.rs
@@ -209,6 +209,15 @@ generic_step_impl! {
         Ok(())
     }
 
+    #[step(expr = "get answers of templated typeql get")]
+    async fn get_answers_of_templated_typeql_get(context: &mut Context, step: &Step) {
+        if context.answer.len() > 1 {
+            panic!("Can only retrieve answers of templated typeql get given 1 previous answer.")
+        }
+        let answer = context.answer.get(0).unwrap();
+        context.answer = match_templated_answer(context, step, &answer).await.unwrap();
+    }
+
     #[step(expr = "templated typeql get; throws exception")]
     async fn templated_typeql_get_throws(context: &mut Context, step: &Step) {
         for answer in &context.answer {


### PR DESCRIPTION
## Usage and product changes

We implement a new steps in every driver for a new step: 'get answers of templated typeql get', which is a modification of the existing 'templated typeql get; throws exception'

## Implementation

- Implement 'get answers of templated typeql get' for each language.