### PR TITLE
Update maven dependencies to fix builds

### DIFF
--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -3,6 +3,9 @@
 @maven//:com_eclipsesource_minimal_json_minimal_json_0_9_5
 @maven//:com_electronwill_night_config_core_3_6_5
 @maven//:com_electronwill_night_config_toml_3_6_5
+@maven//:com_fasterxml_jackson_core_jackson_annotations_2_10_1
+@maven//:com_fasterxml_jackson_core_jackson_core_2_10_1
+@maven//:com_fasterxml_jackson_core_jackson_databind_2_10_1
 @maven//:com_google_android_annotations_4_1_1_4
 @maven//:com_google_api_grpc_proto_google_common_protos_2_9_0
 @maven//:com_google_code_findbugs_annotations_3_0_1
@@ -17,7 +20,7 @@
 @maven//:com_google_protobuf_protobuf_java_3_21_1
 @maven//:com_vaticle_typedb_typedb_cloud_runner_0_0_0_2c96925694c196be3c898aa3ffc0f56ccc84f400
 @maven//:com_vaticle_typedb_typedb_runner_0_0_0_fee8e9c5a8c17a58b4639b91e23458e715e0d3a3
-@maven//:commons_codec_commons_codec_1_11
+@maven//:commons_codec_commons_codec_1_13
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging_1_2
 @maven//:info_picocli_picocli_4_6_1
@@ -88,6 +91,7 @@
 @maven//:net_jcip_jcip_annotations_1_0
 @maven//:org_antlr_antlr4_runtime_4_8
 @maven//:org_apache_commons_commons_compress_1_21
+@maven//:org_apache_commons_commons_lang3_3_9
 @maven//:org_apache_httpcomponents_httpclient_4_5_11
 @maven//:org_apache_httpcomponents_httpcore_4_4_13
 @maven//:org_apiguardian_apiguardian_api_1_1_0
@@ -98,6 +102,7 @@
 @maven//:org_hamcrest_hamcrest_library_1_3
 @maven//:org_jetbrains_compose_compiler_compiler_1_5_7
 @maven//:org_jsoup_jsoup_1_16_1
+@maven//:org_kohsuke_github_api_1_101
 @maven//:org_slf4j_jcl_over_slf4j_2_0_0
 @maven//:org_slf4j_log4j_over_slf4j_2_0_0
 @maven//:org_slf4j_slf4j_api_2_0_0


### PR DESCRIPTION
Maven dependencies have been updated, and the snapshot requires an update as well.

[The commit which resulted in the updated deps](https://github.com/vaticle/dependencies/commit/cb6c94e3bf7759a833622c71f56b558d5cd84a24).