### PR TITLE
JNI library loading uses a predetermined file name

### DIFF
--- a/java/common/Loader.java
+++ b/java/common/Loader.java
@@ -92,7 +92,7 @@ public class Loader {
     private static Path unpackNativeResources(URL resourceURL) throws IOException {
         Path tempPath = Files.createTempDirectory("typedb-driver-lib");
         tempPath.toFile().deleteOnExit();
-        Path newPath = tempPath.resolve(Path.of(resourceURL.getPath()).getFileName().toString());
+        Path newPath = tempPath.resolve(DRIVER_JNI_LIBRARY_NAME);
         Files.copy(resourceURL.openStream(), newPath);
         newPath.toFile().deleteOnExit();
         return newPath;


### PR DESCRIPTION
## Usage and product changes
The unpacked JNI library now uses a pre-determined filename. This replaces logic to extract the filename from the packaged resource.

## Implementation
The new method produces the same filename, since the way we find the resource is through the filename in the first place.
