### PR TITLE
Python. Fix driver.close(). Add integration tests for connection closing for both core and cloud

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -287,12 +287,13 @@ build:
 
         tool/test/start-core-server.sh &&
           bazel test //python/tests/integration:test_stream --test_output=streamed --jobs=1 &&
+          bazel test //python/tests/integration:test_core_connection --test_output=streamed --jobs=1 &&
           export CORE_FAILED= || export CORE_FAILED=1
         tool/test/stop-core-server.sh
         if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
         source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-          bazel test //python/tests/integration:test_connection --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
+          bazel test //python/tests/integration:test_cloud_connection --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           # TODO #635: currently broken test
           # bazel test //python/tests/integration:test_cloud_failover --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
           export CLOUD_FAILED= || export CLOUD_FAILED=1

--- a/python/tests/integration/BUILD
+++ b/python/tests/integration/BUILD
@@ -32,8 +32,19 @@ typedb_cloud_py_test(
 )
 
 py_test(
-    name = "test_connection",
-    srcs = ["test_connection.py"],
+    name = "test_core_connection",
+    srcs = ["test_core_connection.py"],
+    deps = [
+        "//python:driver_python",
+        requirement("PyHamcrest"),
+    ],
+    data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
+    python_version = "PY3"
+)
+
+py_test(
+    name = "test_cloud_connection",
+    srcs = ["test_cloud_connection.py"],
     deps = [
         "//python:driver_python",
         requirement("PyHamcrest"),

--- a/python/tests/integration/test_cloud_connection.py
+++ b/python/tests/integration/test_cloud_connection.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import unittest
+from unittest import TestCase
+
+from hamcrest import *
+
+from typedb.driver import *
+
+TYPEDB = "typedb"
+DATA = SessionType.DATA
+WRITE = TransactionType.WRITE
+CREDENTIAL = TypeDBCredential("admin", "password", tls_enabled=True, tls_root_ca_path=os.environ["ROOT_CA"])
+
+
+class TestDebug(TestCase):
+
+    def test_core_connection_while_running_cloud(self):
+        assert_that(calling(lambda: TypeDB.core_driver("localhost:11729")), raises(TypeDBDriverException))
+
+    def test_open_close_transaction(self):
+        addresses = [
+            "localhost:11729",
+            "localhost:21729",
+            "localhost:31729"
+        ]
+        driver = TypeDB.cloud_driver(addresses, CREDENTIAL)
+        assert_that(driver.is_open(), is_(True))
+        driver.close()
+        assert_that(driver.is_open(), is_(False))
+
+    def test_address_translation(self):
+        address_translation = {
+            "localhost:11729": "localhost:11729",
+            "localhost:21729": "localhost:21729",
+            "localhost:31729": "localhost:31729"
+        }
+        with TypeDB.cloud_driver(address_translation, CREDENTIAL) as driver:
+            if TYPEDB not in [db.name for db in driver.databases.all()]:
+                driver.databases.create(TYPEDB)
+            with driver.session(TYPEDB, DATA) as session, session.transaction(WRITE) as tx:
+                root = tx.concepts.get_root_entity_type()
+                assert_that(len(list(root.get_subtypes(tx))), equal_to(1))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+

--- a/python/tests/integration/test_core_connection.py
+++ b/python/tests/integration/test_core_connection.py
@@ -33,20 +33,11 @@ class TestDebug(TestCase):
     def test_missing_port(self):
         assert_that(calling(lambda: TypeDB.core_driver("localhost")), raises(TypeDBDriverException))
 
-
-    def test_address_translation(self):
-        address_translation = {
-            "localhost:11729": "localhost:11729",
-            "localhost:21729": "localhost:21729",
-            "localhost:31729": "localhost:31729"
-        }
-        credential = TypeDBCredential("admin", "password", tls_enabled=True, tls_root_ca_path=os.environ["ROOT_CA"])
-        with TypeDB.cloud_driver(address_translation, credential) as driver:
-            if TYPEDB not in [db.name for db in driver.databases.all()]:
-                driver.databases.create(TYPEDB)
-            with driver.session(TYPEDB, DATA) as session, session.transaction(WRITE) as tx:
-                root = tx.concepts.get_root_entity_type()
-                assert_that(len(list(root.get_subtypes(tx))), equal_to(1))
+    def test_open_close_transaction(self):
+        driver = TypeDB.core_driver(TypeDB.DEFAULT_ADDRESS)
+        assert_that(driver.is_open(), is_(True))
+        driver.close()
+        assert_that(driver.is_open(), is_(False))
 
 
 if __name__ == "__main__":

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -93,5 +93,5 @@ class _Driver(TypeDBDriver, NativeWrapper[NativeConnection]):
             return False
 
     def close(self) -> None:
-        if not self.is_open():
+        if self.is_open():
             connection_force_close(self._native_connection)


### PR DESCRIPTION
## Usage and product changes
We fix the issue https://github.com/vaticle/typedb-driver/issues/669, where the Python Driver didn't close the connection when calling `TypeDBDriver.close()`.

## Implementation
We needed to reverse the condition of `is_open()`.

The main issue is the absence of tests for our drivers' connections, so we:
* add new integration tests for both core and cloud;
* create an issue for behaviour tests to cover this hole for a brighter future: https://github.com/vaticle/typedb-behaviour/issues/289.