### PR TITLE
Fix misleading cloud encryption error message

### DIFF
--- a/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
@@ -11,7 +11,7 @@
 a| `AddressTranslationMismatch`
 a| `BrokenPipe`
 a| `CloudAllNodesFailed`
-a| `CloudEndpointEncrypted`
+a| `CloudEncryptionSettingsMismatch`
 a| `CloudReplicaNotPrimary`
 a| `CloudSSLCertificateNotValidated`
 a| `CloudTokenCredentialInvalid`

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -62,8 +62,8 @@ error_messages! { ConnectionError
         17: "Invalid token credential.",
     SessionCloseFailed =
         18: "Failed to close session. It may still be open on the server: or it may already have been closed previously.",
-    CloudEndpointEncrypted =
-        19: "Unable to connect to TypeDB Cloud: attempting an unencrypted connection to an encrypted endpoint.",
+    CloudEncryptionSettingsMismatch =
+        19: "Unable to connect to TypeDB Cloud: possible encryption settings mismatch.",
     CloudSSLCertificateNotValidated =
         20: "SSL handshake with TypeDB Cloud failed: the server's identity could not be verified. Possible CA mismatch.",
     BrokenPipe =
@@ -137,7 +137,7 @@ impl Error {
         if status_message == "broken pipe" {
             Error::Connection(ConnectionError::BrokenPipe)
         } else if status_message.contains("received corrupt message") {
-            Error::Connection(ConnectionError::CloudEndpointEncrypted)
+            Error::Connection(ConnectionError::CloudEncryptionSettingsMismatch)
         } else if status_message.contains("UnknownIssuer") {
             Error::Connection(ConnectionError::CloudSSLCertificateNotValidated)
         } else if status_message.contains("Connection refused") {


### PR DESCRIPTION
## Usage and product changes
The old version of the cloud encryption error message confused the user in case, for example, their endpoint is not encrypted, but the connection is. There are also other potential causes of the `received corrupt message` status message, that we can't understand on a deeper level, so it's more correct to have a less specific error message here.

## Implementation
Renamed the error.