### PR TITLE
Fix C# README examples and add issues refs to recent TODOs

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -293,7 +293,7 @@ build:
 
         source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
           bazel test //python/tests/integration:test_connection --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-          # TODO currently broken test
+          # TODO #635: currently broken test
           # bazel test //python/tests/integration:test_cloud_failover --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           export CLOUD_FAILED= || export CLOUD_FAILED=1
         tool/test/stop-cloud-servers.sh
@@ -541,7 +541,7 @@ build:
         export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
-# TODO: assembly tests for all drivers to run in factory
+# TODO #512: assembly tests for all drivers to run in factory
 
 release:
   filter:

--- a/c/BUILD
+++ b/c/BUILD
@@ -222,13 +222,13 @@ filegroup(
     output_group = "header"
 )
 
+# TODO: Not hermetic - requires doxygen on the host (https://github.com/vaticle/bazel-distribution/issues/412)
 doxygen_docs(
     name = "docs_html",
     project_name = "TypeDB C Driver",
     sources = [":_typedb_driver_h_only"],
     main_page_md = ":README.md",
     tags = ["manual"],
-
 )
 
 doxygen_c_to_adoc(

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -199,8 +199,7 @@ alias(
     })
 )
 
-# docs
-# TODO: Not hermetic - requires doxygen on the host
+# TODO: Not hermetic - requires doxygen on the host (https://github.com/vaticle/bazel-distribution/issues/412)
 doxygen_docs(
     name = "docs_html",
     project_name = "TypeDB C++ Driver",

--- a/cpp/test/behaviour/steps/common/common_steps.cpp
+++ b/cpp/test/behaviour/steps/common/common_steps.cpp
@@ -30,7 +30,7 @@ cucumber_bdd::StepCollection<Context> commonSteps = {
     BDD_STEP("wait (\\d+) seconds", {
         std::this_thread::sleep_for(std::chrono::seconds(atoi(matches[1].str().c_str())));
     }),
-    BDD_NOOP("set time-zone is: (.*)"), // TODO: Decide if we want to implement (can be changed only for POSIX).
+    BDD_NOOP("set time-zone is: (.*)"), // TODO #636: consider implementation (looks like it can be changed only for POSIX).
     BDD_NOOP("typedb has configuration"),
 };
 

--- a/cpp/test/cucumber/include/cucumber_bdd/runner.hpp
+++ b/cpp/test/cucumber/include/cucumber_bdd/runner.hpp
@@ -57,7 +57,7 @@ class TestRunner : public TestRunnerBase {
         steps.reserve(totalSteps);
         for (const StepCollection<CTX> stepVec : stepLists) {
             for (const cucumber_bdd::StepDefinition<CTX> stepDef : stepVec) {
-                steps.push_back(StepDefinition<CTX>{stepDef.regex, stepDef.impl});  // TODO: Avoid deep copy?
+                steps.push_back(StepDefinition<CTX>{stepDef.regex, stepDef.impl});
             }
         }
         assert(steps.size() == totalSteps);

--- a/csharp/BUILD
+++ b/csharp/BUILD
@@ -118,7 +118,7 @@ filegroup(
     srcs = [":Drivers.cs"],
 )
 
-# TODO: Not hermetic - requires doxygen on the host
+# TODO: Not hermetic - requires doxygen on the host (https://github.com/vaticle/bazel-distribution/issues/412)
 doxygen_docs(
     name = "docs_html",
     project_name = "TypeDB C# Driver",

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -43,6 +43,7 @@ Any error encountered will throw a `TypeDBDriverException`. Note that methods wh
 ### TypeDB Core
 Connect to TypeDB using `Drivers.CoreDriver` and perform basic read/write operations:
 ```cs
+using TypeDB.Driver;
 using TypeDB.Driver.Api;
 using TypeDB.Driver.Common;
 
@@ -133,6 +134,7 @@ class WelcomeToTypeDB
 ### TypeDB Cloud
 Connect to TypeDB cloud instances using `Drivers.CloudDriver`:
 ```cs
+using TypeDB.Driver;
 using TypeDB.Driver.Api;
 using TypeDB.Driver.Common;
 

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -173,6 +173,7 @@ class WelcomeToTypeDB
                         transaction.Commit();
                     }
                 }
+             }
         }
         catch (TypeDBDriverException e)
         {

--- a/csharp/Test/Behaviour/Util/UtilSteps.cs
+++ b/csharp/Test/Behaviour/Util/UtilSteps.cs
@@ -36,7 +36,7 @@ namespace TypeDB.Driver.Test.Behaviour
         [When(@"set time-zone is: {}")]
         public void SetTimeZoneIs(string timeZoneId)
         {
-            // no-op: C# doesn't support time zone changes.
+            // no-op: C# doesn't support time zone changes. // TODO #636: consider implementation
         }
     }
 }

--- a/rust/tests/behaviour/query/reasoner/steps.rs
+++ b/rust/tests/behaviour/query/reasoner/steps.rs
@@ -101,6 +101,6 @@ generic_step_impl! {
 
     #[step(expr = "verify answers are consistent across {int} executions")]
     async fn verify_answers_are_consistent_across_executions(_context: &mut Context, _executions: usize) {
-        //     We can't execute previous query again because don't remember the query // TODO: start saving the query and implement
+        //     We can't execute previous query again because don't remember the query // TODO #612: start saving the query and implement
     }
 }


### PR DESCRIPTION
## Usage and product changes
C# driver's examples should be able to be built in any namespace now.

Some of the recent `TODO`s left in the codebase have been cleaned or marked with a specific GitHub issue number.  

## Implementation
We suggest leaving refs to GitHub's issues for each newly merged `TODO`s not to lose track of these problems and have more context behind them. It can be done:
- `#issuenumber` if the issue is a part of the target repo;
- full URL if the issue is a part of another repo.