### PR TITLE
Deploy C# driver in a separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,6 +609,13 @@ jobs:
       - deploy-maven-snapshot-unix
       - install-npm-apt
       - deploy-npm-snapshot-unix
+
+  deploy-snapshot-dotnet-any:
+    executor: linux-x86_64-ubuntu-2204
+    steps:
+      - checkout
+      - install-bazel-apt:
+          bazel-arch: amd64
       - deploy-dotnet-snapshot-unix
 
   test-snapshot-linux-arm64:
@@ -765,6 +772,13 @@ jobs:
       - deploy-maven-release-unix
       - install-npm-apt
       - deploy-npm-release-unix
+
+  deploy-release-dotnet-any:
+    executor: linux-x86_64-ubuntu-2204
+    steps:
+      - checkout
+      - install-bazel-apt:
+          bazel-arch: amd64
       - deploy-dotnet-release-unix
 
   deploy-github:
@@ -844,6 +858,17 @@ workflows:
             - deploy-snapshot-mac-x86_64
             - deploy-snapshot-windows-x86_64
 
+      - deploy-snapshot-dotnet-any:
+          filters:
+            branches:
+              only: [development, master]
+          requires:
+            - deploy-snapshot-linux-arm64
+            - deploy-snapshot-linux-x86_64
+            - deploy-snapshot-mac-arm64
+            - deploy-snapshot-mac-x86_64
+            - deploy-snapshot-windows-x86_64
+
       - test-snapshot-linux-arm64:
           filters:
             branches:
@@ -851,6 +876,7 @@ workflows:
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-any
+            - deploy-snapshot-dotnet-any
 
       - test-snapshot-linux-x86_64:
           filters:
@@ -859,6 +885,7 @@ workflows:
           requires:
             - deploy-snapshot-linux-x86_64
             - deploy-snapshot-any
+            - deploy-snapshot-dotnet-any
 
       - test-snapshot-mac-arm64:
           filters:
@@ -867,6 +894,7 @@ workflows:
           requires:
             - deploy-snapshot-mac-arm64
             - deploy-snapshot-any
+            - deploy-snapshot-dotnet-any
 
       - test-snapshot-mac-x86_64:
           filters:
@@ -875,6 +903,7 @@ workflows:
           requires:
             - deploy-snapshot-mac-x86_64
             - deploy-snapshot-any
+            - deploy-snapshot-dotnet-any
 
       - test-snapshot-windows-x86_64:
           filters:
@@ -883,6 +912,7 @@ workflows:
           requires:
             - deploy-snapshot-windows-x86_64
             - deploy-snapshot-any
+            - deploy-snapshot-dotnet-any
 
       - test-snapshot-any:
           filters:
@@ -925,6 +955,17 @@ workflows:
             - deploy-release-mac-x86_64
             - deploy-release-windows-x86_64
 
+      - deploy-release-dotnet-any:
+          filters:
+            branches:
+              only: [release]
+          requires:
+            - deploy-release-linux-arm64
+            - deploy-release-linux-x86_64
+            - deploy-release-mac-arm64
+            - deploy-release-mac-x86_64
+            - deploy-release-windows-x86_64
+
       - deploy-github:
           filters:
             branches:
@@ -936,6 +977,7 @@ workflows:
             - deploy-release-linux-x86_64
             - deploy-release-windows-x86_64
             - deploy-release-any
+            - deploy-release-dotnet-any
 
       - sync-dependencies:
           filters:

--- a/csharp/Api/BUILD
+++ b/csharp/Api/BUILD
@@ -30,7 +30,6 @@ csharp_library(
         "@paket.csharp_deps//newtonsoft.json",
     ],
     out = "TypeDB.Driver.Api",
-    runtime_identifier = "any",
     nullable = nullable_context,
     target_frameworks = target_frameworks,
     targeting_packs = targeting_packs,

--- a/csharp/Common/BUILD
+++ b/csharp/Common/BUILD
@@ -26,7 +26,6 @@ csharp_library(
     srcs = glob(["*.cs", "*/*.cs"]),
     deps = ["//csharp:typedb_driver_pinvoke"],
     out = "TypeDB.Driver.Common",
-    runtime_identifier = "any",
     nullable = nullable_context,
     target_frameworks = target_frameworks,
     targeting_packs = targeting_packs,


### PR DESCRIPTION
## Usage and product changes

Currently, Bazel generates three different build configurations for the underlying FFI library during C# driver deployment. As that requires compilation of the binding generator and lengthy project analysis, that step is prone to random failures (`socket closed`).

As the full analysis of the issue proved time-consuming, we instead opt to make the C# driver deployment step easily retriable.