### PR TITLE
Update Git patch during Windows Circle CI initial job setup

### DIFF
--- a/.circleci/windows/git.patch
+++ b/.circleci/windows/git.patch
@@ -1,10 +1,10 @@
 diff --git a/WORKSPACE b/WORKSPACE
-index 7b30ef2e..145bc0ce 100644
+index a6df7ba2..420f8397 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
-@@ -19,7 +19,7 @@
+@@ -15,7 +15,7 @@
+ # specific language governing permissions and limitations
  # under the License.
- #
  
 -workspace(name = "vaticle_typedb_driver")
 +workspace(name = "v")

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -18,6 +18,7 @@ REM under the License.
 
 REM shorten the workspace name so that we can avoid the long path restriction
 git apply .circleci\windows\git.patch
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
 REM uninstall Java 12 installed by CircleCI
 choco uninstall openjdk --limit-output --yes --no-progress


### PR DESCRIPTION
## Usage and product changes

We update the Windows Circle CI git patch file to be compatible with the WORKSPACE file which has been recently updated. We also add a check of whether the git patch was successfully applied to catch such mistakes early in the future.