### PR TITLE
Turn off statistics reporting in CI

### DIFF
--- a/.circleci/windows/clib/test_assembly.bat
+++ b/.circleci/windows/clib/test_assembly.bat
@@ -35,7 +35,7 @@ cmake --build . --config release
 popd
 set PATH=%cd%\test_assembly_clib\typedb-driver-clib-windows-x86_64\lib;%PATH%;
 
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
 powershell -Command "Start-Sleep -Seconds 10"
 
 test_assembly_clib\Release\test_assembly.exe

--- a/.circleci/windows/cpp/test_assembly.bat
+++ b/.circleci/windows/cpp/test_assembly.bat
@@ -35,7 +35,7 @@ cmake --build . --config release
 popd
 set PATH=%cd%\test_assembly_cpp\typedb-driver-cpp-windows-x86_64\lib;%PATH%;
 
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
 powershell -Command "Start-Sleep -Seconds 10"
 
 test_assembly_cpp\Release\test_assembly.exe

--- a/.circleci/windows/csharp/test_deploy_snapshot.bat
+++ b/.circleci/windows/csharp/test_deploy_snapshot.bat
@@ -25,7 +25,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
 
 powershell -Command "(gc csharp\Test\Deployment\NugetApplicationTest.csproj) -replace 'DRIVER_CSHARP_VERSION_MARKER', '0.0.0-%CIRCLE_SHA1%' | Out-File -encoding ASCII csharp\Test\Deployment\NugetApplicationTest.csproj"
 type csharp\Test\Deployment\NugetApplicationTest.csproj

--- a/.circleci/windows/java/test_deploy_snapshot.bat
+++ b/.circleci/windows/java/test_deploy_snapshot.bat
@@ -25,7 +25,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
 
 powershell -Command "(gc java\test\deployment\pom.xml) -replace 'DRIVER_JAVA_VERSION_MARKER', '0.0.0-%CIRCLE_SHA1%' | Out-File -encoding ASCII java\test\deployment\pom.xml"
 type java\test\deployment\pom.xml

--- a/.circleci/windows/python/test_deploy_snapshot.bat
+++ b/.circleci/windows/python/test_deploy_snapshot.bat
@@ -27,7 +27,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
 
 python3 -m pip install --extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple typedb-driver==0.0.0+%VER%
 cd python/tests/deployment

--- a/java/test/integration/DriverQueryTest.java
+++ b/java/test/integration/DriverQueryTest.java
@@ -73,6 +73,7 @@ public class DriverQueryTest {
     public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
         Map<String, String> options = new HashMap<>();
         options.put("--diagnostics.reporting.errors", "false");
+        options.put("--diagnostics.reporting.statistics", "false");
         typedb = new TypeDBCoreRunner(options);
         typedb.start();
         typedbDriver = TypeDB.coreDriver(typedb.address());

--- a/nodejs/test/integration/test-cloud-failover.js
+++ b/nodejs/test/integration/test-cloud-failover.js
@@ -71,6 +71,7 @@ function serverStart(idx) {
         "--server.encryption.file.internal-zmq.private-key", encryptionResourceDir + "int-zmq-private-key",
         "--server.encryption.file.internal-zmq.public-key", encryptionResourceDir + "int-zmq-public-key",
         "--diagnostics.reporting.errors", "false",
+        "--diagnostics.reporting.statistics", "false",
         "--diagnostics.monitoring.enable", "false"
     ]);
     node.stdout.on('data', (data) => {

--- a/python/tests/integration/cloud_test_rule.bzl
+++ b/python/tests/integration/cloud_test_rule.bzl
@@ -45,6 +45,7 @@ def _rule_implementation(ctx):
                 --server.peers.peer-3.internal-address.grpc=localhost:31731 \
                 --server.encryption.enable=true \
                 --diagnostics.reporting.errors=false \
+                --diagnostics.reporting.statistics=false \
                 --diagnostics.monitoring.enable=false
             }
             if test -d typedb_distribution; then

--- a/python/tests/integration/test_cloud_failover.py
+++ b/python/tests/integration/test_cloud_failover.py
@@ -57,6 +57,7 @@ class TestCloudFailover(TestCase):
             "--server.peers.peer-3.internal-address.grpc", "localhost:31731",
             "--server.encryption.enable", "true",
             "--diagnostics.reporting.errors", "false",
+            "--diagnostics.reporting.statistics", "false",
             "--diagnostics.monitoring.enable", "false"
         ])
 

--- a/tool/test/start-cloud-servers.sh
+++ b/tool/test/start-cloud-servers.sh
@@ -46,6 +46,7 @@ function server_start() {
     --server.encryption.file.internal-zmq.private-key=`realpath tool/test/resources/encryption/int-zmq-private-key` \
     --server.encryption.file.internal-zmq.public-key=`realpath tool/test/resources/encryption/int-zmq-public-key` \
     --diagnostics.reporting.errors=false \
+    --diagnostics.reporting.statistics=false \
     --diagnostics.monitoring.enable=false
 }
 

--- a/tool/test/start-core-server.sh
+++ b/tool/test/start-core-server.sh
@@ -22,7 +22,7 @@ rm -rf typedb-all
 
 bazel run //tool/test:typedb-extractor -- typedb-all
 BAZEL_JAVA_HOME=$(bazel run //tool/test:echo-java-home)
-JAVA_HOME=$BAZEL_JAVA_HOME ./typedb-all/typedb server --diagnostics.reporting.errors=false --diagnostics.monitoring.enable=false &
+JAVA_HOME=$BAZEL_JAVA_HOME ./typedb-all/typedb server --diagnostics.reporting.errors=false --diagnostics.reporting.statistics=false --diagnostics.monitoring.enable=false &
 
 set +e
 POLL_INTERVAL_SECS=0.5


### PR DESCRIPTION
## Usage and product changes
We turn off the `--diagnostics.reporting.statistics` in our CI builds not to send non-real diagnostics data.

In version 2.28 and earlier, this flag purely prevents `TypeDB` from sending any diagnostics data.
In the upcoming version 2.28.1, this flag still allows `TypeDB` to send a single diagnostics snapshot with the information of when the diagnostics data has been turned off, but it happens only after the server runs for 1 hour, so we expect the CI builds not to reach this point and not to send any diagnostics data as well.