### PR TITLE
Remove excessive diagnostics flags, turn on development mode for tests

### DIFF
--- a/.circleci/windows/clib/test_assembly.bat
+++ b/.circleci/windows/clib/test_assembly.bat
@@ -35,7 +35,7 @@ cmake --build . --config release
 popd
 set PATH=%cd%\test_assembly_clib\typedb-driver-clib-windows-x86_64\lib;%PATH%;
 
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --development-mode.enable=true
 powershell -Command "Start-Sleep -Seconds 10"
 
 test_assembly_clib\Release\test_assembly.exe

--- a/.circleci/windows/clib/test_assembly.bat
+++ b/.circleci/windows/clib/test_assembly.bat
@@ -35,7 +35,7 @@ cmake --build . --config release
 popd
 set PATH=%cd%\test_assembly_clib\typedb-driver-clib-windows-x86_64\lib;%PATH%;
 
-START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
+START /B "" typedb-server-windows\typedb server
 powershell -Command "Start-Sleep -Seconds 10"
 
 test_assembly_clib\Release\test_assembly.exe

--- a/.circleci/windows/cpp/test_assembly.bat
+++ b/.circleci/windows/cpp/test_assembly.bat
@@ -35,7 +35,7 @@ cmake --build . --config release
 popd
 set PATH=%cd%\test_assembly_cpp\typedb-driver-cpp-windows-x86_64\lib;%PATH%;
 
-START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
+START /B "" typedb-server-windows\typedb server
 powershell -Command "Start-Sleep -Seconds 10"
 
 test_assembly_cpp\Release\test_assembly.exe

--- a/.circleci/windows/cpp/test_assembly.bat
+++ b/.circleci/windows/cpp/test_assembly.bat
@@ -35,7 +35,7 @@ cmake --build . --config release
 popd
 set PATH=%cd%\test_assembly_cpp\typedb-driver-cpp-windows-x86_64\lib;%PATH%;
 
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --development-mode.enable=true
 powershell -Command "Start-Sleep -Seconds 10"
 
 test_assembly_cpp\Release\test_assembly.exe

--- a/.circleci/windows/csharp/test_deploy_snapshot.bat
+++ b/.circleci/windows/csharp/test_deploy_snapshot.bat
@@ -25,7 +25,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
+START /B "" typedb-server-windows\typedb server
 
 powershell -Command "(gc csharp\Test\Deployment\NugetApplicationTest.csproj) -replace 'DRIVER_CSHARP_VERSION_MARKER', '0.0.0-%CIRCLE_SHA1%' | Out-File -encoding ASCII csharp\Test\Deployment\NugetApplicationTest.csproj"
 type csharp\Test\Deployment\NugetApplicationTest.csproj

--- a/.circleci/windows/csharp/test_deploy_snapshot.bat
+++ b/.circleci/windows/csharp/test_deploy_snapshot.bat
@@ -25,7 +25,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --development-mode.enable=true
 
 powershell -Command "(gc csharp\Test\Deployment\NugetApplicationTest.csproj) -replace 'DRIVER_CSHARP_VERSION_MARKER', '0.0.0-%CIRCLE_SHA1%' | Out-File -encoding ASCII csharp\Test\Deployment\NugetApplicationTest.csproj"
 type csharp\Test\Deployment\NugetApplicationTest.csproj

--- a/.circleci/windows/java/test_deploy_snapshot.bat
+++ b/.circleci/windows/java/test_deploy_snapshot.bat
@@ -25,7 +25,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --development-mode.enable=true
 
 powershell -Command "(gc java\test\deployment\pom.xml) -replace 'DRIVER_JAVA_VERSION_MARKER', '0.0.0-%CIRCLE_SHA1%' | Out-File -encoding ASCII java\test\deployment\pom.xml"
 type java\test\deployment\pom.xml

--- a/.circleci/windows/java/test_deploy_snapshot.bat
+++ b/.circleci/windows/java/test_deploy_snapshot.bat
@@ -25,7 +25,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
+START /B "" typedb-server-windows\typedb server
 
 powershell -Command "(gc java\test\deployment\pom.xml) -replace 'DRIVER_JAVA_VERSION_MARKER', '0.0.0-%CIRCLE_SHA1%' | Out-File -encoding ASCII java\test\deployment\pom.xml"
 type java\test\deployment\pom.xml

--- a/.circleci/windows/python/test_deploy_snapshot.bat
+++ b/.circleci/windows/python/test_deploy_snapshot.bat
@@ -27,7 +27,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server --diagnostics.reporting.statistics=false --diagnostics.reporting.errors=false
+START /B "" typedb-server-windows\typedb server
 
 python3 -m pip install --extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple typedb-driver==0.0.0+%VER%
 cd python/tests/deployment

--- a/.circleci/windows/python/test_deploy_snapshot.bat
+++ b/.circleci/windows/python/test_deploy_snapshot.bat
@@ -27,7 +27,7 @@ powershell -Command "Move-Item -Path bazel-typedb-driver\external\vaticle_typedb
 7z x typedb-server-windows.zip
 RD /S /Q typedb-server-windows
 powershell -Command "Move-Item -Path typedb-server-windows-* -Destination typedb-server-windows"
-START /B "" typedb-server-windows\typedb server
+START /B "" typedb-server-windows\typedb server --development-mode.enable=true
 
 python3 -m pip install --extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple typedb-driver==0.0.0+%VER%
 cd python/tests/deployment

--- a/csharp/Test/Behaviour/Connection/ConnectionStepsBase.cs
+++ b/csharp/Test/Behaviour/Connection/ConnectionStepsBase.cs
@@ -52,11 +52,6 @@ namespace TypeDB.Driver.Test.Behaviour
                 {"transaction-timeout-millis", (option, val) => option.TransactionTimeoutMillis(Int32.Parse(val))}
         };
 
-        public static readonly Dictionary<string, string> ServerOptions =
-            new Dictionary<string, string>(){
-                {"--diagnostics.reporting.enable", "false"}
-        };
-
         // TODO: implement configuration and remove skips when @ignore-typedb-driver is removed from .feature.
         protected bool _requiredConfiguration = false;
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -36,7 +36,7 @@ def vaticle_typedb_protocol():
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
         # NOTE: the sync-marker is also used for workspace status by Bazel!
-        commit = "aea498d852d763c20d9ecc7d11423d7506964b95",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        tag = "2.28.4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -27,6 +27,7 @@ import com.vaticle.typedb.driver.api.TypeDBTransaction;
 import com.vaticle.typedb.driver.api.database.Database;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,11 +61,7 @@ public abstract class ConnectionStepsBase {
             pair("transaction-timeout-millis", (option, val) -> option.transactionTimeoutMillis(Integer.parseInt(val)))
     );
 
-    public static final Map<String, String> serverOptions = map(
-            pair("--diagnostics.reporting.errors", "false"),
-            pair("--diagnostics.reporting.statistics", "false"),
-            pair("--diagnostics.monitoring.enable", "false")
-    );
+    public static final Map<String, String> serverOptions = Collections.emptyMap();
 
     public static TypeDBTransaction tx() {
         return sessionsToTransactions.get(sessions.get(0)).get(0);

--- a/java/test/integration/AddressTranslationTest.java
+++ b/java/test/integration/AddressTranslationTest.java
@@ -47,16 +47,11 @@ import static org.junit.Assert.fail;
 public class AddressTranslationTest {
     private static final Logger LOG = LoggerFactory.getLogger(AddressTranslationTest.class);
 
-    private static final Map<String, String> serverOptions = map(
-            pair("--diagnostics.reporting.errors", "false"),
-            pair("--diagnostics.reporting.statistics", "false"),
-            pair("--diagnostics.monitoring.enable", "false")
-    );
     private static final TypeDBCredential credential = new TypeDBCredential("admin", "password", false);
 
     @Test
     public void testAddressTranslation() {
-        TypeDBCloudRunner typedb = TypeDBCloudRunner.create(Paths.get("."), 3, serverOptions);
+        TypeDBCloudRunner typedb = TypeDBCloudRunner.create(Paths.get("."), 3);
         typedb.start();
         Map<String, String> addresses = typedb.externalAddresses().stream().map(address -> pair(address, address))
                 .collect(Collectors.toMap(Pair::first, Pair::second));

--- a/java/test/integration/DriverQueryTest.java
+++ b/java/test/integration/DriverQueryTest.java
@@ -71,10 +71,7 @@ public class DriverQueryTest {
 
     @BeforeClass
     public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
-        Map<String, String> options = new HashMap<>();
-        options.put("--diagnostics.reporting.errors", "false");
-        options.put("--diagnostics.reporting.statistics", "false");
-        typedb = new TypeDBCoreRunner(options);
+        typedb = new TypeDBCoreRunner();
         typedb.start();
         typedbDriver = TypeDB.coreDriver(typedb.address());
         if (typedbDriver.databases().contains("typedb")) typedbDriver.databases().get("typedb").delete();

--- a/nodejs/test/integration/test-cloud-failover.js
+++ b/nodejs/test/integration/test-cloud-failover.js
@@ -70,6 +70,7 @@ function serverStart(idx) {
         "--server.encryption.file.internal-grpc.root-ca", encryptionResourceDir + "int-grpc-root-ca.pem",
         "--server.encryption.file.internal-zmq.private-key", encryptionResourceDir + "int-zmq-private-key",
         "--server.encryption.file.internal-zmq.public-key", encryptionResourceDir + "int-zmq-public-key",
+        "--diagnostics.monitoring.port", `${idx}1732`,
         "--development-mode.enable", "true"
     ]);
     node.stdout.on('data', (data) => {

--- a/nodejs/test/integration/test-cloud-failover.js
+++ b/nodejs/test/integration/test-cloud-failover.js
@@ -70,9 +70,7 @@ function serverStart(idx) {
         "--server.encryption.file.internal-grpc.root-ca", encryptionResourceDir + "int-grpc-root-ca.pem",
         "--server.encryption.file.internal-zmq.private-key", encryptionResourceDir + "int-zmq-private-key",
         "--server.encryption.file.internal-zmq.public-key", encryptionResourceDir + "int-zmq-public-key",
-        "--diagnostics.reporting.errors", "false",
-        "--diagnostics.reporting.statistics", "false",
-        "--diagnostics.monitoring.enable", "false"
+        "--development-mode.enable", "true"
     ]);
     node.stdout.on('data', (data) => {
         console.log(`stdout: ${data}`);

--- a/python/tests/integration/cloud_test_rule.bzl
+++ b/python/tests/integration/cloud_test_rule.bzl
@@ -44,9 +44,7 @@ def _rule_implementation(ctx):
                 --server.peers.peer-3.internal-address.zeromq=localhost:31730 \
                 --server.peers.peer-3.internal-address.grpc=localhost:31731 \
                 --server.encryption.enable=true \
-                --diagnostics.reporting.errors=false \
-                --diagnostics.reporting.statistics=false \
-                --diagnostics.monitoring.enable=false
+                --development-mode.enable=true
             }
             if test -d typedb_distribution; then
              echo Existing distribution detected. Cleaning.

--- a/python/tests/integration/cloud_test_rule.bzl
+++ b/python/tests/integration/cloud_test_rule.bzl
@@ -44,6 +44,7 @@ def _rule_implementation(ctx):
                 --server.peers.peer-3.internal-address.zeromq=localhost:31730 \
                 --server.peers.peer-3.internal-address.grpc=localhost:31731 \
                 --server.encryption.enable=true \
+                --diagnostics.monitoring.port=${1}1732 \
                 --development-mode.enable=true
             }
             if test -d typedb_distribution; then

--- a/python/tests/integration/test_cloud_failover.py
+++ b/python/tests/integration/test_cloud_failover.py
@@ -56,6 +56,7 @@ class TestCloudFailover(TestCase):
             "--server.peers.peer-3.internal-address.zeromq", "localhost:31730",
             "--server.peers.peer-3.internal-address.grpc", "localhost:31731",
             "--server.encryption.enable", "true",
+            "--diagnostics.monitoring.port", "%s1732" % index,
             "--development-mode.enable", "true"
         ])
 

--- a/python/tests/integration/test_cloud_failover.py
+++ b/python/tests/integration/test_cloud_failover.py
@@ -56,9 +56,7 @@ class TestCloudFailover(TestCase):
             "--server.peers.peer-3.internal-address.zeromq", "localhost:31730",
             "--server.peers.peer-3.internal-address.grpc", "localhost:31731",
             "--server.encryption.enable", "true",
-            "--diagnostics.reporting.errors", "false",
-            "--diagnostics.reporting.statistics", "false",
-            "--diagnostics.monitoring.enable", "false"
+            "--development-mode.enable", "true"
         ])
 
     def get_primary_replica(self, database_manager: DatabaseManager):

--- a/tool/test/start-cloud-servers.sh
+++ b/tool/test/start-cloud-servers.sh
@@ -45,6 +45,7 @@ function server_start() {
     --server.encryption.file.internal-grpc.root-ca=`realpath tool/test/resources/encryption/int-grpc-root-ca.pem` \
     --server.encryption.file.internal-zmq.private-key=`realpath tool/test/resources/encryption/int-zmq-private-key` \
     --server.encryption.file.internal-zmq.public-key=`realpath tool/test/resources/encryption/int-zmq-public-key` \
+    --diagnostics.monitoring.port=${1}1732 \
     --development-mode.enable=true
 }
 

--- a/tool/test/start-cloud-servers.sh
+++ b/tool/test/start-cloud-servers.sh
@@ -45,9 +45,7 @@ function server_start() {
     --server.encryption.file.internal-grpc.root-ca=`realpath tool/test/resources/encryption/int-grpc-root-ca.pem` \
     --server.encryption.file.internal-zmq.private-key=`realpath tool/test/resources/encryption/int-zmq-private-key` \
     --server.encryption.file.internal-zmq.public-key=`realpath tool/test/resources/encryption/int-zmq-public-key` \
-    --diagnostics.reporting.errors=false \
-    --diagnostics.reporting.statistics=false \
-    --diagnostics.monitoring.enable=false
+    --development-mode.enable=true
 }
 
 rm -rf $(seq 1 $NODE_COUNT) typedb-cloud-all

--- a/tool/test/start-core-server.sh
+++ b/tool/test/start-core-server.sh
@@ -22,7 +22,7 @@ rm -rf typedb-all
 
 bazel run //tool/test:typedb-extractor -- typedb-all
 BAZEL_JAVA_HOME=$(bazel run //tool/test:echo-java-home)
-JAVA_HOME=$BAZEL_JAVA_HOME ./typedb-all/typedb server --diagnostics.reporting.errors=false --diagnostics.reporting.statistics=false --diagnostics.monitoring.enable=false &
+JAVA_HOME=$BAZEL_JAVA_HOME ./typedb-all/typedb server --development-mode.enable=true &
 
 set +e
 POLL_INTERVAL_SECS=0.5


### PR DESCRIPTION
## Usage and product changes
We clean the usage of `--diagnostics.***` flags used in the test servers because of the recent propagation of a newer version of `TypeDB`, now supporting the `--development-mode.enable` flag. As the development mode includes disabling any outer reporting, it is a perfect substitution for this logic. 

## Implementation
We remove the unnecessary flags everywhere, aiming to cover it by the activated development mode.

* This mode is activated by default for all the `TypeDB***Runner`s [relevant for the `Java` driver]
* This mode is **not** activated for `vaticle_typedb_artifact` fetched by `vaticle_typedb_artifact()` or built by `bazel build @vaticle_typedb_artifact_*platform*//file`, so we need to manually add `--development-mode.enable=true` for all the invocations of these artifacts. 