### PR TITLE
Add Bazel remote cache setup for CircleCI unix commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ commands:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip38 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
@@ -152,6 +153,7 @@ commands:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip38 --compilation_mode=opt -- release
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip39 --compilation_mode=opt -- release
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip310 --compilation_mode=opt -- release
@@ -180,6 +182,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //java:deploy-maven-jni -- snapshot
 
   deploy-maven-snapshot-unix:
@@ -187,6 +190,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //java:deploy-maven -- snapshot
 
   test-maven-snapshot-unix:
@@ -212,6 +216,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //java:deploy-maven-jni --compilation_mode=opt -- release
 
   deploy-maven-release-unix:
@@ -219,6 +224,7 @@ commands:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //java:deploy-maven --compilation_mode=opt -- release
 
   ######################
@@ -230,6 +236,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //c:deploy-clib-driver --compilation_mode=opt -- snapshot
 
   test-clib-assembly-linux:
@@ -239,6 +246,7 @@ commands:
     steps:
       - run: |
           yum install -y cmake3 make
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build --jobs=8 //c:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-clib-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
@@ -262,6 +270,7 @@ commands:
     steps:
       - run: |
           ulimit -n 100000
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build //c:assemble-mac-<<parameters.target-arch>>-zip
           export ASSEMBLY=typedb-driver-clib-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_clib
@@ -283,6 +292,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //c:deploy-clib-driver --compilation_mode=opt -- release
 
   ########################
@@ -294,6 +304,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //cpp:deploy-cpp-driver --compilation_mode=opt -- snapshot
 
   test-cpp-assembly-linux:
@@ -303,6 +314,7 @@ commands:
     steps:
       - run: |
           yum install -y cmake3 make
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build --jobs=8 //cpp:assemble-linux-<<parameters.target-arch>>-targz
           export ASSEMBLY=typedb-driver-cpp-linux-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
@@ -326,6 +338,7 @@ commands:
     steps:
       - run: |
           ulimit -n 100000
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel build //cpp:assemble-mac-<<parameters.target-arch>>-zip
           export ASSEMBLY=typedb-driver-cpp-mac-<<parameters.target-arch>>
           mkdir -p test_assembly_cpp
@@ -347,6 +360,7 @@ commands:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //cpp:deploy-cpp-driver --compilation_mode=opt -- release
 
   #########################
@@ -384,12 +398,14 @@ commands:
     steps:
       - run: |
           export DEPLOY_NUGET_API_KEY=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=0.0.0-$(git rev-parse HEAD) //csharp:driver-csharp-runtime-push -- snapshot
 
   deploy-dotnet-snapshot-unix:
     steps:
       - run: |
           export DEPLOY_NUGET_API_KEY=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=0.0.0-$(git rev-parse HEAD) //csharp:driver-csharp-push -- snapshot
 
   test-dotnet-snapshot-unix:
@@ -416,12 +432,14 @@ commands:
     steps:
       - run: |
           export DEPLOY_NUGET_API_KEY=$REPO_NUGET_TOKEN
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //csharp:driver-csharp-runtime-push --compilation_mode=opt -- release
 
   deploy-dotnet-release-unix:
     steps:
       - run: |
           export DEPLOY_NUGET_API_KEY=$REPO_NUGET_TOKEN
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //csharp:driver-csharp-push --compilation_mode=opt -- release
 
   #########################
@@ -432,12 +450,14 @@ commands:
     steps:
       - run: |
           export DEPLOY_CRATE_TOKEN=$REPO_TYPEDB_CRATES_TOKEN
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //rust:deploy_crate -- snapshot
 
   deploy-crate-release-unix:
     steps:
       - run: |
           export DEPLOY_CRATE_TOKEN=$REPO_CRATES_TOKEN
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //rust:deploy_crate --compilation_mode=opt -- release
 
   #########################
@@ -458,6 +478,7 @@ commands:
       - run: |
           export DEPLOY_NPM_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_NPM_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //nodejs:deploy-npm -- snapshot
 
   test-npm-snapshot-unix:
@@ -478,6 +499,7 @@ commands:
           wget -q -O - https://cli-assets.heroku.com/apt/release.key | apt-key add -
           wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
           export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
           bazel run --jobs=8 --define version=$(cat VERSION) //nodejs:deploy-npm --compilation_mode=opt -- release
 
 jobs:


### PR DESCRIPTION
## Usage and product changes
CircleCI has random fails because of some process races (when a setup process takes too much time to initialize) or network errors working with Bazel (`Server terminated abruptly (error code: 14, error message: 'Socket closed', log file: '/root/.cache/bazel/_bazel_root/37e9b89f8be6f62402523a372e67422a/server/jvm.out')`). 

To address the last problem, we connect CircleCI builds to our Bazel remote cache for each Bazel operation on Unix-based systems. This way, we won't send too many requests to the remote Bazel servers, using already existing build results from our cache when it's possible.

## Implementation
We add a remote cache setup call before each Bazel command for Unix CircleCI builds.