### PR TITLE
Make the author of the NodeJS and Python drivers "TypeDB Community"

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -4,7 +4,7 @@
   "description": "TypeDB Node.js Driver",
   "author": "Vaticle",
   "license": "Apache-2.0",
-  "homepage": "https://vaticle.com",
+  "homepage": "https://typedb.com",
   "type": "commonjs",
   "repository": {
     "type": "git",

--- a/python/rules.bzl
+++ b/python/rules.bzl
@@ -76,8 +76,8 @@ def native_driver_versioned(python_versions):
                 "Topic :: Database :: Front-Ends"
             ],
             url = "https://github.com/vaticle/typedb-driver-python/",
-            author = "Vaticle",
-            author_email = "community@vaticle.com",
+            author = "TypeDB Community",
+            author_email = "community@typedb.com",
             license = "Apache-2.0",
             requirements_file = "//python:requirements.txt",
             keywords = ["typedb", "database", "graph", "knowledgebase", "knowledge-engineering"],


### PR DESCRIPTION
## Usage and product changes

The `author` field of our NodeJS and Python drivers (`package.json` and PyPi configuration) is now **TypeDB Community** with the email being **community@typedb.com**.

## Implementation

The former labels "Vaticle" and "community@vaticle.com" are no longer applicable and have been replaced.