### PR TITLE
Fix aspect_bazel_lib dependency, update typedb and nodejs dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,3 +33,7 @@ build:macos --stamp --workspace_status_command=$PWD/workspace-status.sh
 
 # TODO
 # build:windows --stamp --workspace_status_command=workspace-status.bat
+
+build --@aspect_rules_ts//ts:skipLibCheck=always
+fetch --@aspect_rules_ts//ts:skipLibCheck=always
+query --@aspect_rules_ts//ts:skipLibCheck=always

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,12 +63,14 @@ cpp_deps()
 # Load //builder/csharp
 load("@vaticle_dependencies//builder/csharp:deps.bzl", dotnet_deps = "deps")
 dotnet_deps()
+
 load(
     "@rules_dotnet//dotnet:repositories.bzl",
     "dotnet_register_toolchains",
     "rules_dotnet_dependencies",
 )
 rules_dotnet_dependencies()
+
 dotnet_register_toolchains("dotnet", "6.0.413")
 load("@rules_dotnet//dotnet:paket.rules_dotnet_nuget_packages.bzl", "rules_dotnet_nuget_packages")
 rules_dotnet_nuget_packages()
@@ -244,7 +246,6 @@ vaticle_typedb_protocol_npm_repositories()
 
 # Setup rules_ts
 load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
-
 rules_ts_dependencies(
     ts_version_from = "//nodejs:package.json",
 )

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -18,8 +18,9 @@
 @maven//:com_google_http_client_google_http_client_1_34_2
 @maven//:com_google_j2objc_j2objc_annotations_1_3
 @maven//:com_google_protobuf_protobuf_java_3_21_1
-@maven//:com_vaticle_typedb_typedb_cloud_runner_2_28_0
-@maven//:com_vaticle_typedb_typedb_runner_2_28_0
+@maven//:com_vaticle_typedb_typedb_cloud_runner_2_28_3
+@maven//:com_vaticle_typedb_typedb_common_2_28_1
+@maven//:com_vaticle_typedb_typedb_runner_2_28_3
 @maven//:com_vdurmont_semver4j_3_1_0
 @maven//:commons_codec_commons_codec_1_13
 @maven//:commons_io_commons_io_2_3

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,7 +25,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.28.0"
+        tag = "2.28.3"
     )
 
 def vaticle_typedb_cloud_artifact():
@@ -35,10 +35,10 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        tag = "2.28.0",
+        tag = "2.28.3",
     )
 
 maven_artifacts = {
-    'com.vaticle.typedb:typedb-runner': '2.28.0',
-    'com.vaticle.typedb:typedb-cloud-runner': '2.28.0',
+    'com.vaticle.typedb:typedb-runner': '2.28.3',
+    'com.vaticle.typedb:typedb-cloud-runner': '2.28.3',
 }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "729d960a92e145e03794395bbe59e02f122f1aee", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/farost/dependencies", # TODO: Change back to vaticle when the deps PR is merged!
+        commit = "a22e2662b126498acb258d0a788fcfe0e790a226", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/farost/dependencies", # TODO: Change back to vaticle when the deps PR is merged!
-        commit = "a22e2662b126498acb258d0a788fcfe0e790a226", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "b89c25993c1e4f11b367435b83ac19bb658bb712", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -82,6 +82,7 @@ ts_project(
         ":node_modules/uuid",
         ":node_modules/@types/uuid",
     ],
+    transpiler = "tsc",
     visibility = ["//visibility:public"],
     out_dir = "dist",
 )
@@ -133,6 +134,7 @@ ts_project(
         ":node_modules/typedoc",
         ":node_modules/@types/node",
     ],
+    transpiler = "tsc",
     visibility = ["//visibility:public"],
     out_dir = ".",
 )

--- a/nodejs/test/behaviour/concept/thing/BUILD
+++ b/nodejs/test/behaviour/concept/thing/BUILD
@@ -37,6 +37,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     declaration = True,
     resolve_json_module = True,
     visibility = ["//visibility:public"],

--- a/nodejs/test/behaviour/concept/thing/attribute/BUILD
+++ b/nodejs/test/behaviour/concept/thing/attribute/BUILD
@@ -37,6 +37,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/concept/thing/entity/BUILD
+++ b/nodejs/test/behaviour/concept/thing/entity/BUILD
@@ -37,6 +37,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/concept/thing/relation/BUILD
+++ b/nodejs/test/behaviour/concept/thing/relation/BUILD
@@ -37,6 +37,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/concept/type/attributetype/BUILD
+++ b/nodejs/test/behaviour/concept/type/attributetype/BUILD
@@ -36,6 +36,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/concept/type/relationtype/BUILD
+++ b/nodejs/test/behaviour/concept/type/relationtype/BUILD
@@ -36,6 +36,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/concept/type/thingtype/BUILD
+++ b/nodejs/test/behaviour/concept/type/thingtype/BUILD
@@ -36,6 +36,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     declaration = True,
     resolve_json_module = True,
     visibility = ["//visibility:public"],

--- a/nodejs/test/behaviour/config/BUILD
+++ b/nodejs/test/behaviour/config/BUILD
@@ -29,6 +29,7 @@ ts_project(
         "//nodejs:node_modules/@types/node",
         "//nodejs:node_modules/@cucumber/cucumber",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/connection/BUILD
+++ b/nodejs/test/behaviour/connection/BUILD
@@ -34,6 +34,7 @@ ts_project(
         "//nodejs:node_modules/google-protobuf",
         "//nodejs:node_modules/@types/google-protobuf",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )
@@ -50,6 +51,7 @@ ts_project(
         "//nodejs:node_modules/@cucumber/cucumber",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )
@@ -66,6 +68,7 @@ ts_project(
         "//nodejs:node_modules/@cucumber/cucumber",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/connection/database/BUILD
+++ b/nodejs/test/behaviour/connection/database/BUILD
@@ -35,6 +35,7 @@ ts_project(
         "//nodejs/test/behaviour/util:util",
         "//nodejs/test/behaviour/connection:steps-base",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/connection/session/BUILD
+++ b/nodejs/test/behaviour/connection/session/BUILD
@@ -35,6 +35,7 @@ ts_project(
         "//nodejs/test/behaviour/util:util",
         "//nodejs/test/behaviour/connection:steps-base",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/connection/transaction/BUILD
+++ b/nodejs/test/behaviour/connection/transaction/BUILD
@@ -35,6 +35,7 @@ ts_project(
         "//nodejs/test/behaviour/util:util",
         "//nodejs/test/behaviour/connection:steps-base",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/connection/user/BUILD
+++ b/nodejs/test/behaviour/connection/user/BUILD
@@ -35,6 +35,7 @@ ts_project(
         "//nodejs/test/behaviour/util:util",
         "//nodejs/test/behaviour/connection:steps-base",
     ],
+    transpiler = "tsc",
     resolve_json_module = True,
     visibility = ["//visibility:public"],
 )

--- a/nodejs/test/behaviour/query/BUILD
+++ b/nodejs/test/behaviour/query/BUILD
@@ -38,6 +38,7 @@ ts_project(
         "//nodejs/test/behaviour/connection:steps-base",
         "//nodejs/test/behaviour/util:util",
     ],
+    transpiler = "tsc",
     declaration = True,
     resolve_json_module = True,
     visibility = ["//visibility:public"],

--- a/nodejs/test/behaviour/util/BUILD
+++ b/nodejs/test/behaviour/util/BUILD
@@ -29,6 +29,7 @@ ts_project(
 
         "//nodejs:node_modules/@types/node",
     ],
+    transpiler = "tsc",
     visibility = ["//visibility:public"],
 )
 
@@ -41,6 +42,7 @@ ts_project(
         "//nodejs:node_modules/@cucumber/cucumber",
         "//nodejs:node_modules/@types/node",
     ],
+    transpiler = "tsc",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
## Usage and product changes
1. We update `typedb` dependencies to `2.28.3` before the release to verify that the builds are still correct before the `driver` release.
2. We update other dependencies that have previously broken the build because of the updated `ts` (`nodejs`) rules:
**dependencies** ref with `nodejs` and `csharp` rules becoming more mature based on [aspect_bazel_lib version globalization](https://github.com/vaticle/dependencies/pull/547);
**typedb-protocol** ref to [propagate](https://github.com/vaticle/typedb-protocol/pull/202) the fixed `ts` rules and fix its build based on this propagation. 

## Implementation
We use the updated rules fixed in [dependencies](https://github.com/vaticle/dependencies/pull/547) and also update the code based on the new requirements of the updates `ts` rules. More details in the comments.