### PR TITLE
Fix CI builds with updated error messages from typedb and typedb-cloud artifacts

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        commit = "179efaf59c6ba428b58f1a5a2f216c8cab7dd1a5",
+        commit = "e4e4fee9d488e2a6e89e29716b98e3213d228809",
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_cloud_artifact():
         artifact_name = "typedb-cloud-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact"]["release"]["download"],
         commit_source = deployment_private["artifact"]["snapshot"]["download"],
-        tag = "2.28.3",
+        commit = "179efaf59c6ba428b58f1a5a2f216c8cab7dd1a5",
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,7 +25,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.28.3"
+        commit = "71532c524af9ac42edbef258b1448990917a330d"
     )
 
 def vaticle_typedb_cloud_artifact():


### PR DESCRIPTION
## Usage and product changes
We update `typedb` and `typedb-cloud` artifacts references to match `TypeDB***Runner`s used in most of the languages with `typeql` versions used in Rust and Java drivers in CI. 

Previously, the versions were mismatched, which caused errors in CI because of the different error messages received from drivers (Rust `typeql` for Rust, Java `typeql` for Java, and direct values from the server for all the other drivers). 